### PR TITLE
fix(logging): downgrade logback to 8.0

### DIFF
--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     implementation("com.microsoft.graph:microsoft-graph:6.36.0")
     implementation("com.azure.spring:spring-cloud-azure-starter:5.22.0")
 
-    implementation("net.logstash.logback:logstash-logback-encoder:9.0")
+    implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
logstash-logback-encoder 9.0 migrated to Jackson 3.x, but Spring Boot still uses Jackson 2.x. We'll need to make further changes.

Structured logging with 8.0 currently works 