### PR TITLE
Add single support-bot P2P placeholder

### DIFF
--- a/.github/workflows/support-bot-extended-test.yaml
+++ b/.github/workflows/support-bot-extended-test.yaml
@@ -1,0 +1,27 @@
+name: support-bot Extended Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  get-latest-version:
+    uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@p2p-v2-test
+    with:
+      image-name: support-bot-ui
+
+  extendedtests:
+    needs: [get-latest-version]
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@p2p-v2-test
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      app-name: support-bot
+      version: ${{ needs.get-latest-version.outputs.version }}
+      version-prefix: v
+      working-directory: ./

--- a/.github/workflows/support-bot-fast-feedback.yaml
+++ b/.github/workflows/support-bot-fast-feedback.yaml
@@ -1,0 +1,32 @@
+name: support-bot Fast Feedback
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  version:
+    uses: coreeng/p2p/.github/workflows/p2p-version.yaml@p2p-v2-test
+    with:
+      version-prefix: v
+    secrets:
+      git-token: ${{ secrets.GITHUB_TOKEN }}
+
+  fastfeedback:
+    needs: [version]
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@p2p-v2-test
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      app-name: support-bot
+      version: ${{ needs.version.outputs.version }}
+      working-directory: ./

--- a/.github/workflows/support-bot-prod.yaml
+++ b/.github/workflows/support-bot-prod.yaml
@@ -1,0 +1,27 @@
+name: support-bot Prod
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * 1-5'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  get-latest-version:
+    uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@p2p-v2-test
+    with:
+      image-name: support-bot-ui
+
+  prod:
+    needs: [get-latest-version]
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@p2p-v2-test
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      app-name: support-bot
+      version: ${{ needs.get-latest-version.outputs.version }}
+      version-prefix: v
+      working-directory: ./

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,101 @@
+# Include P2P Makefile
+include Makefile.p2p
+
+P2P_IMAGE_NAMES := support-bot-api support-bot-ui
+
+.PHONY: lint
+lint:
+	docker run --rm -i docker.io/hadolint/hadolint < support-bot-api/Dockerfile
+	docker run --rm -i docker.io/hadolint/hadolint < support-bot-ui/Dockerfile
+
+
+
+.PHONY: run-app
+run-app:
+	@echo "WARNING: $@ not implemented"
+	docker run --rm -P --name "$(p2p_app_name)" "$(call p2p_image_tag,support-bot-api)"
+
+.PHONY: build-app
+build-app:
+	docker build --tag "$(call p2p_image_tag,support-bot-api)" ./support-bot-api
+	docker build --tag "$(call p2p_image_tag,support-bot-ui)" ./support-bot-ui
+	docker image push "$(call p2p_image_tag,support-bot-api)"
+	docker image push "$(call p2p_image_tag,support-bot-ui)"
+
+
+
+.PHONY: build-functional
+build-functional:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: build-nft
+build-nft:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: build-integration
+build-integration:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: build-extended-test
+build-extended-test:
+	@echo "WARNING: $@ not implemented"
+
+
+
+.PHONY: test-functional
+test-functional:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: test-nft
+test-nft:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: test-integration
+test-integration:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: test-extended-test
+test-extended-test:
+	@echo "WARNING: $@ not implemented"
+
+
+
+.PHONY: deploy-functional
+deploy-functional:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: deploy-nft
+deploy-nft:
+	@echo "WARNING: $@ not implemented"
+
+.PHONY: deploy-extended-test
+deploy-extended-test:
+	@echo "WARNING: $@ not implemented"
+
+
+
+.PHONY: deploy-%
+deploy-%:
+	helm repo add coreeng https://coreeng.github.io/core-platform-assets
+	helm upgrade --install "support-bot-api" coreeng/app -n $(p2p_namespace) \
+		--set appName="support-bot-api" \
+		--set appUrlSuffix="$(p2p_app_url_suffix)" \
+		--set registry=$(p2p_registry) \
+		--set tag="$(p2p_version)" \
+		--set tenantName=$(p2p_tenant_name) \
+		--set image="support-bot-api" \
+		--set ingress.enabled=true \
+		--set ingress.domain="$(INTERNAL_SERVICES_DOMAIN)" \
+		--set port=9898 \
+		--set service.environmentVariables.FOO="bar"
+	helm upgrade --install "support-bot-ui" coreeng/app -n $(p2p_namespace) \
+		--set appName="support-bot-ui" \
+		--set appUrlSuffix="$(p2p_app_url_suffix)" \
+		--set registry=$(p2p_registry) \
+		--set tag="$(p2p_version)" \
+		--set tenantName=$(p2p_tenant_name) \
+		--set image="support-bot-ui" \
+		--set ingress.enabled=true \
+		--set ingress.domain="$(INTERNAL_SERVICES_DOMAIN)" \
+		--set port=9898 \
+		--set service.environmentVariables.FOO="bar"

--- a/Makefile.p2p
+++ b/Makefile.p2p
@@ -1,0 +1,79 @@
+# Do not modify this file
+
+MAKEFLAGS += --warn-undefined-variables
+
+P2P_TENANT_NAME ?= support-bot
+P2P_APP_NAME ?= support-bot
+P2P_VERSION ?= $(shell git rev-parse --short HEAD)
+P2P_IMAGE_NAMES ?= $(P2P_APP_NAME)
+
+P2P_REGISTRY ?= local
+P2P_REGISTRY_FAST_FEEDBACK ?= local/fast-feedback
+P2P_REGISTRY_EXTENDED_TEST ?= local/extended-test
+P2P_REGISTRY_PROD ?= local/prod
+
+.PHONY: p2p-help
+p2p-help:
+	@echo "Usage:"
+	@grep -E '^[a-zA-Z1-9_-]+:.*?## .*$$' -h $(MAKEFILE_LIST) | grep '^p2p-' | awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-30s %s\n", $$1, $$2}'
+
+%: p2p_tenant_name = $(P2P_TENANT_NAME)
+%: p2p_app_name = $(P2P_APP_NAME)
+%: p2p_version = $(P2P_VERSION)
+
+.PHONY: p2p-build
+p2p-build: lint build-app ## Build the app
+%-app: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-app: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(1),$(1),$(P2P_APP_NAME)):$(P2P_VERSION)
+
+.PHONY: p2p-functional
+p2p-functional: build-functional deploy-functional test-functional ## Run functional tests
+%-functional: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-functional
+%-functional: p2p_namespace=$(P2P_NAMESPACE_FUNCTIONAL)
+%-functional: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-functional: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(1),$(1),$(P2P_APP_NAME))-functional:$(P2P_VERSION)
+
+.PHONY: p2p-nft
+p2p-nft: build-nft deploy-nft test-nft ## Run NFT tests
+%-nft: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-nft
+%-nft: p2p_namespace=$(P2P_NAMESPACE_NFT)
+%-nft: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-nft: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(1),$(1),$(P2P_APP_NAME))-nft:$(P2P_VERSION)
+
+.PHONY: p2p-integration
+p2p-integration: build-integration deploy-integration test-integration ## Run integration tests
+%-integration: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-integration
+%-integration: p2p_namespace=$(P2P_NAMESPACE_INTEGRATION)
+%-integration: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-integration: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(1),$(1),$(P2P_APP_NAME))-integration:$(P2P_VERSION)
+
+.PHONY: p2p-extended-test
+p2p-extended-test: build-extended-test deploy-extended-test test-extended-test ## Run extended tests
+%-extended-test: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-extended
+%-extended-test: p2p_namespace=$(P2P_NAMESPACE_EXTENDED)
+%-extended-test: p2p_registry=$(P2P_REGISTRY_EXTENDED_TEST)
+%-extended-test: p2p_image_tag=$(P2P_REGISTRY_EXTENDED_TEST)/$(if $(1),$(1),$(P2P_APP_NAME))-extended:$(P2P_VERSION)
+
+.PHONY: p2p-prod
+p2p-prod: deploy-prod ## Deploy to production
+%-prod: p2p_app_url_suffix=
+%-prod: p2p_namespace=$(P2P_NAMESPACE_PROD)
+%-prod: p2p_registry=$(P2P_REGISTRY_PROD)
+
+.PHONY: p2p-promote-to-extended-test
+p2p-promote-to-extended-test:
+	$(foreach image, $(P2P_IMAGE_NAMES), \
+		corectl p2p promote "$(image):$(P2P_VERSION)" \
+			--source-stage "$(P2P_REGISTRY_FAST_FEEDBACK_PATH)" \
+			--dest-registry "$(P2P_REGISTRY)" \
+			--dest-stage "$(P2P_REGISTRY_EXTENDED_TEST_PATH)" \
+	;)
+
+.PHONY: p2p-promote-to-prod
+p2p-promote-to-prod:
+	$(foreach image, $(P2P_IMAGE_NAMES), \
+		corectl p2p promote "$(image):$(P2P_VERSION)" \
+			--source-stage "$(P2P_REGISTRY_EXTENDED_TEST_PATH)" \
+			--dest-registry "$(P2P_REGISTRY)" \
+			--dest-stage "$(P2P_REGISTRY_PROD_PATH)" \
+	;)

--- a/support-bot-api/Dockerfile
+++ b/support-bot-api/Dockerfile
@@ -1,0 +1,3 @@
+FROM stefanprodan/podinfo:6.7.1
+
+EXPOSE 9898

--- a/support-bot-ui/Dockerfile
+++ b/support-bot-ui/Dockerfile
@@ -1,0 +1,3 @@
+FROM stefanprodan/podinfo:6.7.1
+
+EXPOSE 9898


### PR DESCRIPTION
Adds single support-bot P2P that builds/deploys two artifacts.
Use the podman docker image for now and the standard coreeng helm chart as placeholders.