### PR TITLE
feature: Fetch teams in parallel

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsConfig.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsConfig.java
@@ -41,7 +41,8 @@ import java.util.concurrent.Executors;
     PlatformTeamsConfig.GcpProps.class,
     GenericPlatformTeamsFetcher.Config.class,
     StaticPlatformTeamsProps.class,
-    StaticPlatformUsersProps.class
+    StaticPlatformUsersProps.class,
+    PlatformTeamsFetchProps.class
 })
 @RequiredArgsConstructor
 public class PlatformTeamsConfig {
@@ -51,8 +52,8 @@ public class PlatformTeamsConfig {
     private final StaticPlatformUsersProps staticPlatformUsersProps;
 
     @Bean
-    public PlatformTeamsService platformTeamsService(PlatformTeamsFetcher teamsFetcher, PlatformUsersFetcher usersFetcher) {
-        return new PlatformTeamsService(teamsFetcher, usersFetcher, escalationTeamsRegistry);
+    public PlatformTeamsService platformTeamsService(PlatformTeamsFetcher teamsFetcher, PlatformUsersFetcher usersFetcher, PlatformTeamsFetchProps fetchProps) {
+        return new PlatformTeamsService(teamsFetcher, usersFetcher, escalationTeamsRegistry, fetchProps);
     }
 
     @Bean

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetchProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetchProps.java
@@ -1,0 +1,13 @@
+package com.coreeng.supportbot.teams;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties("platform-integration.fetch")
+public record PlatformTeamsFetchProps(
+    int maxConcurrency,
+    Duration timeout
+) {
+}
+

--- a/api/service/src/main/resources/application.yaml
+++ b/api/service/src/main/resources/application.yaml
@@ -100,6 +100,9 @@ enums:
 
 platform-integration:
   enabled: true
+  fetch:
+    max-concurrency: 64
+    timeout: 30s
   kubernetes:
     disable-http-proxy: false
     base-url: ""

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
@@ -1,0 +1,82 @@
+package com.coreeng.supportbot.teams;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import com.coreeng.supportbot.teams.fakes.FakeEscalationTeamsRegistry;
+import com.coreeng.supportbot.teams.fakes.FakeTeamsFetcher;
+import com.coreeng.supportbot.teams.fakes.SlowUsersFetcher;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlatformTeamsServiceConcurrencyTest {
+    @Test
+    void respectsMaxConcurrencyAndRunsInParallel() {
+        // Arrange: 6 groups, each taking ~200ms. With maxConcurrency=2, expect ~3 waves => ~600ms total (+ overhead).
+        int groups = 6;
+        Duration perCallDelay = Duration.ofMillis(200);
+        int maxConcurrency = 2;
+        Duration timeout = Duration.ofSeconds(5);
+
+        long serialMillis = perCallDelay.multipliedBy(groups).toMillis();
+        long expectedWaves = (long) Math.ceil(groups / (double) maxConcurrency);
+        long idealParallelMillis = perCallDelay.multipliedBy(expectedWaves).toMillis();
+
+        List<PlatformTeamsFetcher.TeamAndGroupTuple> teams = new ArrayList<>();
+        List<EscalationTeam> escalationTeams = new ArrayList<>();
+        for (int i = 1; i <= groups; i++) {
+            String teamName = "team-" + i;
+            String groupRef = "G" + i;
+            teams.add(new PlatformTeamsFetcher.TeamAndGroupTuple(teamName, groupRef));
+            escalationTeams.add(new EscalationTeam(teamName, teamName, "SOME"));
+        }
+
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(teams);
+        SlowUsersFetcher usersFetcher = new SlowUsersFetcher(
+            perCallDelay,
+            groupRef -> List.of(new PlatformUsersFetcher.Membership(groupRef.toLowerCase() + "@test.com"))
+        );
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(escalationTeams);
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(maxConcurrency, timeout);
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        // Act
+        Instant start = Instant.now();
+        service.init();
+        Duration elapsed = Duration.between(start, Instant.now());
+        long elapsedMillis = elapsed.toMillis();
+
+        // Assert: concurrency never exceeded the configured gate
+        int maxObserved = usersFetcher.maxObservedAtSameTime();
+        assertTrue(maxObserved <= maxConcurrency,
+            "Observed concurrency (" + maxObserved + ") should be <= maxConcurrency (" + maxConcurrency + ")");
+
+        // allow for overhead/jitter: should be < serial and not wildly larger than the ideal parallel time
+        assertTrue(elapsedMillis < serialMillis,
+            "Elapsed (" + elapsedMillis + "ms) should be less than serial time (" + serialMillis + "ms)");
+        assertTrue(elapsedMillis <= idealParallelMillis + 100,
+            "Elapsed (" + elapsedMillis + "ms) should be around ideal parallel time (" + idealParallelMillis + "ms) with tolerance");
+
+        // Sanity: structures are built correctly
+        assertEquals(groups, service.listTeams().size());
+        for (int i = 1; i <= groups; i++) {
+            String teamName = "team-" + i;
+            String groupRef = "G" + i;
+            var team = service.findTeamByName(teamName);
+            assertNotNull(team);
+            assertTrue(team.groupRefs().contains(groupRef));
+            assertEquals(1, team.users().size());
+            var user = service.findUserByEmail(groupRef.toLowerCase() + "@test.com");
+            assertNotNull(user);
+            assertTrue(service.listTeamsByUserEmail(groupRef.toLowerCase() + "@test.com").stream()
+                .anyMatch(t -> t.name().equals(teamName)));
+        }
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
@@ -1,0 +1,192 @@
+package com.coreeng.supportbot.teams;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import com.coreeng.supportbot.teams.fakes.FakeEscalationTeamsRegistry;
+import com.coreeng.supportbot.teams.fakes.FakeTeamsFetcher;
+import com.coreeng.supportbot.teams.fakes.FakeUsersFetcher;
+import com.coreeng.supportbot.teams.fakes.SlowUsersFetcher;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlatformTeamsServiceTest {
+    @Test
+    void singleTeamSingleGroup_buildsGraph_andNormalizesEmails() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("wow", "wow-group")
+        ));
+        PlatformUsersFetcher usersFetcher = new FakeUsersFetcher(
+            Map.of("wow-group", List.of(new PlatformUsersFetcher.Membership("WOW1@TEST.COM")))
+        );
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("wow", "wow", "SOME")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        service.init();
+
+        assertEquals(1, service.listTeams().size());
+        var team = service.findTeamByName("wow");
+        assertNotNull(team);
+        assertTrue(team.groupRefs().contains("wow-group"));
+        assertEquals(1, team.users().size());
+
+        // normalized lookup
+        assertNotNull(service.findUserByEmail("wow1@test.com"));
+        assertNotNull(service.findUserByEmail("WOW1@TEST.COM"));
+        assertEquals(1, service.listTeamsByUserEmail("wow1@test.com").size());
+        assertEquals("wow", service.listTeamsByUserEmail("wow1@test.com").getFirst().name());
+    }
+
+    @Test
+    void twoTeamsSharingOneGroup_dedupsFetch_andLinksUsersToBothTeams() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("A", "shared"),
+            new PlatformTeamsFetcher.TeamAndGroupTuple("B", "shared")
+        ));
+        FakeUsersFetcher usersFetcher = new FakeUsersFetcher(
+            Map.of("shared", List.of(
+                new PlatformUsersFetcher.Membership("u1@test.com"),
+                new PlatformUsersFetcher.Membership("u2@test.com")
+            ))
+        );
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("A", "A", "SOME"),
+            new EscalationTeam("B", "B", "SOME")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        service.init();
+
+        assertEquals(1, usersFetcher.getCallCount("shared"));
+
+        var teamA = service.findTeamByName("A");
+        var teamB = service.findTeamByName("B");
+        assertNotNull(teamA);
+        assertNotNull(teamB);
+        assertEquals(2, teamA.users().size());
+        assertEquals(2, teamB.users().size());
+
+        assertEquals(2, service.listTeamsByUserEmail("u1@test.com").size());
+        assertEquals(2, service.listTeamsByUserEmail("u2@test.com").size());
+    }
+
+    @Test
+    void singleTeamTwoGroups_unionsUsers() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("T1", "G1"),
+            new PlatformTeamsFetcher.TeamAndGroupTuple("T1", "G2")
+        ));
+        PlatformUsersFetcher usersFetcher = new FakeUsersFetcher(
+            Map.of(
+                "G1", List.of(new PlatformUsersFetcher.Membership("a@test.com")),
+                "G2", List.of(new PlatformUsersFetcher.Membership("b@test.com"))
+            )
+        );
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("T1", "T1", "SOME")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        service.init();
+
+        var t1 = service.findTeamByName("T1");
+        assertNotNull(t1);
+        assertEquals(2, t1.users().size());
+        assertEquals(1, service.listTeamsByUserEmail("a@test.com").size());
+        assertEquals(1, service.listTeamsByUserEmail("b@test.com").size());
+    }
+
+    @Test
+    void escalationMappingMismatch_failsInit() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("wow", "G")
+        ));
+        PlatformUsersFetcher usersFetcher = new FakeUsersFetcher(Map.of());
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("wow", "wow", "SOME"),
+            new EscalationTeam("unknown", "unknown", "SOME")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, service::init);
+        assertEquals("Unknown escalation teams specified: [unknown]", ex.getMessage());
+    }
+
+    @Test
+    void globalTimeout_triggersFailure() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("T", "slow-G")
+        ));
+        PlatformUsersFetcher usersFetcher = new SlowUsersFetcher(Duration.ofMillis(200));
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("T", "T", "SOME")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(1, Duration.ofMillis(50));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, service::init);
+        assertTrue(ex.getMessage().toLowerCase().contains("timed out"));
+    }
+
+    @Test
+    void noTeams_resultsInEmptyState_andNoUserFetchCalls() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of());
+        FakeUsersFetcher usersFetcher = new FakeUsersFetcher(Map.of());
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of());
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        service.init();
+
+        assertEquals(0, usersFetcher.getTotalCalls());
+        assertTrue(service.listTeams().isEmpty());
+    }
+
+    @Test
+    void duplicateTuples_sameTeamAndGroup_areIdempotent() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("T", "G"),
+            new PlatformTeamsFetcher.TeamAndGroupTuple("T", "G")
+        ));
+        FakeUsersFetcher usersFetcher = new FakeUsersFetcher(
+            Map.of("G", List.of(new PlatformUsersFetcher.Membership("u@test.com")))
+        );
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("T", "T", "SOME")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        service.init();
+
+        assertEquals(1, usersFetcher.getCallCount("G"));
+        var t = service.findTeamByName("T");
+        assertNotNull(t);
+        assertEquals(1, t.groupRefs().size());
+        assertTrue(t.groupRefs().contains("G"));
+        assertEquals(1, t.users().size());
+        assertEquals(1, service.listTeamsByUserEmail("u@test.com").size());
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeEscalationTeamsRegistry.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeEscalationTeamsRegistry.java
@@ -1,0 +1,29 @@
+package com.coreeng.supportbot.teams.fakes;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import com.google.common.collect.ImmutableList;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class FakeEscalationTeamsRegistry implements EscalationTeamsRegistry {
+    private final List<EscalationTeam> teams;
+
+    @Override
+    public ImmutableList<EscalationTeam> listAllEscalationTeams() {
+        return ImmutableList.copyOf(teams);
+    }
+
+    @Override
+    public EscalationTeam findEscalationTeamByCode(String code) {
+        return teams.stream().filter(t -> t.code().equals(code)).findFirst().orElse(null);
+    }
+
+    @Override
+    public EscalationTeam findEscalationTeamByName(String teamName) {
+        return teams.stream().filter(t -> t.label().equals(teamName)).findFirst().orElse(null);
+    }
+}
+

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeTeamsFetcher.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeTeamsFetcher.java
@@ -1,0 +1,17 @@
+package com.coreeng.supportbot.teams.fakes;
+
+import com.coreeng.supportbot.teams.PlatformTeamsFetcher;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class FakeTeamsFetcher implements PlatformTeamsFetcher {
+    private final List<TeamAndGroupTuple> teams;
+
+    @Override
+    public List<TeamAndGroupTuple> fetchTeams() {
+        return teams;
+    }
+}
+

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeUsersFetcher.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeUsersFetcher.java
@@ -1,0 +1,30 @@
+package com.coreeng.supportbot.teams.fakes;
+
+import com.coreeng.supportbot.teams.PlatformUsersFetcher;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RequiredArgsConstructor
+public class FakeUsersFetcher implements PlatformUsersFetcher {
+    private final Map<String, List<Membership>> membershipsByGroup;
+    private final Map<String, Integer> calls = new ConcurrentHashMap<>();
+
+    @Override
+    public List<Membership> fetchMembershipsByGroupRef(String groupRef) {
+        calls.merge(groupRef, 1, Integer::sum);
+        return membershipsByGroup.getOrDefault(groupRef, Collections.emptyList());
+    }
+
+    public int getCallCount(String groupRef) {
+        return calls.getOrDefault(groupRef, 0);
+    }
+
+    public int getTotalCalls() {
+        return calls.values().stream().mapToInt(Integer::intValue).sum();
+    }
+}
+

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/SlowUsersFetcher.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/SlowUsersFetcher.java
@@ -1,0 +1,46 @@
+package com.coreeng.supportbot.teams.fakes;
+
+import com.coreeng.supportbot.teams.PlatformUsersFetcher;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public class SlowUsersFetcher implements PlatformUsersFetcher {
+    private final Duration delay;
+    private final Function<String, List<Membership>> getResultFn;
+
+    private final AtomicInteger inFlight = new AtomicInteger(0);
+    private final AtomicInteger maxObserved = new AtomicInteger(0);
+
+    public SlowUsersFetcher(Duration delay) {
+        this(delay, groupRef -> Collections.emptyList());
+    }
+
+    public SlowUsersFetcher(Duration delay, Function<String, List<Membership>> getResultFn) {
+        this.delay = delay;
+        this.getResultFn = getResultFn;
+    }
+
+    @Override
+    public List<Membership> fetchMembershipsByGroupRef(String groupRef) {
+        int now = inFlight.incrementAndGet();
+        maxObserved.getAndAccumulate(now, Math::max);
+        try {
+            Thread.sleep(delay.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } finally {
+            inFlight.decrementAndGet();
+        }
+        return getResultFn.apply(groupRef);
+    }
+
+    public int maxObservedAtSameTime() {
+        return maxObserved.get();
+    }
+}
+


### PR DESCRIPTION
The bot fetches teams from identity providers on startup.
It's doing it sequentially. This can cause big delays for the startup time in case there is a big amount of teams in an org.
This change make this process parallel.
For example, with ~130 teams originally it took ~30 seconds to start up. Now it takes about 7 seconds.
It's possible to control concurrency level and timeout via properties:
```yaml
platform-integration:
  fetch:
    max-concurrency: 64
    timeout: 30s
```