### PR TITLE
feature: Support filtering by tickets with no tags in homepage queries

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/homepage/HomepageFilter.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/homepage/HomepageFilter.java
@@ -24,6 +24,8 @@ public class HomepageFilter {
     private Timeframe timeframe;
     @Builder.Default
     private ImmutableList<String> tags = ImmutableList.of();
+    @Builder.Default
+    private boolean includeNoTags = false;
     @Nullable
     private String impact;
     @Nullable

--- a/api/service/src/main/java/com/coreeng/supportbot/homepage/HomepageView.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/homepage/HomepageView.java
@@ -62,6 +62,7 @@ public class HomepageView {
                 .dateFrom(dateFrom)
                 .dateTo(dateTo)
                 .tags(filter.tags())
+                .includeNoTags(filter.includeNoTags())
                 .escalationTeam(filter.escalationTeam())
                 .impacts(
                     filter.impact() != null

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketInMemoryRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketInMemoryRepository.java
@@ -193,9 +193,13 @@ public class TicketInMemoryRepository implements TicketRepository {
                 return false;
             }
         }
-        if (!query.tags().isEmpty()
-            && !new HashSet<>(ticket.tags()).containsAll(query.tags())) {
-            return false;
+        if (query.includeNoTags() || !query.tags().isEmpty()) {
+            boolean matchesNoTags = query.includeNoTags() && ticket.tags().isEmpty();
+            boolean matchesSelectedTags = !query.tags().isEmpty()
+                && new HashSet<>(ticket.tags()).containsAll(query.tags());
+            if (!matchesNoTags && !matchesSelectedTags) {
+                return false;
+            }
         }
         if (!query.impacts().isEmpty()) {
             if (ticket.impact() == null) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketsQuery.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketsQuery.java
@@ -37,6 +37,8 @@ public class TicketsQuery {
     @Builder.Default
     private ImmutableList<String> tags = ImmutableList.of();
     @Builder.Default
+    private boolean includeNoTags = false;
+    @Builder.Default
     private ImmutableList<String> impacts = ImmutableList.of();
     @Builder.Default
     private ImmutableList<String> teams = ImmutableList.of();

--- a/api/service/src/test/java/com/coreeng/supportbot/homepage/HomepageViewTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/homepage/HomepageViewTest.java
@@ -33,6 +33,7 @@ class HomepageViewTest {
                         .impact("production blocking")
                         .status(TicketStatus.opened)
                         .tags(ImmutableList.of("tag-a", "tag-b"))
+                        .includeNoTags(true)
                         .build())
                 .build();
 
@@ -45,6 +46,7 @@ class HomepageViewTest {
         assertThat(ticketsQuery.tags().get(0)).isEqualTo("tag-a");
         assertThat(ticketsQuery.tags().get(1)).isEqualTo("tag-b");
         assertThat(ticketsQuery.status()).isEqualTo(TicketStatus.opened);
+        assertThat(ticketsQuery.includeNoTags()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Add an option to filter tickets that have no tags on the slack bot homepage:
<img width="632" height="709" alt="image" src="https://github.com/user-attachments/assets/3d4d6fe9-4dd9-4f19-968c-38703c86794b" />
