### PR TITLE
chore: add ui deployment to helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,17 +148,16 @@ deploy-api-functional: ## Deploy service and DB for functional tests, then run t
 	./api/scripts/deploy-service.sh
 
 .PHONY: deploy-ui-%
-deploy-ui-%:
-	helm repo add core-platform-assets https://coreeng.github.io/core-platform-assets
-	helm upgrade --install "$(p2p_app_name)-ui" core-platform-assets/core-platform-app -n "$(p2p_namespace)" \
-		-f <(envsubst < ui/p2p/config/common.yaml) \
-		-f <(envsubst < ui/p2p/config/$*.yaml) \
-		--set nameOverride="$(p2p_app_name)-ui" \
-		--set tenantName="$(p2p_tenant_name)" \
-		--set image.repository="$(p2p_registry)/$(p2p_app_name)-ui" \
+deploy-ui-%: # Add UI to existing API deployment
+	helm upgrade --install "$(p2p_app_name)" ./api/k8s/service -n "$(p2p_namespace)" \
+		-f api/k8s/service/values-$*.yaml \
+		-f ui/p2p/config/common.yaml \
+		-f ui/p2p/config/$*.yaml \
+		--set image.repository="$(p2p_registry)/$(p2p_app_name)" \
 		--set image.tag="$(p2p_version)" \
-		--set ingress.appUrlSuffix="$(p2p_app_url_suffix)" \
-		--set ingress.domain="$(BASE_DOMAIN)" \
+		--set ui.image.repository="$(p2p_registry)/$(p2p_app_name)-ui" \
+		--set ui.image.tag="$(p2p_version)" \
+		--set "ui.ingress.hosts[0].host=$(p2p_app_name)-ui$(p2p_app_url_suffix).$(BASE_DOMAIN)" \
 		--atomic \
 		--timeout 10m
 

--- a/api/k8s/service/templates/_helpers.tpl
+++ b/api/k8s/service/templates/_helpers.tpl
@@ -60,3 +60,21 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "support-bot.ui.fullname" -}}
+{{- printf "%s-ui" (include "support-bot.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "support-bot.ui.labels" -}}
+helm.sh/chart: {{ include "support-bot.chart" . }}
+{{ include "support-bot.ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "support-bot.ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "support-bot.name" . }}-ui
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/api/k8s/service/templates/ui-deployment.yaml
+++ b/api/k8s/service/templates/ui-deployment.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "support-bot.ui.fullname" . }}
+  labels:
+    {{- include "support-bot.ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.ui.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "support-bot.ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.ui.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "support-bot.ui.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "support-bot.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.ui.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ui
+          securityContext:
+            {{- toYaml .Values.ui.securityContext | nindent 12 }}
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ui.service.port }}
+              protocol: TCP
+          env:
+            {{- toYaml .Values.ui.env | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.ui.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.ui.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.ui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/api/k8s/service/templates/ui-ingress.yaml
+++ b/api/k8s/service/templates/ui-ingress.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "support-bot.ui.fullname" . }}
+  labels:
+    {{- include "support-bot.ui.labels" . | nindent 4 }}
+  {{- with .Values.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ui.ingress.className }}
+  {{- end }}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+    {{- range .Values.ui.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ui.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "support-bot.ui.fullname" $ }}
+                port:
+                  number: {{ $.Values.ui.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/api/k8s/service/templates/ui-service.yaml
+++ b/api/k8s/service/templates/ui-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "support-bot.ui.fullname" . }}
+  labels:
+    {{- include "support-bot.ui.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - port: {{ .Values.ui.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "support-bot.ui.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/api/k8s/service/values.yaml
+++ b/api/k8s/service/values.yaml
@@ -120,3 +120,75 @@ configMap:
   annotations: {}
   data:
     # your properties for application.yaml
+
+ui:
+  enabled: false
+
+  image:
+    repository: support-bot-ui
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: support-bot-ui.example
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  livenessProbe:
+    httpGet:
+      path: /livez
+      port: 3000
+    failureThreshold: 3
+    periodSeconds: 20
+    successThreshold: 1
+    timeoutSeconds: 1
+
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: 3000
+    failureThreshold: 3
+    periodSeconds: 20
+    successThreshold: 1
+    timeoutSeconds: 1
+
+  podAnnotations: {}
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  env: []

--- a/ui/p2p/config/common.yaml
+++ b/ui/p2p/config/common.yaml
@@ -1,37 +1,10 @@
 ---
-replicaCount: 1
-
-resources:
-  requests:
-    cpu: 1000m
-    memory: 1024Mi
-  limits:
-    cpu: 1000m
-    memory: 1024Mi
-
-livenessProbe:
-  failureThreshold: 3
-  httpGet:
-    port: 3000
-    path: /livez
-  periodSeconds: 20
-  successThreshold: 1
-  timeoutSeconds: 1
-readinessProbe:
-  failureThreshold: 3
-  httpGet:
-    port: 3000
-    path: /readyz
-  periodSeconds: 20
-  successThreshold: 1
-  timeoutSeconds: 1
-
-ingress:
+ui:
   enabled: true
-  hosts:
-    - paths:
-        - path: "/"
-          pathType: "ImplementationSpecific"
 
-service:
-  port: 3000
+  ingress:
+    enabled: true
+    hosts:
+      - paths:
+          - path: "/"
+            pathType: "ImplementationSpecific"

--- a/ui/p2p/config/extended-test.yaml
+++ b/ui/p2p/config/extended-test.yaml
@@ -1,14 +1,23 @@
 ---
-envVarsMap:
-  BACKEND_URL: http://support-bot.support-bot-extended:8080
-  DATABASE_URL: ${SUPPORTBOT_DB_URL}
-  NODE_ENV: development
-  NEXTAUTH_SECRET: ""  # Set from Kubernetes secret
-  NEXTAUTH_URL: ""
-  # These will be injected via --set flags in Makefile
-  AZURE_AD_CLIENT_ID: ""  # Set from Kubernetes secret
-  AZURE_AD_CLIENT_SECRET: ""  # Set from Kubernetes secret
-  AZURE_AD_TENANT_ID: ""  # Set from Kubernetes secret
-  GOOGLE_CLIENT_ID: ""  # Set from Kubernetes secret
-  GOOGLE_CLIENT_SECRET: ""  # Set from Kubernetes secret
-  AUTH_TRUST_HOST: "true"
+ui:
+  env:
+    - name: NODE_ENV
+      value: "development"
+    - name: BACKEND_URL
+      value: "http://support-bot.support-bot-extended:8080"
+    - name: NEXTAUTH_SECRET
+      value: ""
+    - name: NEXTAUTH_URL
+      value: ""
+    - name: AZURE_AD_CLIENT_ID
+      value: ""
+    - name: AZURE_AD_CLIENT_SECRET
+      value: ""
+    - name: AZURE_AD_TENANT_ID
+      value: ""
+    - name: GOOGLE_CLIENT_ID
+      value: ""
+    - name: GOOGLE_CLIENT_SECRET
+      value: ""
+    - name: AUTH_TRUST_HOST
+      value: "true"

--- a/ui/p2p/config/functional.yaml
+++ b/ui/p2p/config/functional.yaml
@@ -1,32 +1,11 @@
 ---
-envVarsMap:
-  NODE_ENV: test  # Enable test mode bypass for authentication middleware
-  BACKEND_URL: http://mock-backend:8080
-  DATABASE_URL: postgresql://mock-db:5432/testdb
-  NEXTAUTH_SECRET: test-secret-for-functional-tests-only
-  NEXTAUTH_URL: http://support-bot-ui:3000
-  # OAuth credentials not needed for functional tests (mocked authentication)
-  AZURE_AD_CLIENT_ID: ""
-  AZURE_AD_CLIENT_SECRET: ""
-  AZURE_AD_TENANT_ID: ""
-  GOOGLE_CLIENT_ID: ""
-  GOOGLE_CLIENT_SECRET: ""
-  ENABLE_TEST_AUTH_BYPASS: "true"
-
-resources:
-  requests:
-    cpu: 500m
-    memory: 512Mi
-  limits:
-    memory: 1Gi
-
-livenessProbe:
-  failureThreshold: 3
-  periodSeconds: 10
-  timeoutSeconds: 3
-  initialDelaySeconds: 10
-readinessProbe:
-  failureThreshold: 3
-  periodSeconds: 10
-  timeoutSeconds: 3
-  initialDelaySeconds: 10
+ui:
+  env:
+    - name: NODE_ENV
+      value: "test"
+    - name: BACKEND_URL
+      value: "http://mock-backend:8080"
+    - name: NEXTAUTH_SECRET
+      value: "test-secret-for-functional-tests-only"
+    - name: NEXTAUTH_URL
+      value: "http://support-bot-ui:3000"

--- a/ui/p2p/config/integration.yaml
+++ b/ui/p2p/config/integration.yaml
@@ -1,12 +1,19 @@
 ---
-# Backend URLs for integration tests
-envVarsMap:
-  BACKEND_URL: http://mock-backend:8080
-  DATABASE_URL: postgresql://mock-db:5432/testdb
-  NEXTAUTH_SECRET: ""  # Set from Kubernetes secret
-  NEXTAUTH_URL: ""  # Set from ingress configuration via --set flag in Makefile
-  AZURE_AD_CLIENT_ID: ""  # Set from Kubernetes secret
-  AZURE_AD_CLIENT_SECRET: ""  # Set from Kubernetes secret
-  AZURE_AD_TENANT_ID: ""  # Set from Kubernetes secret
-  GOOGLE_CLIENT_ID: ""  # Set from Kubernetes secret
-  GOOGLE_CLIENT_SECRET: ""  # Set from Kubernetes secret
+ui:
+  env:
+    - name: BACKEND_URL
+      value: "http://mock-backend:8080"
+    - name: NEXTAUTH_SECRET
+      value: ""
+    - name: NEXTAUTH_URL
+      value: ""
+    - name: AZURE_AD_CLIENT_ID
+      value: ""
+    - name: AZURE_AD_CLIENT_SECRET
+      value: ""
+    - name: AZURE_AD_TENANT_ID
+      value: ""
+    - name: GOOGLE_CLIENT_ID
+      value: ""
+    - name: GOOGLE_CLIENT_SECRET
+      value: ""

--- a/ui/p2p/config/nft.yaml
+++ b/ui/p2p/config/nft.yaml
@@ -1,14 +1,28 @@
 ---
-# Increase resources for NFT load testing
-replicaCount: 2
+ui:
+  replicaCount: 2
 
-resources:
-  requests:
-    cpu: 1500m
-    memory: 2000Mi
-  limits:
-    cpu: 1500m
-    memory: 2000Mi
+  resources:
+    requests:
+      cpu: 1500m
+      memory: 2000Mi
+    limits:
+      cpu: 1500m
+      memory: 2000Mi
+
+  env:
+    - name: NODE_ENV
+      value: "test"
+    - name: VUS
+      value: "100"
+    - name: REQ_PER_SECOND
+      value: "300"
+    - name: BACKEND_URL
+      value: "http://mock-backend:8080"
+    - name: NEXTAUTH_SECRET
+      value: "test-secret-for-nft-tests-only"
+    - name: NEXTAUTH_URL
+      value: "http://support-bot-ui:3000"
 
 # Configure k6 test pod resources (injector)
 tests:
@@ -20,19 +34,3 @@ tests:
       limits:
         cpu: 1000m
         memory: 3Gi
-
-# Override NFT defaults and provide backend URLs
-envVarsMap:
-  VUS: "100"
-  REQ_PER_SECOND: "300"
-  BACKEND_URL: http://mock-backend:8080
-  DATABASE_URL: postgresql://mock-db:5432/testdb
-  NEXTAUTH_SECRET: test-secret-for-nft-tests-only
-  NEXTAUTH_URL: http://support-bot-ui:3000
-  # OAuth credentials not needed for NFT tests (mocked authentication)
-  AZURE_AD_CLIENT_ID: ""
-  AZURE_AD_CLIENT_SECRET: ""
-  AZURE_AD_TENANT_ID: ""
-  GOOGLE_CLIENT_ID: ""
-  GOOGLE_CLIENT_SECRET: ""
-  ENABLE_TEST_AUTH_BYPASS: "true"

--- a/ui/p2p/config/prod.yaml
+++ b/ui/p2p/config/prod.yaml
@@ -1,11 +1,17 @@
-wawait---
-envVarsMap:
-  # OAuth Credentials - Set these from Kubernetes secrets in production
-  # These will be injected via --set flags in Makefile
-  NEXTAUTH_SECRET: ""  # Set from Kubernetes secret
-  NEXTAUTH_URL: ""  # Set from ingress configuration via --set flag in Makefile
-  AZURE_AD_CLIENT_ID: ""  # Set from Kubernetes secret
-  AZURE_AD_CLIENT_SECRET: ""  # Set from Kubernetes secret
-  AZURE_AD_TENANT_ID: ""  # Set from Kubernetes secret
-  GOOGLE_CLIENT_ID: ""  # Set from Kubernetes secret
-  GOOGLE_CLIENT_SECRET: ""  # Set from Kubernetes secret
+---
+ui:
+  env:
+    - name: NEXTAUTH_SECRET
+      value: ""
+    - name: NEXTAUTH_URL
+      value: ""
+    - name: AZURE_AD_CLIENT_ID
+      value: ""
+    - name: AZURE_AD_CLIENT_SECRET
+      value: ""
+    - name: AZURE_AD_TENANT_ID
+      value: ""
+    - name: GOOGLE_CLIENT_ID
+      value: ""
+    - name: GOOGLE_CLIENT_SECRET
+      value: ""


### PR DESCRIPTION
### Summary                                                                                                                                                                                                              
                                                                                                                                                                                                                        
Combine API and UI into a single Helm chart for unified deployments.                                                                                                                                                    
                                                                                                                                                                                                                          
### What changed                                                                                                                                                                                                         
- Added UI templates to helm chart
- UI disabled by default `ui.enabled: false` for backward compatibility
- Updated `deploy-ui-%` targets to use the combined chart