### PR TITLE
bug: Fix the Users Controller logic to return proper teams

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/teams/rest/UsersController.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/rest/UsersController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashSet;
+
 @RestController
 @RequiredArgsConstructor
 public class UsersController {
@@ -22,11 +24,18 @@ public class UsersController {
     public ResponseEntity<UserUI> findByEmail(
         @RequestParam String email
     ) {
+        ImmutableList<Team> teams = teamService.listTeamsByUserEmail(email);
+
         PlatformUser user = platformTeamsService.findUserByEmail(email);
-        if (user == null) {
+        if (user == null && teams.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
-        ImmutableList<Team> teams = teamService.listTeamsByUserEmail(email);
+        // If the user is not a member of any platform teams, but is, for example, a support member,
+        // return a minimal PlatformUser so the caller still gets their team memberships.
+        if (user == null) {
+            user = new PlatformUser(email.toLowerCase(), new HashSet<>());
+        }
         return ResponseEntity.ok(mapper.mapToUI(user, teams));
     }
 }
+


### PR DESCRIPTION
Currently, if you are not a member of any platform teams, but you are a support engineer, we return no groups as we fail faster than we should. This PR addresses that logic by looking at all types of teams before returning not found.