### PR TITLE
feature(service): Extract hardcoded static users and groups to the properties file and a few other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ p2p-prod:          publish-prod                           deploy-prod           
 lint-api-app: ## Lint api app
 	docker run --rm -i docker.io/hadolint/hadolint < api/Dockerfile
 	docker run --rm -i docker.io/hadolint/hadolint < api/functional/Dockerfile
+	docker run --rm -i docker.io/hadolint/hadolint < api/integration-tests/Dockerfile
 
 .PHONY: lint-ui-app
 lint-ui-app: ## Lint ui app

--- a/api/integration-tests/Dockerfile
+++ b/api/integration-tests/Dockerfile
@@ -1,6 +1,7 @@
 FROM gradle:8.11.1-jdk21 AS builder
 WORKDIR /home/gradle/project
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 # Copy gradle wrapper and settings

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsConfig.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsConfig.java
@@ -39,13 +39,17 @@ import java.util.concurrent.Executors;
 )
 @EnableConfigurationProperties({
         PlatformTeamsConfig.GcpProps.class,
-        GenericPlatformTeamsFetcher.Config.class
+        GenericPlatformTeamsFetcher.Config.class,
+        StaticPlatformTeamsProps.class,
+        StaticPlatformUsersProps.class
 })
 @RequiredArgsConstructor
 public class PlatformTeamsConfig {
     private final GcpProps gcpProps;
     private final CredentialsProvider gcpCredsProvider;
     private final EscalationTeamsRegistry escalationTeamsRegistry;
+    private final StaticPlatformTeamsProps staticPlatformTeamsProps;
+    private final StaticPlatformUsersProps staticPlatformUsersProps;
 
     @Bean
     public PlatformTeamsService platformTeamsService(PlatformTeamsFetcher teamsFetcher, PlatformUsersFetcher usersFetcher) {
@@ -64,7 +68,7 @@ public class PlatformTeamsConfig {
     @Bean
     @ConditionalOnProperty("platform-integration.teams-scraping.static.enabled")
     public PlatformTeamsFetcher localPlatformTeamsFetcher() {
-        return new StaticPlatformTeamsFetcher();
+        return new StaticPlatformTeamsFetcher(staticPlatformTeamsProps);
     }
 
     @Bean
@@ -124,7 +128,7 @@ public class PlatformTeamsConfig {
     @Bean
     @ConditionalOnProperty("platform-integration.static-user.enabled")
     public PlatformUsersFetcher staticUsersFetcher() {
-        return new StaticUsersFetcher();
+        return new StaticUsersFetcher(staticPlatformUsersProps);
     }
 
     @Bean

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcher.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcher.java
@@ -9,11 +9,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StaticPlatformTeamsFetcher implements PlatformTeamsFetcher {
 
+    private final StaticPlatformTeamsProps props;
+
     @Override
     public List<TeamAndGroupTuple> fetchTeams() {
-        TeamAndGroupTuple t1 = new TeamAndGroupTuple("wow", "wow-group");
-        TeamAndGroupTuple t2 = new TeamAndGroupTuple("infra-integration", "infra-group");
-        TeamAndGroupTuple t3 = new TeamAndGroupTuple("connected-app", "connected-app-group");
-        return List.of(t1, t2, t3);
+        return props.teams().stream()
+            .map(team -> new TeamAndGroupTuple(team.name(), team.groupRef()))
+            .toList();
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsProps.java
@@ -1,0 +1,16 @@
+package com.coreeng.supportbot.teams;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties("platform-integration.teams-scraping.static")
+public record StaticPlatformTeamsProps(
+    boolean enabled,
+    List<TeamConfig> teams
+) {
+    public record TeamConfig(
+        String name,
+        String groupRef
+    ) {}
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformUsersProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformUsersProps.java
@@ -1,0 +1,13 @@
+package com.coreeng.supportbot.teams;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+import java.util.Map;
+
+@ConfigurationProperties("platform-integration.static-user")
+public record StaticPlatformUsersProps(
+    boolean enabled,
+    Map<String, List<String>> users
+) {
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticUsersFetcher.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticUsersFetcher.java
@@ -9,12 +9,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StaticUsersFetcher implements PlatformUsersFetcher {
 
+    private final StaticPlatformUsersProps props;
+
     @Override
     public List<Membership> fetchMembershipsByGroupRef(String groupRef) {
-        if ("wow-group".equals(groupRef)) {
-            return List.of(new Membership("savvas.michael@cecg.io"));
-        } else {
-            return List.of(new Membership("test1@test.com"), new Membership("test2@test.com"), new Membership("test3@test.com"));
-        }
+        return props.users().getOrDefault(groupRef, List.of()).stream()
+            .map(Membership::new)
+            .toList();
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryViewMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryViewMapper.java
@@ -216,17 +216,9 @@ public class TicketSummaryViewMapper {
     }
 
     private StaticSelectElement renderTeamsInput(TicketSummaryView.TeamsInput teams) {
-        return staticSelect(s -> s
-            .actionId(TicketField.team.actionId())
-            .initialOption(
-                teams.currentTeam() != null
-                    ? OptionObject.builder()
-                    .text(plainText(teams.currentTeam()))
-                    .value(teams.currentTeam())
-                    .build()
-                    : null
-            )
-            .optionGroups(ImmutableList.of(
+        ImmutableList.Builder<OptionGroupObject> optionGroupsBuilder = ImmutableList.builderWithExpectedSize(2);
+        if (!teams.authorTeams().isEmpty()) {
+            optionGroupsBuilder.add(
                 OptionGroupObject.builder()
                     .label(plainText("Suggested teams"))
                     .options(
@@ -237,7 +229,12 @@ public class TicketSummaryViewMapper {
                                 .build())
                             .collect(toImmutableList())
                     )
-                    .build(),
+                    .build()
+
+            );
+        }
+        if (!teams.otherTeams().isEmpty()) {
+            optionGroupsBuilder.add(
                 OptionGroupObject.builder()
                     .label(plainText("Others"))
                     .options(
@@ -249,7 +246,24 @@ public class TicketSummaryViewMapper {
                             .collect(toImmutableList())
                     )
                     .build()
-            ))
+            );
+        }
+        ImmutableList<OptionGroupObject> optionGroups = optionGroupsBuilder.build();
+        return staticSelect(s -> {
+                s.actionId(TicketField.team.actionId())
+                    .initialOption(
+                        teams.currentTeam() != null
+                            ? OptionObject.builder()
+                            .text(plainText(teams.currentTeam()))
+                            .value(teams.currentTeam())
+                            .build()
+                            : null
+                    );
+                if (!optionGroups.isEmpty()) {
+                    s.optionGroups(optionGroups);
+                }
+                return s;
+            }
         );
     }
 

--- a/api/service/src/main/resources/application-functionaltests.yaml
+++ b/api/service/src/main/resources/application-functionaltests.yaml
@@ -46,37 +46,6 @@ enums:
     - label: Abnormal Behaviour
       code: abnormalBehaviour
 
-platform-integration:
-  enabled: true
-  kubernetes:
-    base-url: "http://localhost:8001"
-    disable-http-proxy: true
-  gcp:
-    enabled: false
-    app-name: Support Bot
-    client:
-      base-url: "http://localhost:8003"
-  azure:
-    enabled: true
-    client:
-      base-url: "http://localhost:8002/v1.0"
-  teams-scraping:
-    core-platform:
-      enabled: false
-    k8s-generic:
-      enabled: true
-      config:
-        apiVersion: core
-        kind: Tenant
-        namespace: null
-        filter:
-          name-regexp: null
-          label-selector: null
-        teamName:
-          pointer: /metadata/name
-        groupRef:
-          pointer: /spec/groupRef
-
 support-team:
   name: Core Support
   slack-group-id: S01234567ST

--- a/api/service/src/main/resources/application.yaml
+++ b/api/service/src/main/resources/application.yaml
@@ -115,6 +115,17 @@ platform-integration:
       base-url: ""
   static-user:
     enabled: true
+    users:
+      wow-group:
+        - wow1@test.com
+      infra-group:
+        - infra1@test.com
+        - infra2@test.com
+        - infra3@test.com
+      connected-app-group:
+        - connected-app1@test.com
+        - connected-app2@test.com
+        - connected-app3@test.com
   azure:
     enabled: false
     client:
@@ -122,6 +133,13 @@ platform-integration:
   teams-scraping:
     static:
       enabled: true
+      teams:
+        - name: wow
+          groupRef: wow-group
+        - name: infra-integration
+          groupRef: infra-group
+        - name: connected-app
+          groupRef: connected-app-group
     core-platform:
       enabled: false
     k8s-generic:


### PR DESCRIPTION
- Extract hardcoded static users and groups to the properties file
- Fix the bug when the current user is not present in any known group and summary slack modal is not opening because slack rejects a message with empty optiongroup
- Add a linter for integration-tests dockerfile