### PR TITLE
Fixing bug where closing issue with closed escalation produced error

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
@@ -105,6 +105,9 @@ public class EscalationProcessingService {
 
     public void resolveByTicketId(TicketId ticketId) {
         for (var escalation : repository.listByTicketId(ticketId)) {
+            if (EscalationStatus.resolved.equals(escalation.status())) {
+                continue;
+            }
             resolve(escalation);
         }
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/JdbcEscalationRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/JdbcEscalationRepository.java
@@ -124,9 +124,8 @@ public class JdbcEscalationRepository implements EscalationRepository {
     public Escalation markResolved(Escalation escalation, Instant at) {
         checkNotNull(escalation);
         checkNotNull(escalation.id());
-        if (EscalationStatus.resolved == escalation.status()) {
-            return escalation;
-        }
+        checkArgument(escalation.status() != EscalationStatus.resolved);
+        checkArgument(escalation.resolvedAt() == null);
 
         int escalationChanged = dsl.update(ESCALATION)
             .set(ESCALATION.STATUS, com.coreeng.supportbot.dbschema.enums.EscalationStatus.resolved)


### PR DESCRIPTION
There was a bug where closing an escalation individually, and then closing the ticket itself would cause an IllegalArgumentException. This fixes that