### PR TITLE
bug: Use team code for referencing teams

### DIFF
--- a/api/functional/build.gradle.kts
+++ b/api/functional/build.gradle.kts
@@ -139,8 +139,10 @@ tasks.register("testIntegrated") {
             val jarFile = bootJarTask.archiveFile.get().asFile
 
             logger.lifecycle("Starting service: $jarFile")
-            val logfile = File(logfilePath)
-            logfile.createNewFile()
+            val logfile = File(logfilePath).apply {
+                parentFile.mkdirs()
+                createNewFile()
+            }
             serviceProcess = ProcessBuilder(
                 "${System.getProperty("java.home")}/bin/java",
                 "-jar", jarFile.absolutePath,

--- a/api/functional/src/test/java/com/coreeng/supportbot/Config.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/Config.java
@@ -99,7 +99,8 @@ public record Config(
     }
 
     public record EscalationTeam(
-        String name,
+        String label,
+        String code,
         String slackGroupId
     ) {}
     public record Tag(

--- a/api/functional/src/test/java/com/coreeng/supportbot/TicketManagementTests.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/TicketManagementTests.java
@@ -62,8 +62,8 @@ public class TicketManagementTests {
         ImmutableList<@NonNull String> firstTags = ImmutableList.of("jenkins-pipelines", "networking");
         ImmutableList<@NonNull String> secondTags = ImmutableList.of("ingresses", "networking");
 
-        ticket.escalateViaTestApi(MessageTs.now(), firstTeam.name(), firstTags);
-        ticket.escalateViaTestApi(MessageTs.now(), secondTeam.name(), secondTags);
+        ticket.escalateViaTestApi(MessageTs.now(), firstTeam.code(), firstTags);
+        ticket.escalateViaTestApi(MessageTs.now(), secondTeam.code(), secondTags);
 
         var closeStubs = ticket.stubCloseFlow(queryTs);
 
@@ -203,12 +203,12 @@ public class TicketManagementTests {
 
         // when
         ticket.openEscalationAndSubmit(asSupport.slack(), openEscalationTriggerId, EscalationFormSubmission.Values.builder()
-            .team(escalationTeam.name())
+            .team(escalationTeam.code())
             .tags(ImmutableList.of("jenkins-pipelines", "networking"))
             .build());
 
         EscalationFormSubmission.Values values = EscalationFormSubmission.Values.builder()
-            .team(escalationTeam.name())
+            .team(escalationTeam.code())
             .tags(ImmutableList.of("jenkins-pipelines", "networking"))
             .build();
 
@@ -234,7 +234,7 @@ public class TicketManagementTests {
 
         // Escalate via test controller
         ImmutableList<@NonNull String> escalationTags = ImmutableList.of("jenkins-pipelines", "networking");
-        ticket.escalateViaTestApi(MessageTs.now(), config.escalationTeams().getFirst().name(), escalationTags);
+        ticket.escalateViaTestApi(MessageTs.now(), config.escalationTeams().getFirst().code(), escalationTags);
 
         // Stub Slack updates for closing (composite)
         var closeStubs_whenEscalatedClosed = ticket.stubCloseFlow(queryTs);

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/EscalationForm.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/EscalationForm.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.text.StringSubstitutor;
 
-import com.coreeng.supportbot.Config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -47,15 +46,14 @@ public class EscalationForm {
                 .collect(Collectors.joining(",\n"));
 
             String teamOptions = ticket.config().escalationTeams().stream()
-                .map(Config.EscalationTeam::name)
-                .map(teamName -> String.format(
+                .map(team -> String.format(
                     """
                         {
                           "text": {"type": "plain_text", "text": %s},
                           "value": %s
                         }""",
-                    safeJson(teamName),
-                    safeJson(teamName)
+                    safeJson(team.label()),
+                    safeJson(team.code())
                 ))
                 .collect(Collectors.joining(",\n"));
 

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/EscalationMessage.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/EscalationMessage.java
@@ -24,7 +24,7 @@ public class EscalationMessage {
 
     private final String channelId;
     private final MessageTs threadTs;
-    private final String team;
+    private final String teamLabel;
     private final String slackGroupId;
     private final String expectedSlackGroupId;
 
@@ -33,7 +33,7 @@ public class EscalationMessage {
         assertThat(response.query().ts()).isEqualTo(threadTs);
         assertThat(response.escalated()).isTrue();
         assertThat(response.escalations())
-            .anySatisfy(e -> assertThat(e.team().name()).isEqualTo(team));
+            .anySatisfy(e -> assertThat(e.team().label()).isEqualTo(teamLabel));
 
         assertThat(slackGroupId).isNotBlank();
         if (expectedSlackGroupId != null && !expectedSlackGroupId.isBlank()) {
@@ -67,11 +67,11 @@ public class EscalationMessage {
             String mrkdwn = objectMapper.readTree(blocksRaw).get(0).get("text").get("text").asText();
             Matcher matcher = GROUP_PATTERN.matcher(mrkdwn);
             assertThat(matcher).matches();
-            String team = matcher.group("team");
+            String teamLabel = matcher.group("team");
             String groupId = matcher.group("group");
 
             String text = servedStub.getRequest().formParameter("text").firstValue();
-            assertThat(text).isEqualTo("Escalation to team: " + team);
+            assertThat(text).isEqualTo("Escalation to team: " + teamLabel);
 
             // Validate full blocks JSON equals expected
             String expectedBlocks = String.format("""
@@ -84,7 +84,7 @@ public class EscalationMessage {
                     }
                   }
                 ]
-                """, team, groupId);
+                """, teamLabel, groupId);
             assertThatJson(objectMapper.readTree(blocksRaw)).isEqualTo(expectedBlocks);
 
             JsonNode responseBody = objectMapper.readTree(servedStub.getResponse().getBody());
@@ -94,7 +94,7 @@ public class EscalationMessage {
             return EscalationMessage.builder()
                 .channelId(channelId)
                 .threadTs(threadTs)
-                .team(team)
+                .teamLabel(teamLabel)
                 .slackGroupId(groupId)
                 .expectedSlackGroupId(expectedSlackGroupId)
                 .build();

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/FullSummaryForm.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/FullSummaryForm.java
@@ -342,12 +342,12 @@ public class FullSummaryForm {
             } else {
                 escalationsBlock = ticket.escalations().stream()
                     .map(escalation -> {
-                        String teamName = escalation.team();
+                        String teamCode = escalation.team();
                         String groupId = ticket.config().escalationTeams().stream()
-                            .filter(t -> t.name().equals(teamName))
+                            .filter(t -> t.code().equals(teamCode))
                             .findFirst()
                             .map(Config.EscalationTeam::slackGroupId)
-                            .orElseThrow(() -> new AssertionError("Team not found: " + teamName));
+                            .orElseThrow(() -> new AssertionError("Team not found: " + teamCode));
                         return String.format(
                             """
                                 {

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/SupportBotClient.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/SupportBotClient.java
@@ -125,7 +125,7 @@ public class SupportBotClient {
 
     public record QueryResponse(String link, Instant date, MessageTs ts) {}
     public record TicketFormMessage(MessageTs ts) {}
-    public record Team(String name, ImmutableList<@NonNull String> types) {}
+    public record Team(String label, String code, ImmutableList<@NonNull String> types) {}
     @Builder
     @Getter
     @Jacksonized

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/Ticket.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/Ticket.java
@@ -60,7 +60,7 @@ public class Ticket implements SearchableForTicket {
             .status(Ticket.Status.fromCode(ticketResponse.status()))
             .team(
                 ticketResponse.team() != null
-                    ? ticketResponse.team().name()
+                    ? ticketResponse.team().code()
                     : null
             )
             .tags(ticketResponse.tags())
@@ -179,7 +179,7 @@ public class Ticket implements SearchableForTicket {
         if (team == null) {
             assertThat(response.team()).isNull();
         } else {
-            assertThat(response.team().name()).isEqualTo(team);
+            assertThat(response.team().code()).isEqualTo(team);
         }
         assertThat(response.tags()).isEqualTo(tags());
 
@@ -188,7 +188,7 @@ public class Ticket implements SearchableForTicket {
         for (int i = 0; i < escalations.size(); i++) {
             var expectedEscalation = escalations.get(i);
             var actualEscalation = response.escalations().get(i);
-            assertThat(actualEscalation.team().name()).isEqualTo(expectedEscalation.team());
+            assertThat(actualEscalation.team().code()).isEqualTo(expectedEscalation.team());
             assertThat(actualEscalation.tags()).isEqualTo(expectedEscalation.tags());
             if (expectedEscalation.createdAt() != null) {
                 assertThat(actualEscalation.openedAt()).isCloseTo(expectedEscalation.createdAt(), within(2, ChronoUnit.SECONDS));

--- a/api/functional/src/test/resources/config.yaml
+++ b/api/functional/src/test/resources/config.yaml
@@ -35,9 +35,11 @@ tenants:
       - email: nazira.armel@company.com
 
 escalationTeams:
-  - name: wow
+  - label: WoW
+    code: wow
     slackGroupId: S01234ESCWW
-  - name: infra-integration
+  - label: Infra Integration
+    code: infra-integration
     slackGroupId: S01234ESCII
 tags:
   - label: Ingresses

--- a/api/integration-tests/src/test/java/com/coreeng/supportbot/teams/rest/ServiceStartupTest.java
+++ b/api/integration-tests/src/test/java/com/coreeng/supportbot/teams/rest/ServiceStartupTest.java
@@ -88,14 +88,14 @@ public class ServiceStartupTest {
             .extract().body().jsonPath().getList("", TeamUI.class);
 
         TeamUI coreTeam = teams.stream()
-            .filter(team -> testTeamName.equals(team.name()))
+            .filter(team -> testTeamName.equals(team.code()))
             .findFirst()
             .orElse(null);
 
         assertThat(coreTeam)
             .as("Team '%s' should be present in response", testTeamName)
             .isNotNull();
-        assertThat(coreTeam.name())
+        assertThat(coreTeam.code())
             .as("Team name should match expected value")
             .isEqualTo(testTeamName);
         assertThat(coreTeam.types())

--- a/api/integration-tests/src/test/java/com/coreeng/supportbot/teams/rest/TeamUI.java
+++ b/api/integration-tests/src/test/java/com/coreeng/supportbot/teams/rest/TeamUI.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public record TeamUI(
-    @JsonProperty("name") String name,
+    @JsonProperty("label") String label,
+    @JsonProperty("code") String code,
     @JsonProperty("types") List<String> types
 ) {}

--- a/api/service/src/main/java/com/coreeng/supportbot/config/SupportTeamProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/config/SupportTeamProps.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("support-team")
 public record SupportTeamProps(
     String name,
+    String code,
     String slackGroupId
 ) {
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
@@ -59,15 +59,6 @@ public class EnumsService implements
     }
 
     @Nullable
-    @Override
-    public EscalationTeam findEscalationTeamByName(String teamName) {
-        return escalationTeams.stream()
-            .filter(t -> teamName.equals(t.label()))
-            .findAny()
-            .orElse(null);
-    }
-
-    @Nullable
     private <T extends EnumerationValue> T findByCode(String code, ImmutableList<T> values) {
         return values.stream()
             .filter(v -> code.equals(v.code()))

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EscalationTeamsRegistry.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EscalationTeamsRegistry.java
@@ -8,6 +8,4 @@ public interface EscalationTeamsRegistry {
     ImmutableList<EscalationTeam> listAllEscalationTeams();
     @Nullable
     EscalationTeam findEscalationTeamByCode(String code);
-    @Nullable
-    EscalationTeam findEscalationTeamByName(String teamName);
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationCreatedMessage.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationCreatedMessage.java
@@ -1,20 +1,10 @@
 package com.coreeng.supportbot.escalation;
 
 
+import com.coreeng.supportbot.enums.EscalationTeam;
 
 public record EscalationCreatedMessage(
     EscalationId escalationId,
-    String escalationTeam,
-    String slackTeamGroupId
+    EscalationTeam team
 ) {
-    public static EscalationCreatedMessage of(
-        Escalation escalation,
-        String slackTeamGroupId
-    ) {
-        return new EscalationCreatedMessage(
-            escalation.id(),
-            escalation.team(),
-            slackTeamGroupId
-        );
-    }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationCreatedMessageMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationCreatedMessageMapper.java
@@ -24,8 +24,8 @@ public class EscalationCreatedMessageMapper {
     }
 
     private ImmutableList<LayoutBlock> renderBlocks(EscalationCreatedMessage message) {
-        String str = "\nEscalated to team: " + message.escalationTeam()
-                     + "("+ "<!subteam^" +message.slackTeamGroupId() + ">)";
+        String str = "\nEscalated to team: " + message.team().label()
+                     + "("+ "<!subteam^" +message.team().slackGroupId() + ">)";
         return ImmutableList.of(
             section(s -> s
                 .text(markdownText(str))
@@ -34,7 +34,7 @@ public class EscalationCreatedMessageMapper {
     }
 
     private String getTextMessage(EscalationCreatedMessage message) {
-        return format("Escalation to team: %s", message.escalationTeam());
+        return format("Escalation to team: %s", message.team().label());
     }
 
     public EscalationResolveInput parseTriggerInput(String json) {

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
@@ -1,8 +1,7 @@
 package com.coreeng.supportbot.escalation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.coreeng.supportbot.config.SlackTicketsProps;
+import com.coreeng.supportbot.enums.EscalationTeam;
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
 import com.coreeng.supportbot.slack.MessageTs;
 import com.coreeng.supportbot.slack.client.SlackClient;
@@ -34,7 +33,7 @@ public class EscalationProcessingService {
                 request.tags()
             )
         );
-        if (escalation.id() == null) {
+        if (escalation == null || escalation.id() == null) {
             log.warn("Escalation already exists");
             return escalation;
         }
@@ -43,10 +42,11 @@ public class EscalationProcessingService {
             .addArgument(escalation::id)
             .log("Escalation created: {}");
 
+        EscalationTeam team = escalationTeamsRegistry.findEscalationTeamByCode(escalation.team());
         ChatPostMessageResponse messagePostResponse = slackClient.postMessage(new SlackPostMessageRequest(
-            createdMessageMapper.renderMessage(EscalationCreatedMessage.of(
-                escalation,
-                checkNotNull(escalationTeamsRegistry.findEscalationTeamByName(escalation.team())).slackGroupId()
+            createdMessageMapper.renderMessage(new EscalationCreatedMessage(
+                escalation.id(),
+                team
             )),
             slackTicketsProps.channelId(),
             request.ticket().queryTs()

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationRepository.java
@@ -4,8 +4,8 @@ import com.coreeng.supportbot.slack.MessageTs;
 import com.coreeng.supportbot.ticket.TicketId;
 import com.coreeng.supportbot.util.Page;
 import com.google.common.collect.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.time.Instant;
 
 public interface EscalationRepository {

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/rest/EscalationUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/rest/EscalationUIMapper.java
@@ -27,7 +27,7 @@ public class EscalationUIMapper {
             )))
             .openedAt(escalation.openedAt())
             .resolvedAt(escalation.resolvedAt())
-            .team(teamUIMapper.mapToUI(checkNotNull(teamService.findTeamByName(escalation.team()))))
+            .team(teamUIMapper.mapToUI(checkNotNull(teamService.findTeamByCode(escalation.team()))))
             .tags(escalation.tags())
             .build();
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/sentiment/SentimentService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/sentiment/SentimentService.java
@@ -71,7 +71,7 @@ public class SentimentService {
             .map(m -> {
                 String email = userIdToEmail.get(m.getUser());
                 String team = supportTeamService.isMemberByUserEmail(email)
-                    ? supportTeam.name()
+                    ? supportTeam.code()
                     : ticket.team();
                 return Message.builder()
                     .user(m.getUser())
@@ -88,8 +88,8 @@ public class SentimentService {
 
         String ticketAuthorId = threadPage.getMessages().getFirst().getUser();
         Sentiment authorSentiment = calculateAuthorSentiment(ticketAuthorId, messageSentiments);
-        Sentiment supportSentiment = calculateSupportTeamSentiment(supportTeam.name(), messageSentiments);
-        Sentiment othersSentiment = calculateOthersSentiment(ticketAuthorId, supportTeam.name(), messageSentiments);
+        Sentiment supportSentiment = calculateSupportTeamSentiment(supportTeam.code(), messageSentiments);
+        Sentiment othersSentiment = calculateOthersSentiment(ticketAuthorId, supportTeam.code(), messageSentiments);
 
         return TicketSentimentResults.builder()
             .ticketId(id)

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/SupportTeamService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/SupportTeamService.java
@@ -21,6 +21,7 @@ public class SupportTeamService {
     public Team getTeam() {
         return new Team(
             supportTeamProps.name(),
+            supportTeamProps.code(),
             ImmutableList.of(TeamType.support)
         );
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/Team.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/Team.java
@@ -3,7 +3,8 @@ package com.coreeng.supportbot.teams;
 import com.google.common.collect.ImmutableList;
 
 public record Team(
-    String name,
+    String label,
+    String code,
     ImmutableList<TeamType> types
 ) {
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
@@ -1,5 +1,6 @@
 package com.coreeng.supportbot.teams;
 
+import com.coreeng.supportbot.enums.EscalationTeam;
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
 import com.google.common.collect.ImmutableList;
 import lombok.RequiredArgsConstructor;
@@ -42,19 +43,19 @@ public class TeamService {
         return switch (type) {
             case tenant -> mapPlatformTeams(platformTeamsService.listTeams());
             case l2Support -> escalationTeamsRegistry.listAllEscalationTeams().stream()
-                .map(t -> new Team(t.label(), ImmutableList.of(TeamType.l2Support)))
+                .map(t -> new Team(t.label(), t.code(), ImmutableList.of(TeamType.l2Support)))
                 .collect(toImmutableList());
             case support -> ImmutableList.of(supportTeamService.getTeam());
         };
     }
 
     @Nullable
-    public Team findTeamByName(String name) {
+    public Team findTeamByCode(String code) {
         Team supportTeam = supportTeamService.getTeam();
-        if (supportTeam.name().equals(name)) {
+        if (supportTeam.code().equals(code)) {
             return supportTeam;
         }
-        PlatformTeam team = platformTeamsService.findTeamByName(name);
+        PlatformTeam team = platformTeamsService.findTeamByName(code);
         return team != null
             ? mapPlatformTeam(team)
             : null;
@@ -68,11 +69,18 @@ public class TeamService {
 
     @NotNull
     private Team mapPlatformTeam(PlatformTeam t) {
+        EscalationTeam escalationTeam = escalationTeamsRegistry.findEscalationTeamByCode(t.name());
+        if (escalationTeam != null) {
+            return new Team(
+                escalationTeam.label(),
+                escalationTeam.code(),
+                ImmutableList.of(TeamType.tenant, TeamType.l2Support)
+            );
+        }
         return new Team(
             t.name(),
-            escalationTeamsRegistry.findEscalationTeamByName(t.name()) != null
-                ? ImmutableList.of(TeamType.tenant, TeamType.l2Support)
-                : ImmutableList.of(TeamType.tenant)
+            t.name(),
+            ImmutableList.of(TeamType.tenant)
         );
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUI.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUI.java
@@ -4,7 +4,8 @@ import com.coreeng.supportbot.teams.TeamType;
 import com.google.common.collect.ImmutableList;
 
 public record TeamUI(
-    String name,
+    String label,
+    String code,
     ImmutableList<TeamType> types
 ) {
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUIMapper.java
@@ -23,7 +23,8 @@ public class TeamUIMapper {
 
     public TeamUI mapToUI(Team team) {
         return new TeamUI(
-            team.name(),
+            team.label(),
+            team.code(),
             team.types()
         );
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/EscalateViewMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/EscalateViewMapper.java
@@ -107,9 +107,7 @@ public class EscalateViewMapper {
             .collect(toImmutableList());
 
         ViewState.Value teamValue = checkNotNull(passedValues.get(Fields.team.actionId()));
-        String team = checkNotNull(escalationTeamsRegistry.findEscalationTeamByCode(
-            teamValue.getSelectedOption().getValue()
-        )).label();
+        String team = teamValue.getSelectedOption().getValue();
 
         ViewState.Value threadPermalinkValue = passedValues.get(Fields.threadPermalink.actionId());
         String threadPermalink = threadPermalinkValue != null

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
@@ -68,7 +68,7 @@ public class TicketSummaryService {
                 return TicketSummaryView.EscalationView.of(
                     e,
                     threadPermalink,
-                    checkNotNull(escalationTeamsRegistry.findEscalationTeamByName(e.team())).slackGroupId()
+                    checkNotNull(escalationTeamsRegistry.findEscalationTeamByCode(e.team())).slackGroupId()
                 );
             })
             .collect(toImmutableList());

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
@@ -39,7 +39,7 @@ public class TicketUIMapper {
             .status(ticket.ticket().status())
             .team(
                 ticket.ticket().team() != null
-                    ? teamUIMapper.mapToUI(checkNotNull(teamService.findTeamByName(ticket.ticket().team())))
+                    ? teamUIMapper.mapToUI(checkNotNull(teamService.findTeamByCode(ticket.ticket().team())))
                     : null
             )
             .impact(ticket.ticket().impact())

--- a/api/service/src/main/resources/application-functionaltests.yaml
+++ b/api/service/src/main/resources/application-functionaltests.yaml
@@ -12,10 +12,10 @@ slack:
 
 enums:
   escalation-teams:
-    - label: wow
+    - label: WoW
       code: wow
       slack-group-id: S01234ESCWW
-    - label: infra-integration
+    - label: Infra Integration
       code: infra-integration
       slack-group-id: S01234ESCII
 #    - label: connected-app

--- a/api/service/src/main/resources/application.yaml
+++ b/api/service/src/main/resources/application.yaml
@@ -157,6 +157,7 @@ platform-integration:
 
 support-team:
   name: Core Support
+  code: support
   slack-group-id: S08948NBMED
   static:
     enabled: false

--- a/api/service/src/test/java/com/coreeng/supportbot/escalation/EscalationProcessingServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/escalation/EscalationProcessingServiceTest.java
@@ -80,10 +80,10 @@ class EscalationProcessingServiceTest {
     ChatPostMessageResponse chatPostMessageResponse = new ChatPostMessageResponse();
     chatPostMessageResponse.setTs("ts");
     when(escalationRepository.createIfNotExists(any(Escalation.class)))
-        .thenReturn(Escalation.builder().id(new EscalationId(1)).build());
+        .thenReturn(expectedEscalation.toBuilder().id(new EscalationId(1)).build());
     when(slackClient.postMessage(any())).thenReturn(chatPostMessageResponse);
     when(escalationRepository.update(any(Escalation.class))).thenReturn(expectedEscalation);
-    when(escalationTeamsRegistry.findEscalationTeamByName(any())).thenReturn(new EscalationTeam("some-team","someTeam","id"));
+    when(escalationTeamsRegistry.findEscalationTeamByCode("some-team")).thenReturn(new EscalationTeam("some-team","someTeam","id"));
 
     // when
     Escalation escalation = processingService.createEscalation(escalationRequest);

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeEscalationTeamsRegistry.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/fakes/FakeEscalationTeamsRegistry.java
@@ -20,10 +20,5 @@ public class FakeEscalationTeamsRegistry implements EscalationTeamsRegistry {
     public EscalationTeam findEscalationTeamByCode(String code) {
         return teams.stream().filter(t -> t.code().equals(code)).findFirst().orElse(null);
     }
-
-    @Override
-    public EscalationTeam findEscalationTeamByName(String teamName) {
-        return teams.stream().filter(t -> t.label().equals(teamName)).findFirst().orElse(null);
-    }
 }
 


### PR DESCRIPTION
Use team code for referencing teams.
There were a couple of places where teams were referenced by name