### PR TITLE
feat: support escalation-only teams independent of platform teams

### DIFF
--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -79,9 +79,9 @@ ticket:
     stale-reminder-interval: 1d
 
 enums:
-  escalation-teams: # Platform teams for query escalation
+  escalation-teams: # Teams available for query escalation
     - label: wow # Label showed on the UI
-      code: wow # Team ID. have to be unique and match the team name in the platform
+      code: wow # Team ID. Must be unique. Have to match platform team name unless platform-integration.fetch.ignore-unknown-teams is set to true
       slack-group-id: S08948NBMED # Slack group ID that will be tagged on escalations
   tags: # Ticket tags
     - label: Ingresses # Label showed on the UI
@@ -104,6 +104,12 @@ enums:
 
 platform-integration: # Whether to enable platform integration to automatically scrape for teams and members
   enabled: true
+  fetch:
+    max-concurrency: 64 # Maximum number of concurrent requests when fetching team data
+    timeout: 30s # Timeout for fetching all team data
+    ignore-unknown-teams: false # Whether to allow escalation teams that don't exist in platform teams.
+                                 # If false, startup will fail if any escalation team is not found in platform teams.
+                                 # If true, escalation-only teams are allowed (they will have only 'l2Support' type).
   gcp:
     app-name: Support Bot # Used by GCP client
     enabled: true

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetchProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetchProps.java
@@ -7,7 +7,8 @@ import java.time.Duration;
 @ConfigurationProperties("platform-integration.fetch")
 public record PlatformTeamsFetchProps(
     int maxConcurrency,
-    Duration timeout
+    Duration timeout,
+    boolean ignoreUnknownTeams
 ) {
 }
 

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
@@ -175,10 +175,16 @@ public class PlatformTeamsService {
             .collect(toImmutableSet());
         var setsDiff = Sets.difference(escalationTeamNames, teamNames);
         if (!setsDiff.isEmpty()) {
-            throw new IllegalStateException("Unknown escalation teams specified: " +
-                                            setsDiff.stream()
-                                                .collect(joining(", ", "[", "]"))
-            );
+            if (fetchProps.ignoreUnknownTeams()) {
+                log.info("""
+                    Found unknown escalation teams: {}.
+                    Ensure that it's expected that these teams are not found among platform teams.""", setsDiff);
+            } else {
+                throw new IllegalStateException("Unknown escalation teams specified: " +
+                                                setsDiff.stream()
+                                                    .collect(joining(", ", "[", "]"))
+                );
+            }
         }
     }
 

--- a/api/service/src/main/resources/application.yaml
+++ b/api/service/src/main/resources/application.yaml
@@ -104,6 +104,7 @@ platform-integration:
   fetch:
     max-concurrency: 64
     timeout: 30s
+    ignore-unknown-teams: false # Whether to check for unknown escalation teams and fail if any are found
   kubernetes:
     disable-http-proxy: false
     base-url: ""

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
@@ -44,7 +44,7 @@ class PlatformTeamsServiceConcurrencyTest {
 
         EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(escalationTeams);
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(maxConcurrency, timeout);
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(maxConcurrency, timeout, false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         // Act

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
@@ -28,7 +28,7 @@ class PlatformTeamsServiceTest {
             new EscalationTeam("wow", "wow", "SOME")
         ));
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         service.init();
@@ -64,7 +64,7 @@ class PlatformTeamsServiceTest {
             new EscalationTeam("B", "B", "SOME")
         ));
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         service.init();
@@ -99,7 +99,7 @@ class PlatformTeamsServiceTest {
             new EscalationTeam("T1", "T1", "SOME")
         ));
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         service.init();
@@ -123,11 +123,40 @@ class PlatformTeamsServiceTest {
             new EscalationTeam("unknown", "unknown", "SOME")
         ));
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class, service::init);
         assertEquals("Unknown escalation teams specified: [unknown]", ex.getMessage());
+    }
+
+    @Test
+    void escalationMappingMismatch_ignoresUnknownTeamsWhenFlagIsTrue() {
+        PlatformTeamsFetcher teamsFetcher = new FakeTeamsFetcher(List.of(
+            new PlatformTeamsFetcher.TeamAndGroupTuple("wow", "G")
+        ));
+        PlatformUsersFetcher usersFetcher = new FakeUsersFetcher(
+            Map.of("G", List.of(new PlatformUsersFetcher.Membership("user@test.com")))
+        );
+
+        EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("wow", "wow", "SOME"),
+            new EscalationTeam("unknown", "unknown", "SOME"),
+            new EscalationTeam("another-unknown", "another-unknown", "SOME2")
+        ));
+
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1), true);
+        PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
+
+        // Should not throw an exception
+        service.init();
+
+        // Verify that the service initialized correctly with the known team
+        assertEquals(1, service.listTeams().size());
+        var team = service.findTeamByName("wow");
+        assertNotNull(team);
+        assertEquals("wow", team.name());
+        assertEquals(1, team.users().size());
     }
 
     @Test
@@ -140,7 +169,7 @@ class PlatformTeamsServiceTest {
             new EscalationTeam("T", "T", "SOME")
         ));
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(1, Duration.ofMillis(50));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(1, Duration.ofMillis(50), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class, service::init);
@@ -153,7 +182,7 @@ class PlatformTeamsServiceTest {
         FakeUsersFetcher usersFetcher = new FakeUsersFetcher(Map.of());
         EscalationTeamsRegistry registry = new FakeEscalationTeamsRegistry(List.of());
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(2, Duration.ofSeconds(1), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         service.init();
@@ -176,7 +205,7 @@ class PlatformTeamsServiceTest {
             new EscalationTeam("T", "T", "SOME")
         ));
 
-        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2));
+        PlatformTeamsFetchProps props = new PlatformTeamsFetchProps(4, Duration.ofSeconds(2), false);
         PlatformTeamsService service = new PlatformTeamsService(teamsFetcher, usersFetcher, registry, props);
 
         service.init();

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
@@ -1,0 +1,435 @@
+package com.coreeng.supportbot.teams;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import com.coreeng.supportbot.teams.fakes.FakeEscalationTeamsRegistry;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TeamServiceTest {
+
+    @Test
+    void listTeamsByType_tenant_returnsOnlyPlatformTeams() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Escalation Only 1", "escalation-only-1", "SLACK1"),
+            new EscalationTeam("Escalation Only 2", "escalation-only-2", "SLACK2")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        PlatformTeam platformTeam1 = new PlatformTeam("team1", Set.of(), Set.of());
+        PlatformTeam platformTeam2 = new PlatformTeam("team2", Set.of(), Set.of());
+        when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformTeam1, platformTeam2));
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeamsByType(TeamType.tenant);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("team1", result.get(0).code());
+        assertEquals(ImmutableList.of(TeamType.tenant), result.get(0).types());
+        assertEquals("team2", result.get(1).code());
+        assertEquals(ImmutableList.of(TeamType.tenant), result.get(1).types());
+    }
+
+    @Test
+    void listTeamsByType_l2Support_returnsEscalationOnlyTeams() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+
+        PlatformTeam platformOnlyTeam1 = new PlatformTeam("platform-only-1", Set.of(), Set.of());
+        PlatformTeam platformOnlyTeam2 = new PlatformTeam("platform-only-2", Set.of(), Set.of());
+        when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformOnlyTeam1, platformOnlyTeam2));
+        when(platformTeamsService.findTeamByName(anyString())).thenReturn(null);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Escalation Team 1", "esc1", "SLACK1"),
+            new EscalationTeam("Escalation Team 2", "esc2", "SLACK2")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeamsByType(TeamType.l2Support);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("Escalation Team 1", result.get(0).label());
+        assertEquals("esc1", result.get(0).code());
+        assertEquals(ImmutableList.of(TeamType.l2Support), result.get(0).types());
+        assertEquals("Escalation Team 2", result.get(1).label());
+        assertEquals("esc2", result.get(1).code());
+        assertEquals(ImmutableList.of(TeamType.l2Support), result.get(1).types());
+    }
+
+    @Test
+    void listTeamsByType_l2Support_returnsTeamsWithBothTypesWhenAlsoPlatformTeam() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+
+        PlatformTeam platformAndEscalationTeam = new PlatformTeam("esc1", Set.of(), Set.of());
+        PlatformTeam platformOnlyTeam = new PlatformTeam("platform-only-noise", Set.of(), Set.of());
+        when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformAndEscalationTeam, platformOnlyTeam));
+        when(platformTeamsService.findTeamByName("esc1")).thenReturn(platformAndEscalationTeam);
+        when(platformTeamsService.findTeamByName("esc2")).thenReturn(null);
+        when(platformTeamsService.findTeamByName("platform-only-noise")).thenReturn(platformOnlyTeam);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Escalation Team 1", "esc1", "SLACK1"),
+            new EscalationTeam("Escalation Team 2", "esc2", "SLACK2")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeamsByType(TeamType.l2Support);
+
+        // then
+        assertEquals(2, result.size());
+
+        // First team is both platform and escalation
+        assertEquals("Escalation Team 1", result.get(0).label());
+        assertEquals("esc1", result.get(0).code());
+        assertEquals(ImmutableList.of(TeamType.tenant, TeamType.l2Support), result.get(0).types());
+
+        // Second team is escalation only
+        assertEquals("Escalation Team 2", result.get(1).label());
+        assertEquals("esc2", result.get(1).code());
+        assertEquals(ImmutableList.of(TeamType.l2Support), result.get(1).types());
+    }
+
+    @Test
+    void listTeamsByType_support_returnsSupportTeam() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeamsByType(TeamType.support);
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals("Support Team", result.get(0).label());
+        assertEquals("support", result.get(0).code());
+        assertEquals(ImmutableList.of(TeamType.support), result.get(0).types());
+    }
+
+    @Test
+    void findTeamByCode_returnsSupportTeam() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        Team result = teamService.findTeamByCode("support");
+
+        // then
+        assertNotNull(result);
+        assertEquals("Support Team", result.label());
+        assertEquals("support", result.code());
+        assertEquals(ImmutableList.of(TeamType.support), result.types());
+    }
+
+    @Test
+    void findTeamByCode_returnsPlatformOnlyTeam() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        PlatformTeam platformTeam = new PlatformTeam("platform1", Set.of(), Set.of());
+        when(platformTeamsService.findTeamByName("platform1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByName("escalation-noise-1")).thenReturn(null);
+        when(platformTeamsService.findTeamByName("escalation-noise-2")).thenReturn(null);
+
+        // Add noise: escalation teams with different codes
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Escalation Noise 1", "escalation-noise-1", "SLACK1"),
+            new EscalationTeam("Escalation Noise 2", "escalation-noise-2", "SLACK2")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        Team result = teamService.findTeamByCode("platform1");
+
+        // then
+        assertNotNull(result);
+        assertEquals("platform1", result.label());
+        assertEquals("platform1", result.code());
+        assertEquals(ImmutableList.of(TeamType.tenant), result.types());
+    }
+
+    @Test
+    void findTeamByCode_returnsPlatformTeamWithBothTypesWhenAlsoEscalation() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
+        when(platformTeamsService.findTeamByName("team1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByName("other-team")).thenReturn(null);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Team 1", "team1", "SLACK1"),
+            new EscalationTeam("Other Team", "other-team", "SLACK2")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        Team result = teamService.findTeamByCode("team1");
+
+        // then
+        assertNotNull(result);
+        assertEquals("Team 1", result.label());
+        assertEquals("team1", result.code());
+        assertEquals(ImmutableList.of(TeamType.tenant, TeamType.l2Support), result.types());
+    }
+
+    @Test
+    void findTeamByCode_returnsEscalationOnlyTeam() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
+        when(platformTeamsService.findTeamByName("esc2")).thenReturn(null);
+
+        PlatformTeam platformOnlyNoise = new PlatformTeam("platform-noise", Set.of(), Set.of());
+        when(platformTeamsService.findTeamByName("platform-noise")).thenReturn(platformOnlyNoise);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Escalation Team 1", "esc1", "SLACK1"),
+            new EscalationTeam("Escalation Team 2", "esc2", "SLACK2")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        Team result = teamService.findTeamByCode("esc1");
+
+        // then
+        assertNotNull(result);
+        assertEquals("Escalation Team 1", result.label());
+        assertEquals("esc1", result.code());
+        assertEquals(ImmutableList.of(TeamType.l2Support), result.types());
+    }
+
+    @Test
+    void findTeamByCode_returnsNullWhenTeamNotFound() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByName("unknown")).thenReturn(null);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        Team result = teamService.findTeamByCode("unknown");
+
+        // then
+        assertNull(result);
+    }
+
+    @Test
+    void listTeams_includesAllTeamTypes() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        PlatformTeam platformOnlyTeam = new PlatformTeam("platform1", Set.of(), Set.of());
+        PlatformTeam bothTypesTeam = new PlatformTeam("both1", Set.of(), Set.of());
+        when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformOnlyTeam, bothTypesTeam));
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Both Team", "both1", "SLACK1")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeams();
+
+        // then
+        assertEquals(3, result.size());
+
+        // Verify platform-only team has only tenant type
+        Team platformTeam = result.stream().filter(t -> "platform1".equals(t.code())).findFirst().orElse(null);
+        assertNotNull(platformTeam);
+        assertEquals("platform1", platformTeam.label());
+        assertEquals(ImmutableList.of(TeamType.tenant), platformTeam.types());
+
+        // Verify team with both types has both tenant and l2Support
+        Team bothTeam = result.stream().filter(t -> "both1".equals(t.code())).findFirst().orElse(null);
+        assertNotNull(bothTeam);
+        assertEquals("Both Team", bothTeam.label());
+        assertEquals(ImmutableList.of(TeamType.tenant, TeamType.l2Support), bothTeam.types());
+
+        // Verify support team has only support type
+        Team supportTeam = result.stream().filter(t -> "support".equals(t.code())).findFirst().orElse(null);
+        assertNotNull(supportTeam);
+        assertEquals("Support Team", supportTeam.label());
+        assertEquals(ImmutableList.of(TeamType.support), supportTeam.types());
+
+        // Verify we have exactly one of each type
+        long platformOnlyCount = result.stream().filter(t -> t.types().equals(ImmutableList.of(TeamType.tenant))).count();
+        long bothTypesCount = result.stream().filter(t -> t.types().equals(ImmutableList.of(TeamType.tenant, TeamType.l2Support))).count();
+        long supportOnlyCount = result.stream().filter(t -> t.types().equals(ImmutableList.of(TeamType.support))).count();
+
+        assertEquals(1, platformOnlyCount, "Should have exactly 1 platform-only team");
+        assertEquals(1, bothTypesCount, "Should have exactly 1 team with both types");
+        assertEquals(1, supportOnlyCount, "Should have exactly 1 support team");
+    }
+
+    @Test
+    void listTeamsByUserEmail_returnsUserPlatformTeams() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        PlatformTeam userTeam = new PlatformTeam("team1", Set.of(), Set.of());
+
+        PlatformTeam otherUserTeam1 = new PlatformTeam("other-team-1", Set.of(), Set.of());
+        PlatformTeam otherUserTeam2 = new PlatformTeam("other-team-2", Set.of(), Set.of());
+
+        when(platformTeamsService.listTeamsByUserEmail("user@test.com")).thenReturn(ImmutableList.of(userTeam));
+        when(platformTeamsService.listTeamsByUserEmail("other@test.com")).thenReturn(ImmutableList.of(otherUserTeam1, otherUserTeam2));
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeamsByUserEmail("user@test.com");
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals("team1", result.get(0).code());
+        assertEquals(ImmutableList.of(TeamType.tenant), result.get(0).types());
+    }
+
+    @Test
+    void listTeamsByUserEmail_includesSupportTeamForSupportMembers() {
+        // given
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
+        when(platformTeamsService.listTeamsByUserEmail("support@test.com")).thenReturn(ImmutableList.of(platformTeam));
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        when(supportTeamService.isMemberByUserEmail("support@test.com")).thenReturn(true);
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when
+        ImmutableList<Team> result = teamService.listTeamsByUserEmail("support@test.com");
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("team1", result.get(0).code());
+        assertEquals("support", result.get(1).code());
+    }
+
+    @Test
+    void consistency_teamHasSameTypesRegardlessOfHowItsQueried() {
+        // given - team that is both platform and escalation
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
+        when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformTeam));
+        when(platformTeamsService.findTeamByName("team1")).thenReturn(platformTeam);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Team 1", "team1", "SLACK1")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when - query the same team in different ways
+        Team fromFindByCode = teamService.findTeamByCode("team1");
+        Team fromListByTypeTenant = teamService.listTeamsByType(TeamType.tenant).stream()
+            .filter(t -> "team1".equals(t.code()))
+            .findFirst()
+            .orElse(null);
+        Team fromListByTypeL2Support = teamService.listTeamsByType(TeamType.l2Support).stream()
+            .filter(t -> "team1".equals(t.code()))
+            .findFirst()
+            .orElse(null);
+        Team fromListTeams = teamService.listTeams().stream()
+            .filter(t -> "team1".equals(t.code()))
+            .findFirst()
+            .orElse(null);
+
+        // then - all should have the same types
+        ImmutableList<TeamType> expectedTypes = ImmutableList.of(TeamType.tenant, TeamType.l2Support);
+
+        assertNotNull(fromFindByCode);
+        assertEquals(expectedTypes, fromFindByCode.types());
+
+        assertNotNull(fromListByTypeTenant);
+        assertEquals(expectedTypes, fromListByTypeTenant.types());
+
+        assertNotNull(fromListByTypeL2Support);
+        assertEquals(expectedTypes, fromListByTypeL2Support.types());
+
+        assertNotNull(fromListTeams);
+        assertEquals(expectedTypes, fromListTeams.types());
+    }
+
+    @Test
+    void consistency_escalationOnlyTeamHasOnlyL2SupportType() {
+        // given - escalation team that is NOT a platform team
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of());
+        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
+
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
+            new EscalationTeam("Escalation Only", "esc1", "SLACK1")
+        ));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+
+        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+
+        // when - query the same team in different ways
+        Team fromFindByCode = teamService.findTeamByCode("esc1");
+        Team fromListByTypeL2Support = teamService.listTeamsByType(TeamType.l2Support).stream()
+            .filter(t -> "esc1".equals(t.code()))
+            .findFirst()
+            .orElse(null);
+
+        // then - both should have only l2Support type
+        ImmutableList<TeamType> expectedTypes = ImmutableList.of(TeamType.l2Support);
+
+        assertNotNull(fromFindByCode);
+        assertEquals(expectedTypes, fromFindByCode.types());
+
+        assertNotNull(fromListByTypeL2Support);
+        assertEquals(expectedTypes, fromListByTypeL2Support.types());
+
+        // Should NOT appear in tenant list
+        ImmutableList<Team> tenantTeams = teamService.listTeamsByType(TeamType.tenant);
+        assertTrue(tenantTeams.stream().noneMatch(t -> "esc1".equals(t.code())));
+    }
+
+    private SupportTeamService mockSupportTeamService() {
+        SupportTeamService supportTeamService = mock(SupportTeamService.class);
+        Team supportTeam = new Team("Support Team", "support", ImmutableList.of(TeamType.support));
+        when(supportTeamService.getTeam()).thenReturn(supportTeam);
+        when(supportTeamService.isMemberByUserEmail(anyString())).thenReturn(false);
+        return supportTeamService;
+    }
+}


### PR DESCRIPTION
- Add `ignoreUnknownTeams` flag to PlatformTeamsFetchProps to control validation
- Update TeamService to correctly assign team types based on team membership: