### PR TITLE
bug: Fix an issue when ticket is created by posting eyes on a thread reply

### DIFF
--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/MessageToPost.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/MessageToPost.java
@@ -18,4 +18,10 @@ public class MessageToPost {
     private final String message;
     @NonNull
     private final MessageTs ts;
+    /**
+     * Thread timestamp - set when posting a reply within a thread.
+     * When set, the message is posted as a reply to the thread.
+     */
+    @Nullable
+    private final MessageTs threadTs;
 }

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/SlackMessage.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/SlackMessage.java
@@ -29,6 +29,15 @@ public class SlackMessage {
         );
     }
 
+    /**
+     * Stub conversations.replies to indicate this message is a thread reply.
+     *
+     * @param threadTs The parent thread timestamp (indicates this message is a reply in that thread)
+     */
+    public Stub stubAsThreadReply(MessageTs threadTs) {
+        return slackWiremock.stubConversationsReplies(channelId, ts, threadTs);
+    }
+
     public StubWithResult<TicketMessage> expectThreadMessagePosted(ThreadMessagePostedExpectation<TicketMessage> expectation) {
         return slackWiremock.stubMessagePosted(expectation.toBuilder()
             .threadTs(ts)
@@ -37,6 +46,10 @@ public class SlackMessage {
     }
 
     public TicketCreationFlowStubs stubTicketCreationFlow(MessageTs newTicketMessageTs) {
+        // Stub conversations.replies to indicate this is NOT a thread reply
+        // This is needed because the service checks if the message is a thread reply before creating a ticket
+        slackWiremock.stubConversationsReplies(channelId, ts, null);
+
         Stub reaction = expectReactionAdded("ticket");
         StubWithResult<TicketMessage> posted = expectThreadMessagePosted(
             ThreadMessagePostedExpectation.<TicketMessage>builder()

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/SlackTestKit.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/SlackTestKit.java
@@ -18,6 +18,25 @@ public class SlackTestKit {
             .build());
     }
 
+    /**
+     * Post a reply in a thread.
+     *
+     * @param ts       Timestamp of the reply message
+     * @param threadTs Timestamp of the parent thread (original message)
+     * @param message  The message content
+     * @return The posted SlackMessage representing the reply
+     */
+    public SlackMessage postThreadReply(MessageTs ts, MessageTs threadTs, String message) {
+        return supportBotSlackClient.notifyMessagePosted(MessageToPost.builder()
+            .userId(testKit.userId())
+            .teamId(testKit.teamId())
+            .channelId(testKit.channelId())
+            .message(message)
+            .ts(ts)
+            .threadTs(threadTs)
+            .build());
+    }
+
     public void addReactionTo(SlackMessage targetMessage, String reaction) {
         slackWiremock.stubAuthTest();
         supportBotSlackClient.notifyReactionAdded(ReactionToAdd.builder()

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/Stub.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/Stub.java
@@ -25,4 +25,11 @@ public class Stub {
             .as("%s: stub was called exactly once", message)
             .hasSize(1);
     }
+
+    public void assertIsNotCalled(String message) {
+        GetServeEventsResult serveEvents = wireMockServer.getServeEvents(ServeEventQuery.forStubMapping(mapping));
+        assertThat(serveEvents.getServeEvents())
+            .as("%s: stub should not have been called", message)
+            .isEmpty();
+    }
 }

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/StubWithResult.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/StubWithResult.java
@@ -42,6 +42,13 @@ public class StubWithResult<T> {
         resultCalculated = true;
     }
 
+    public void assertIsNotCalled(String message) {
+        GetServeEventsResult serveEvents = wireMockServer.getServeEvents(ServeEventQuery.forStubMapping(mapping));
+        assertThat(serveEvents.getServeEvents())
+            .as("%s: stub should not have been called", message)
+            .isEmpty();
+    }
+
     public T result() {
         assertThat(resultCalculated).isTrue();
         return result;

--- a/api/functional/src/test/java/com/coreeng/supportbot/testkit/SupportBotSlackClient.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/testkit/SupportBotSlackClient.java
@@ -21,6 +21,9 @@ public class SupportBotSlackClient {
     private final SlackWiremock slackWiremock;
 
     public SlackMessage notifyMessagePosted(MessageToPost message) {
+        String threadTsField = message.threadTs() != null
+            ? "\"thread_ts\": \"" + message.threadTs() + "\","
+            : "";
         String body = StringSubstitutor.replace(
             """
                 {
@@ -32,6 +35,7 @@ public class SupportBotSlackClient {
                     "user": "${userId}",
                     "type": "message",
                     "ts": "${ts}",
+                    ${threadTsField}
                     "client_msg_id": "03ede034-b608-4428-baca-926730014431",
                     "text": "${message}",
                     "team": "${teamId}",
@@ -77,7 +81,8 @@ public class SupportBotSlackClient {
                 "userId", message.userId(),
                 "message", message.message(),
                 "channelId", message.channelId(),
-                "ts", message.ts().toString()
+                "ts", message.ts().toString(),
+                "threadTsField", threadTsField
             )
         );
         given()

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/slack/TicketSlackService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/slack/TicketSlackService.java
@@ -14,4 +14,6 @@ public interface TicketSlackService {
     void editTicketForm(MessageRef threadRef, TicketCreatedMessage message);
     void warnStaleness(MessageRef queryRef);
     void postRatingRequest(MessageRef queryRef, TicketId ticketId, String userId);
+
+    boolean isThreadReply(MessageRef messageRef);
 }


### PR DESCRIPTION
# Steps to reproduce
1. Post a query
2. Put an eyes on it
3. Post a message in the query thread
4. Put an eye on it

# Actual result
2 ticket forms in the thread

# Expected result
eyes reaction to the message in the query thread have to be ignored