### PR TITLE
Persist URL Filters

### DIFF
--- a/ui/src/app/__tests__/page.test.tsx
+++ b/ui/src/app/__tests__/page.test.tsx
@@ -5,8 +5,13 @@ import { useAuth } from '../../hooks/useAuth'
 import { useTeamFilter } from '../../contexts/TeamFilterContext'
 import { useKnowledgeGapsEnabled } from '../../lib/hooks'
 
+let mockSearchParamsValue = ''
+const mockReplace = jest.fn()
+
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(mockSearchParamsValue),
 }))
 
 jest.mock('../../hooks/useAuth', () => ({
@@ -67,16 +72,18 @@ jest.mock('next/image', () => ({
 
 const mockRouter = {
   push: jest.fn(),
+  replace: mockReplace,
 }
 
-const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
-const mockUseTeamFilter = useTeamFilter as jest.MockedFunction<typeof useTeamFilter>
-const mockUseKnowledgeGapsEnabled = useKnowledgeGapsEnabled as jest.MockedFunction<typeof useKnowledgeGapsEnabled>
+const mockUseAuth = useAuth as unknown as jest.Mock
+const mockUseTeamFilter = useTeamFilter as unknown as jest.Mock
+const mockUseKnowledgeGapsEnabled = useKnowledgeGapsEnabled as unknown as jest.Mock
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 
 describe('Dashboard - Support Area Summary visibility', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSearchParamsValue = ''
     mockUseRouter.mockReturnValue(mockRouter as any)
     mockUseTeamFilter.mockReturnValue({
       hasFullAccess: true,
@@ -410,6 +417,119 @@ describe('Dashboard - Support Area Summary visibility', () => {
         expect(screen.getByText('Tickets')).toBeInTheDocument()
         expect(screen.getByText('Escalations')).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('URL tab deep-linking', () => {
+    beforeEach(() => {
+      mockUseKnowledgeGapsEnabled.mockReturnValue({
+        data: true,
+        isLoading: false,
+        error: null,
+      } as any)
+      mockUseAuth.mockReturnValue({
+        user: {
+          name: 'User',
+          email: 'user@example.com',
+          roles: ['supportEngineer'],
+          teams: [],
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        logout: jest.fn(),
+        refreshUser: jest.fn(),
+        isLeadership: false,
+        isEscalationTeam: false,
+        isSupportEngineer: true,
+        actualEscalationTeams: [],
+      })
+      mockUseTeamFilter.mockReturnValue({
+        hasFullAccess: true,
+        selectedTeam: null,
+        setSelectedTeam: jest.fn(),
+        effectiveTeams: [],
+        allTeams: [],
+        initialized: true,
+      })
+    })
+
+    it('opens tickets tab when tab=tickets is present', async () => {
+      mockSearchParamsValue = 'tab=tickets&ticketDate=lastWeek'
+      render(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Tickets Page')).toBeInTheDocument()
+      })
+    })
+
+    it('uses home tab for invalid tab values', async () => {
+      mockSearchParamsValue = 'tab=not-a-real-tab'
+      render(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Stats Page')).toBeInTheDocument()
+      })
+    })
+
+    it('writes tab query param when switching tabs and preserves existing params', async () => {
+      mockSearchParamsValue = 'foo=bar'
+      render(<Dashboard />)
+
+      const ticketsButton = await screen.findByRole('button', { name: 'Tickets' })
+      ticketsButton.click()
+
+      expect(mockReplace).toHaveBeenCalled()
+      const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
+      expect(url).toContain('/?')
+      expect(url).toContain('foo=bar')
+      expect(url).toContain('tab=tickets')
+    })
+
+    it('drops tickets-only params when switching to a non-tickets tab', async () => {
+      mockSearchParamsValue = 'tab=tickets&ticketDate=lastWeek&ticketStatus=closed&ticketTeam=connected-app&ticketImpact=productionBlocking&foo=bar'
+      render(<Dashboard />)
+
+      const escalationsButton = await screen.findByRole('button', { name: 'Escalations' })
+      escalationsButton.click()
+
+      expect(mockReplace).toHaveBeenCalled()
+      const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
+      expect(url).toContain('tab=escalations')
+      expect(url).toContain('foo=bar')
+      expect(url).not.toContain('ticketDate=')
+      expect(url).not.toContain('ticketStatus=')
+      expect(url).not.toContain('ticketTeam=')
+      expect(url).not.toContain('ticketImpact=')
+    })
+
+    it('drops section param when switching away from SLA tab', async () => {
+      mockSearchParamsValue = 'tab=sla&section=response&foo=bar'
+      render(<Dashboard />)
+
+      const escalationsButton = await screen.findByRole('button', { name: 'Escalations' })
+      escalationsButton.click()
+
+      expect(mockReplace).toHaveBeenCalled()
+      const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
+      expect(url).toContain('tab=escalations')
+      expect(url).toContain('foo=bar')
+      expect(url).not.toContain('section=')
+    })
+
+    it('drops escalations-only params when switching to a non-escalations tab', async () => {
+      mockSearchParamsValue = 'tab=escalations&escDate=lastWeek&escStatus=resolved&escTeam=Tenant%20Alpha&foo=bar'
+      render(<Dashboard />)
+
+      const ticketsButton = await screen.findByRole('button', { name: 'Tickets' })
+      ticketsButton.click()
+
+      expect(mockReplace).toHaveBeenCalled()
+      const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
+      expect(url).toContain('tab=tickets')
+      expect(url).toContain('foo=bar')
+      expect(url).not.toContain('escDate=')
+      expect(url).not.toContain('escStatus=')
+      expect(url).not.toContain('escTeam=')
     })
   })
 })

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import React, { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import React, { useEffect, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import StatsPage from '@/components/stats/stats'
 import TicketsPage from '@/components/tickets/tickets'
 import EscalationsPage from '@/components/escalations/escalations'
@@ -62,6 +62,34 @@ const supportSubTabs: SupportTab[] = [
     }
 ]
 
+const TICKETS_URL_PARAM_KEYS = [
+    'ticketDate',
+    'ticketFrom',
+    'ticketTo',
+    'ticketStatus',
+    'ticketTeam',
+    'ticketImpact',
+    'ticketTag',
+    'ticketEscalated',
+    'ticketEscalatedTo',
+    'ticketSortBy',
+    'ticketSortDir',
+    'ticketPage',
+]
+
+const ESCALATIONS_URL_PARAM_KEYS = [
+    'escDate',
+    'escFrom',
+    'escTo',
+    'escStatus',
+    'escTeam',
+    'escImpact',
+    'escTag',
+    'escSortBy',
+    'escSortDir',
+    'escPage',
+]
+
 // 2. Derive TabKey types
 type SupportSubTabKey = typeof supportSubTabs[number]['key']
 
@@ -70,9 +98,12 @@ export default function Dashboard() {
     const { hasFullAccess } = useTeamFilter()
     const { data: isKnowledgeGapsEnabled } = useKnowledgeGapsEnabled()
     const router = useRouter()
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
 
     // State
     const [activeSupportSubTab, setActiveSupportSubTab] = useState<SupportSubTabKey>('home')
+    const [didHydrateTabFromUrl, setDidHydrateTabFromUrl] = useState(false)
 
     // Sidebar state
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
@@ -116,11 +147,43 @@ export default function Dashboard() {
 
     // Show all tabs based on access level and feature flags
     const supportTabs = supportSubTabs.filter(isTabVisible)
+    const searchParamTab = searchParams.get('tab')
 
-    // Compute effective tab - fallback to 'home' if current tab is not in available tabs
+    useEffect(() => {
+        if (didHydrateTabFromUrl) return
+        if (!searchParamTab) {
+            setDidHydrateTabFromUrl(true)
+            return
+        }
+        const requestedTab = supportTabs.find(tab => tab.key === searchParamTab)
+        if (requestedTab && activeSupportSubTab !== requestedTab.key) {
+            setActiveSupportSubTab(requestedTab.key)
+        }
+        setDidHydrateTabFromUrl(true)
+    }, [searchParamTab, supportTabs, activeSupportSubTab, didHydrateTabFromUrl])
+
+    // Compute effective tab - default to 'home' if current tab is not available
     const effectiveTab = supportTabs.some(tab => tab.key === activeSupportSubTab)
         ? activeSupportSubTab
         : 'home'
+
+    const handleSupportTabChange = (tabKey: SupportSubTabKey) => {
+        setActiveSupportSubTab(tabKey)
+        const params = new URLSearchParams(searchParams.toString())
+        params.set('tab', tabKey)
+        if (tabKey !== 'tickets') {
+            TICKETS_URL_PARAM_KEYS.forEach(key => params.delete(key))
+        }
+        if (tabKey !== 'escalations') {
+            ESCALATIONS_URL_PARAM_KEYS.forEach(key => params.delete(key))
+        }
+        if (tabKey !== 'sla') {
+            params.delete('section')
+        }
+        const nextQuery = params.toString()
+        const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname
+        router.replace(nextUrl, { scroll: false })
+    }
 
 
     // Show loading state while session is being fetched
@@ -199,7 +262,7 @@ export default function Dashboard() {
                                         return (
                                             <button
                                                 key={tab.key}
-                                                onClick={() => setActiveSupportSubTab(tab.key)}
+                                                onClick={() => handleSupportTabChange(tab.key)}
                                                 className={`w-full flex items-center gap-3 px-8 py-2.5 text-sm hover:bg-gray-700 transition-colors ${isActive ? 'bg-blue-600 text-white' : 'text-gray-300'
                                                     }`}
                                             >

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { Suspense, useEffect, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import StatsPage from '@/components/stats/stats'
 import TicketsPage from '@/components/tickets/tickets'
@@ -93,7 +93,7 @@ const ESCALATIONS_URL_PARAM_KEYS = [
 // 2. Derive TabKey types
 type SupportSubTabKey = typeof supportSubTabs[number]['key']
 
-export default function Dashboard() {
+function DashboardContent() {
     const { user, isLoading, isAuthenticated, logout } = useAuth()
     const { hasFullAccess } = useTeamFilter()
     const { data: isKnowledgeGapsEnabled } = useKnowledgeGapsEnabled()
@@ -360,5 +360,22 @@ export default function Dashboard() {
                 </div>
             </div>
         </div>
+    )
+}
+
+export default function Dashboard() {
+    return (
+        <Suspense
+            fallback={
+                <div className="flex items-center justify-center h-screen bg-gray-50">
+                    <div className="text-center">
+                        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mb-4"></div>
+                        <p className="text-gray-600">Loading...</p>
+                    </div>
+                </div>
+            }
+        >
+            <DashboardContent />
+        </Suspense>
     )
 }

--- a/ui/src/components/dashboards/dashboards.tsx
+++ b/ui/src/components/dashboards/dashboards.tsx
@@ -54,6 +54,7 @@ export default function DashboardsPage() {
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search)
+        params.set('tab', 'sla')
         params.set('section', activeSection)
         const newUrl = `${window.location.pathname}?${params.toString()}`
         window.history.replaceState({}, '', newUrl)

--- a/ui/src/components/escalations/__tests__/escalations.test.tsx
+++ b/ui/src/components/escalations/__tests__/escalations.test.tsx
@@ -6,6 +6,15 @@ import * as hooks from '../../../lib/hooks'
 import * as TeamFilterContext from '../../../contexts/TeamFilterContext'
 import * as AuthHook from '../../../hooks/useAuth'
 
+const mockReplace = jest.fn()
+let mockSearchParamsValue = ''
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ replace: mockReplace }),
+    usePathname: () => '/',
+    useSearchParams: () => new URLSearchParams(mockSearchParamsValue),
+}))
+
 jest.mock('../../../lib/hooks')
 jest.mock('../../../contexts/TeamFilterContext')
 jest.mock('../../../hooks/useAuth')
@@ -15,11 +24,11 @@ jest.mock('../EscalatedToMyTeamTable', () => {
     return Mock
 })
 
-const mockUseEscalations = hooks.useEscalations as jest.MockedFunction<typeof hooks.useEscalations>
-const mockUseTenantTeams = hooks.useTenantTeams as jest.MockedFunction<typeof hooks.useTenantTeams>
-const mockUseRegistry = hooks.useRegistry as jest.MockedFunction<typeof hooks.useRegistry>
-const mockUseTeamFilter = TeamFilterContext.useTeamFilter as jest.MockedFunction<typeof TeamFilterContext.useTeamFilter>
-const mockUseAuth = AuthHook.useAuth as jest.MockedFunction<typeof AuthHook.useAuth>
+const mockUseEscalations = hooks.useEscalations as unknown as jest.Mock
+const mockUseTenantTeams = hooks.useTenantTeams as unknown as jest.Mock
+const mockUseRegistry = hooks.useRegistry as unknown as jest.Mock
+const mockUseTeamFilter = TeamFilterContext.useTeamFilter as unknown as jest.Mock
+const mockUseAuth = AuthHook.useAuth as unknown as jest.Mock
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -36,6 +45,8 @@ const daysAgo = (n: number) => {
 describe('EscalationsPage', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockSearchParamsValue = ''
+        mockReplace.mockClear()
 
         mockUseRegistry.mockReturnValue({
             data: { impacts: [], tags: [] },
@@ -826,5 +837,177 @@ describe('EscalationsPage', () => {
 
         expect(screen.queryByTestId('escalations-team-filter')).not.toBeInTheDocument()
         expect(screen.queryByText(/Scope:/i)).not.toBeInTheDocument()
+    })
+
+    describe('URL filter sync', () => {
+        it('hydrates escalation filters from URL query params', () => {
+            mockSearchParamsValue = 'tab=escalations&escDate=custom&escFrom=2024-01-01&escTo=2024-01-31&escStatus=resolved&escTeam=Tenant%20Alpha&escImpact=high&escTag=networking&escSortBy=resolvedAt&escSortDir=asc'
+
+            mockUseTeamFilter.mockReturnValue({
+                selectedTeam: null,
+                setSelectedTeam: jest.fn(),
+                hasFullAccess: true,
+                effectiveTeams: [],
+                allTeams: [],
+                initialized: true
+            })
+
+            mockUseRegistry.mockReturnValue({
+                data: {
+                    impacts: [{ code: 'high', label: 'High' }],
+                    tags: [{ code: 'networking', label: 'Networking' }]
+                },
+                isLoading: false,
+                error: null,
+            } as unknown as ReturnType<typeof hooks.useRegistry>)
+
+            mockUseTenantTeams.mockReturnValue({
+                data: [{ name: 'Tenant Alpha' }],
+                isLoading: false,
+                error: null,
+            } as unknown as ReturnType<typeof hooks.useTenantTeams>)
+
+            mockUseEscalations.mockReturnValue({
+                data: {
+                    page: 0,
+                    totalPages: 1,
+                    totalElements: 1,
+                    content: [
+                        {
+                            id: 'esc-1',
+                            ticketId: 'T-1',
+                            escalatingTeam: 'Tenant Alpha',
+                            team: { name: 'Infra' },
+                            impact: 'high',
+                            tags: ['networking'],
+                            openedAt: daysAgo(1),
+                            resolvedAt: daysAgo(0),
+                            hasThread: false,
+                        },
+                    ],
+                },
+                isLoading: false,
+                error: null,
+            } as unknown as ReturnType<typeof hooks.useEscalations>)
+
+            render(<EscalationsPage />, { wrapper: Wrapper })
+
+            expect(screen.getByDisplayValue('Custom Range')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('Resolved')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('Tenant Alpha')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('High')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('Networking')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('2024-01-01')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('2024-01-31')).toBeInTheDocument()
+        })
+
+        it('syncs escalation filter changes back to URL and preserves unrelated params', () => {
+            mockSearchParamsValue = 'foo=bar'
+            render(<EscalationsPage />, { wrapper: Wrapper })
+            mockReplace.mockClear()
+
+            fireEvent.change(screen.getByTestId('escalations-status-filter'), { target: { value: 'resolved' } })
+
+            expect(mockReplace).toHaveBeenCalled()
+            const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
+            expect(url).toContain('/?')
+            expect(url).toContain('foo=bar')
+            expect(url).toContain('tab=escalations')
+            expect(url).toContain('escStatus=resolved')
+            expect(url).toContain('escDate=lastWeek')
+        })
+
+        it('removes tickets-only params when syncing escalation URL', () => {
+            mockSearchParamsValue = 'tab=escalations&ticketTeam=connected-app&ticketStatus=closed&foo=bar'
+            render(<EscalationsPage />, { wrapper: Wrapper })
+
+            expect(mockReplace).toHaveBeenCalled()
+            const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
+            expect(url).toContain('tab=escalations')
+            expect(url).toContain('foo=bar')
+            expect(url).not.toContain('ticketTeam=')
+            expect(url).not.toContain('ticketStatus=')
+            expect(url).toContain('escDate=lastWeek')
+        })
+
+        it('supports privileged -> non-privileged shared escalation URL views', () => {
+            mockSearchParamsValue = 'tab=escalations&escDate=any&escStatus=ongoing&escTeam=Tenant%20Beta'
+
+            mockUseTeamFilter.mockReturnValue({
+                selectedTeam: 'Escalation Team 2 Test',
+                setSelectedTeam: jest.fn(),
+                hasFullAccess: false,
+                effectiveTeams: ['Escalation Team 2 Test'],
+                allTeams: ['Escalation Team 2 Test'],
+                initialized: true
+            })
+            mockUseAuth.mockReturnValue({
+                user: null,
+                isLoading: false,
+                isAuthenticated: true,
+                isLeadership: false,
+                isEscalationTeam: true,
+                isSupportEngineer: false,
+                actualEscalationTeams: ['Escalation Team 2 Test'],
+                logout: jest.fn()
+            })
+            mockUseEscalations.mockReturnValue({
+                data: {
+                    page: 0,
+                    totalPages: 1,
+                    totalElements: 2,
+                    content: [
+                        { id: 'e1', ticketId: 'T-A', escalatingTeam: 'Tenant Alpha', team: { name: 'Infra' }, impact: null, tags: [], openedAt: daysAgo(1), resolvedAt: null, hasThread: false },
+                        { id: 'e2', ticketId: 'T-B', escalatingTeam: 'Tenant Beta', team: { name: 'Infra' }, impact: null, tags: [], openedAt: daysAgo(1), resolvedAt: null, hasThread: false },
+                    ],
+                },
+                isLoading: false, error: null,
+            } as unknown as ReturnType<typeof hooks.useEscalations>)
+
+            render(<EscalationsPage />, { wrapper: Wrapper })
+
+            expect(screen.getByText('T-B')).toBeInTheDocument()
+            expect(screen.queryByText('T-A')).not.toBeInTheDocument()
+        })
+
+        it('supports non-privileged -> privileged shared escalation URL views', () => {
+            mockSearchParamsValue = 'tab=escalations&escDate=any&escStatus=ongoing&escTeam=Tenant%20Beta'
+
+            mockUseTeamFilter.mockReturnValue({
+                selectedTeam: null,
+                setSelectedTeam: jest.fn(),
+                hasFullAccess: true,
+                effectiveTeams: [],
+                allTeams: [],
+                initialized: true
+            })
+            mockUseAuth.mockReturnValue({
+                user: null,
+                isLoading: false,
+                isAuthenticated: true,
+                isLeadership: true,
+                isEscalationTeam: false,
+                isSupportEngineer: false,
+                actualEscalationTeams: [],
+                logout: jest.fn()
+            })
+            mockUseEscalations.mockReturnValue({
+                data: {
+                    page: 0,
+                    totalPages: 1,
+                    totalElements: 2,
+                    content: [
+                        { id: 'e1', ticketId: 'T-A', escalatingTeam: 'Tenant Alpha', team: { name: 'Infra' }, impact: null, tags: [], openedAt: daysAgo(1), resolvedAt: null, hasThread: false },
+                        { id: 'e2', ticketId: 'T-B', escalatingTeam: 'Tenant Beta', team: { name: 'Infra' }, impact: null, tags: [], openedAt: daysAgo(1), resolvedAt: null, hasThread: false },
+                    ],
+                },
+                isLoading: false, error: null,
+            } as unknown as ReturnType<typeof hooks.useEscalations>)
+
+            render(<EscalationsPage />, { wrapper: Wrapper })
+
+            expect(screen.getByText('T-B')).toBeInTheDocument()
+            expect(screen.queryByText('T-A')).not.toBeInTheDocument()
+        })
     })
 })

--- a/ui/src/components/escalations/escalations.tsx
+++ b/ui/src/components/escalations/escalations.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useEscalations, useRegistry, useTenantTeams } from '@/lib/hooks'
 import { useTeamFilter } from '@/contexts/TeamFilterContext'
 import { useAuth } from '@/hooks/useAuth'
@@ -9,8 +9,60 @@ import EscalatedToMyTeamTable from './EscalatedToMyTeamTable'
 import LoadingSkeleton from '@/components/LoadingSkeleton'
 import { TEAM_SCOPE } from '@/lib/constants'
 import { normalizeTeamKey } from '@/lib/teamUtils'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 type SortColumn = 'ticketId' | 'escalatingTeam' | 'escalatedTo' | 'openedAt' | 'resolvedAt' | 'duration'
+const ESCALATIONS_SORT_COLUMNS = new Set<SortColumn>([
+    'ticketId',
+    'escalatingTeam',
+    'escalatedTo',
+    'openedAt',
+    'resolvedAt',
+    'duration',
+])
+
+const parseDateFilter = (value: string | null): '' | 'lastWeek' | 'last2Weeks' | 'lastMonth' | 'custom' => {
+    if (value === 'any') return ''
+    if (value === 'lastWeek' || value === 'last2Weeks' || value === 'lastMonth' || value === 'custom') {
+        return value
+    }
+    return 'lastWeek'
+}
+
+const parseStatusFilter = (value: string | null): 'all' | 'ongoing' | 'resolved' => {
+    return value === 'ongoing' || value === 'resolved' ? value : 'all'
+}
+
+const parseSortColumn = (value: string | null): SortColumn => {
+    return value && ESCALATIONS_SORT_COLUMNS.has(value as SortColumn)
+        ? value as SortColumn
+        : 'openedAt'
+}
+
+const parseSortDirection = (value: string | null): 'asc' | 'desc' => {
+    return value === 'asc' || value === 'desc' ? value : 'desc'
+}
+
+const parsePage = (value: string | null): number => {
+    if (!value) return 0
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+}
+
+const TICKETS_URL_PARAM_KEYS = [
+    'ticketDate',
+    'ticketFrom',
+    'ticketTo',
+    'ticketStatus',
+    'ticketTeam',
+    'ticketImpact',
+    'ticketTag',
+    'ticketEscalated',
+    'ticketEscalatedTo',
+    'ticketSortBy',
+    'ticketSortDir',
+    'ticketPage',
+]
 
 function SortableHeader({
     col,
@@ -41,20 +93,34 @@ function SortableHeader({
 }
 
 export default function EscalationsPage() {
+    const router = useRouter()
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
     const { data: escalationsData, isLoading: isLoadingEscalations, error: errorEscalations } = useEscalations()
     const { data: tenantTeamsData } = useTenantTeams()
     const { data: registryData } = useRegistry()
     const ALL_TEAMS_FILTER = TEAM_SCOPE.ALL_TEAMS
-    const [selectedTeam, setSelectedTeam] = useState<string>('')
-    const [statusFilter, setStatusFilter] = useState<'all' | 'ongoing' | 'resolved'>('all')
-    const [impactFilter, setImpactFilter] = useState<string>('all')
-    const [tagFilter, setTagFilter] = useState<string>('')
     type DateFilter = '' | 'lastWeek' | 'last2Weeks' | 'lastMonth' | 'custom'
-    const [dateFilter, setDateFilter] = useState<DateFilter>('lastWeek')
-    const [customDateRange, setCustomDateRange] = useState<{ start?: string; end?: string }>({})
-    const [sortColumn, setSortColumn] = useState<SortColumn>('openedAt')
-    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
-    const [pageIndex, setPageIndex] = useState<number>(0)
+    const initialDateFilter = parseDateFilter(searchParams.get('escDate'))
+    const initialCustomDateRange = initialDateFilter === 'custom'
+        ? { start: searchParams.get('escFrom') || '', end: searchParams.get('escTo') || '' }
+        : {}
+    const initialStatusFilter = parseStatusFilter(searchParams.get('escStatus'))
+    const initialTeamFilter = searchParams.get('escTeam') || ''
+    const initialImpactFilter = searchParams.get('escImpact') || 'all'
+    const initialTagFilter = searchParams.get('escTag') || ''
+    const initialSortColumn = parseSortColumn(searchParams.get('escSortBy'))
+    const initialSortDirection = parseSortDirection(searchParams.get('escSortDir'))
+    const initialPage = parsePage(searchParams.get('escPage'))
+    const [selectedTeam, setSelectedTeam] = useState<string>(initialTeamFilter)
+    const [statusFilter, setStatusFilter] = useState<'all' | 'ongoing' | 'resolved'>(initialStatusFilter)
+    const [impactFilter, setImpactFilter] = useState<string>(initialImpactFilter)
+    const [tagFilter, setTagFilter] = useState<string>(initialTagFilter)
+    const [dateFilter, setDateFilter] = useState<DateFilter>(initialDateFilter)
+    const [customDateRange, setCustomDateRange] = useState<{ start?: string; end?: string }>(initialCustomDateRange)
+    const [sortColumn, setSortColumn] = useState<SortColumn>(initialSortColumn)
+    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(initialSortDirection)
+    const [pageIndex, setPageIndex] = useState<number>(initialPage)
     const pageSize = 15
 
     const {
@@ -77,6 +143,49 @@ export default function EscalationsPage() {
         if (selectedTeam !== '') setSelectedTeam('')
         if (pageIndex !== 0) setPageIndex(0)
     }
+
+    useEffect(() => {
+        const params = new URLSearchParams(searchParams.toString())
+        // Escalations URLs should not carry tickets-specific filters.
+        TICKETS_URL_PARAM_KEYS.forEach(key => params.delete(key))
+        params.set('tab', 'escalations')
+        params.set('escDate', dateFilter === '' ? 'any' : dateFilter)
+        if (dateFilter === 'custom') {
+            customDateRange.start ? params.set('escFrom', customDateRange.start) : params.delete('escFrom')
+            customDateRange.end ? params.set('escTo', customDateRange.end) : params.delete('escTo')
+        } else {
+            params.delete('escFrom')
+            params.delete('escTo')
+        }
+        statusFilter !== 'all' ? params.set('escStatus', statusFilter) : params.delete('escStatus')
+        selectedTeam ? params.set('escTeam', selectedTeam) : params.delete('escTeam')
+        impactFilter !== 'all' ? params.set('escImpact', impactFilter) : params.delete('escImpact')
+        tagFilter ? params.set('escTag', tagFilter) : params.delete('escTag')
+        sortColumn !== 'openedAt' ? params.set('escSortBy', sortColumn) : params.delete('escSortBy')
+        sortDirection !== 'desc' ? params.set('escSortDir', sortDirection) : params.delete('escSortDir')
+        pageIndex > 0 ? params.set('escPage', String(pageIndex)) : params.delete('escPage')
+
+        const nextQuery = params.toString()
+        const currentQuery = searchParams.toString()
+        if (nextQuery !== currentQuery) {
+            const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname
+            router.replace(nextUrl, { scroll: false })
+        }
+    }, [
+        pathname,
+        router,
+        searchParams,
+        dateFilter,
+        customDateRange.start,
+        customDateRange.end,
+        statusFilter,
+        selectedTeam,
+        impactFilter,
+        tagFilter,
+        sortColumn,
+        sortDirection,
+        pageIndex,
+    ])
 
     // --- Formatting helpers ---
     const formatDate = (isoString?: string) => isoString ? new Date(isoString).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' }) : '-'

--- a/ui/src/components/tickets/__tests__/tickets.test.tsx
+++ b/ui/src/components/tickets/__tests__/tickets.test.tsx
@@ -4,6 +4,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Tickets from '../tickets';
 import * as hooks from '../../../lib/hooks';
 
+const mockReplace = jest.fn();
+let mockSearchParamsValue = '';
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({
+        replace: mockReplace,
+    }),
+    usePathname: () => '/tickets',
+    useSearchParams: () => new URLSearchParams(mockSearchParamsValue),
+}));
+
 // Mock the hooks
 jest.mock('../../../lib/hooks');
 
@@ -109,6 +120,8 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
 describe('Tickets Component', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockSearchParamsValue = '';
+        mockReplace.mockClear();
         
         // Default mock implementations
         mockUseTeamFilter.mockReturnValue({
@@ -1026,6 +1039,182 @@ describe('Tickets Component', () => {
                 expect(from).toBeDefined();
                 expect(to).toBeDefined();
             }
+        });
+    });
+
+    describe('URL filter sync', () => {
+        it('hydrates filters from URL query params', () => {
+            mockSearchParamsValue = 'ticketDate=custom&ticketFrom=2024-01-01&ticketTo=2024-01-31&ticketStatus=closed&ticketTeam=Team%20B&ticketImpact=high&ticketTag=bug&ticketEscalated=Yes&ticketEscalatedTo=Infra%20Team&ticketSortBy=closedAt&ticketSortDir=asc&ticketPage=1';
+            const mockTickets = getMockPaginatedTickets([
+                { ...createMockTicket('1', 'closed', 'Team B', 'high'), tags: ['bug'], escalations: [{ id: 'esc-1', team: { name: 'Infra Team' } }] },
+            ]);
+
+            mockUseTickets.mockReturnValue({
+                data: mockTickets,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useTickets>);
+            mockUseAllTickets.mockReturnValue({
+                data: mockTickets,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+            render(<Tickets />, { wrapper: Wrapper });
+
+            expect(screen.getByDisplayValue('Custom Range')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('Closed')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('Team B')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('High Impact')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('Bug')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('Yes')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('Infra Team')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('2024-01-01')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('2024-01-31')).toBeInTheDocument();
+        });
+
+        it('uses safe defaults for invalid query params', () => {
+            mockSearchParamsValue = 'ticketDate=invalid&ticketStatus=nope&ticketSortBy=bad&ticketSortDir=sideways&ticketPage=-2';
+            const mockTickets = getMockPaginatedTickets([
+                createMockTicket('1', 'opened', 'Team A', 'high')
+            ]);
+
+            mockUseTickets.mockReturnValue({
+                data: mockTickets,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useTickets>);
+
+            render(<Tickets />, { wrapper: Wrapper });
+
+            expect(screen.getByDisplayValue('Last Week')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('All Status')).toBeInTheDocument();
+            expect(screen.getByText(/Opened At ↓/i)).toBeInTheDocument();
+            expect(screen.getByText(/Page 1 of/i)).toBeInTheDocument();
+        });
+
+        it('syncs filter changes back to URL while preserving unrelated params', () => {
+            mockSearchParamsValue = 'foo=bar';
+            const mockTickets = getMockPaginatedTickets([
+                createMockTicket('1', 'opened', 'Team A', 'high')
+            ]);
+
+            mockUseTickets.mockReturnValue({
+                data: mockTickets,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useTickets>);
+
+            render(<Tickets />, { wrapper: Wrapper });
+            mockReplace.mockClear();
+
+            const statusSelect = screen.getAllByRole('combobox').find(sel =>
+                Array.from((sel as HTMLSelectElement).options).some(o => o.textContent === 'All Status')
+            ) as HTMLSelectElement;
+            fireEvent.change(statusSelect, { target: { value: 'opened' } });
+
+            expect(mockReplace).toHaveBeenCalled();
+            const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1];
+            expect(url).toContain('/tickets?');
+            expect(url).toContain('foo=bar');
+            expect(url).toContain('tab=tickets');
+            expect(url).toContain('ticketStatus=opened');
+            expect(url).toContain('ticketDate=lastWeek');
+            expect(url).not.toContain('status=');
+            expect(url).not.toContain('date=');
+        });
+
+        it('removes escalations-only params when syncing tickets URL', () => {
+            mockSearchParamsValue = 'tab=tickets&escTeam=connected-app&escStatus=resolved&foo=bar';
+            const mockTickets = getMockPaginatedTickets([
+                createMockTicket('1', 'opened', 'Team A', 'high')
+            ]);
+
+            mockUseTickets.mockReturnValue({
+                data: mockTickets,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useTickets>);
+
+            render(<Tickets />, { wrapper: Wrapper });
+
+            expect(mockReplace).toHaveBeenCalled();
+            const [url] = mockReplace.mock.calls[mockReplace.mock.calls.length - 1];
+            expect(url).toContain('tab=tickets');
+            expect(url).toContain('foo=bar');
+            expect(url).not.toContain('escTeam=');
+            expect(url).not.toContain('escStatus=');
+            expect(url).toContain('ticketDate=lastWeek');
+        });
+
+        it('supports privileged -> non-privileged shared ticket URL views', () => {
+            mockSearchParamsValue = 'tab=tickets&ticketDate=any&ticketStatus=opened&ticketTeam=Team%20B';
+            const sharedData = getMockPaginatedTickets([
+                createMockTicket('1', 'opened', 'Team A', 'high'),
+                createMockTicket('2', 'opened', 'Team B', 'high'),
+            ]);
+
+            mockUseTickets.mockReturnValue({
+                data: sharedData,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useTickets>);
+            mockUseAllTickets.mockReturnValue({
+                data: sharedData,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+            // Non-privileged context opening a URL created by privileged user.
+            mockUseTeamFilter.mockReturnValue({
+                selectedTeam: 'Team A',
+                setSelectedTeam: jest.fn(),
+                hasFullAccess: false,
+                effectiveTeams: ['Team A'],
+                allTeams: ['Team A', 'Team B'],
+                initialized: true
+            });
+
+            render(<Tickets />, { wrapper: Wrapper });
+
+            const tableBodyText = screen.getByRole('table').querySelector('tbody')?.textContent || '';
+            expect(tableBodyText).toContain('Team B');
+            expect(tableBodyText).not.toContain('Team A');
+        });
+
+        it('supports non-privileged -> privileged shared ticket URL views', () => {
+            mockSearchParamsValue = 'tab=tickets&ticketDate=any&ticketStatus=opened&ticketTeam=Team%20B';
+            const sharedData = getMockPaginatedTickets([
+                createMockTicket('1', 'opened', 'Team A', 'high'),
+                createMockTicket('2', 'opened', 'Team B', 'high'),
+            ]);
+
+            mockUseTickets.mockReturnValue({
+                data: sharedData,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useTickets>);
+            mockUseAllTickets.mockReturnValue({
+                data: sharedData,
+                isLoading: false,
+                error: null
+            } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+            // Privileged context opening a URL created by non-privileged user.
+            mockUseTeamFilter.mockReturnValue({
+                selectedTeam: null,
+                setSelectedTeam: jest.fn(),
+                hasFullAccess: true,
+                effectiveTeams: [],
+                allTeams: ['Team A', 'Team B'],
+                initialized: true
+            });
+
+            render(<Tickets />, { wrapper: Wrapper });
+
+            const tableBodyText = screen.getByRole('table').querySelector('tbody')?.textContent || '';
+            expect(tableBodyText).toContain('Team B');
+            expect(tableBodyText).not.toContain('Team A');
         });
     });
 });

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -1,18 +1,62 @@
 'use client'
 
-import {useMemo, useState} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import {useAllTickets, useRegistry, useTenantTeams, useTickets, useAssignmentEnabled} from '@/lib/hooks'
 import {useTeamFilter} from '@/contexts/TeamFilterContext'
 import {TicketWithLogs, PaginatedTickets, TicketImpact, TicketTag} from "@/lib/types"
 import LoadingSkeleton from '@/components/LoadingSkeleton'
 import EditTicketModal from './EditTicketModal'
 import {useQueryClient} from '@tanstack/react-query'
+import {usePathname, useRouter, useSearchParams} from 'next/navigation'
 import { TEAM_SCOPE } from '@/lib/constants'
 import { normalizeTeamKey } from '@/lib/teamUtils'
 import { getDateRangeFromFilter } from '@/lib/dateRange'
 
+const TICKET_SORT_COLUMNS = new Set(['openedAt', 'closedAt'])
+
+const parseDateFilter = (value: string | null): '' | 'lastWeek' | 'last2Weeks' | 'lastMonth' | 'custom' => {
+    if (value === 'any') return ''
+    if (value === 'lastWeek' || value === 'last2Weeks' || value === 'lastMonth' || value === 'custom') {
+        return value
+    }
+    return 'lastWeek'
+}
+
+const parseStatusFilter = (value: string | null): string => {
+    return value === 'opened' || value === 'closed' || value === 'stale' ? value : ''
+}
+
+const parseSortColumn = (value: string | null): 'openedAt' | 'closedAt' => {
+    return value && TICKET_SORT_COLUMNS.has(value) ? (value as 'openedAt' | 'closedAt') : 'openedAt'
+}
+
+const parseSortDirection = (value: string | null): 'asc' | 'desc' => {
+    return value === 'asc' || value === 'desc' ? value : 'desc'
+}
+
+const parsePage = (value: string | null): number => {
+    if (!value) return 0
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+}
+
+const ESCALATIONS_URL_PARAM_KEYS = [
+    'escDate',
+    'escFrom',
+    'escTo',
+    'escStatus',
+    'escTeam',
+    'escImpact',
+    'escTag',
+    'escSortBy',
+    'escSortDir',
+    'escPage',
+]
 
 export default function TicketsPage() {
+    const router = useRouter()
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
     const {
         effectiveTeams,
         hasNoTeamScope: contextHasNoTeamScope,
@@ -24,27 +68,46 @@ export default function TicketsPage() {
     const hasNoTeamScope = contextHasNoTeamScope ?? effectiveTeams.includes(TEAM_SCOPE.NO_TEAMS)
     const isViewingAllTeams = contextIsViewingAllTeams ?? (effectiveTeams.length === 0 && !hasNoTeamScope)
     type DateFilter = '' | 'lastWeek' | 'last2Weeks' | 'lastMonth' | 'custom'
+    const initialDateFilter = parseDateFilter(searchParams.get('ticketDate'))
+    const initialCustomDateRange = initialDateFilter === 'custom'
+        ? {
+            start: searchParams.get('ticketFrom') || '',
+            end: searchParams.get('ticketTo') || ''
+        }
+        : {}
+    const initialStatusFilter = parseStatusFilter(searchParams.get('ticketStatus'))
+    const initialTeamFilter = searchParams.get('ticketTeam') || ''
+    const initialImpactFilter = searchParams.get('ticketImpact') || ''
+    const initialTagFilter = searchParams.get('ticketTag') || ''
+    const initialEscalatedValue = searchParams.get('ticketEscalated')
+    const initialEscalatedFilter = initialEscalatedValue === 'Yes' || initialEscalatedValue === 'No'
+        ? initialEscalatedValue || ''
+        : ''
+    const initialEscalatedToFilter = searchParams.get('ticketEscalatedTo') || ''
+    const initialSortColumn = parseSortColumn(searchParams.get('ticketSortBy'))
+    const initialSortDirection = parseSortDirection(searchParams.get('ticketSortDir'))
+    const initialPage = parsePage(searchParams.get('ticketPage'))
 
     // Selected ticket
     const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null)
     const [isModalOpen, setIsModalOpen] = useState(false)
 
     // Filters
-    const [dateFilter, setDateFilter] = useState<DateFilter>('lastWeek')
-    const [customDateRange, setCustomDateRange] = useState<{ start?: string; end?: string }>({})
-    const [statusFilter, setStatusFilter] = useState('')
+    const [dateFilter, setDateFilter] = useState<DateFilter>(initialDateFilter)
+    const [customDateRange, setCustomDateRange] = useState<{ start?: string; end?: string }>(initialCustomDateRange)
+    const [statusFilter, setStatusFilter] = useState(initialStatusFilter)
     const ALL_TEAMS_FILTER = TEAM_SCOPE.ALL_TEAMS
-    const [teamFilter, setTeamFilter] = useState('')
-    const [impactFilter, setImpactFilter] = useState('')
-    const [tagFilter, setTagFilter] = useState('')
-    const [escalatedFilter, setEscalatedFilter] = useState('')
-    const [escalatedToFilter, setEscalatedToFilter] = useState('')
+    const [teamFilter, setTeamFilter] = useState(initialTeamFilter)
+    const [impactFilter, setImpactFilter] = useState(initialImpactFilter)
+    const [tagFilter, setTagFilter] = useState(initialTagFilter)
+    const [escalatedFilter, setEscalatedFilter] = useState(initialEscalatedFilter)
+    const [escalatedToFilter, setEscalatedToFilter] = useState(initialEscalatedToFilter)
     type SortColumn = 'openedAt' | 'closedAt'
-    const [sortColumn, setSortColumn] = useState<SortColumn>('openedAt')
-    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
+    const [sortColumn, setSortColumn] = useState<SortColumn>(initialSortColumn)
+    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(initialSortDirection)
 
     // Pagination
-    const [currentPage, setCurrentPage] = useState(0)
+    const [currentPage, setCurrentPage] = useState(initialPage)
     const pageSize = 15
 
     const dateRange = useMemo(
@@ -116,7 +179,7 @@ export default function TicketsPage() {
     }
 
     // Build team options from both registry list and the data we actually received.
-    // This prevents missing teams (e.g., escalation/legacy teams) from showing 0 results when filtered.
+    // This prevents missing teams (e.g., escalation or historic teams) from showing 0 results when filtered.
     const ticketsDataTyped = ticketsData as PaginatedTickets | undefined
     const ticketsContent = useMemo(
         () => (ticketsDataTyped?.content as TicketWithLogs[] | undefined) ?? [],
@@ -223,6 +286,54 @@ export default function TicketsPage() {
         if (teamFilter !== '') setTeamFilter('')
         if (currentPage !== 0) setCurrentPage(0)
     }
+
+    // Keep filter and pagination state in URL to support sharable views.
+    useEffect(() => {
+        const params = new URLSearchParams(searchParams.toString())
+        // Tickets URLs should not carry escalations-specific filters.
+        ESCALATIONS_URL_PARAM_KEYS.forEach(key => params.delete(key))
+        params.set('tab', 'tickets')
+        params.set('ticketDate', dateFilter === '' ? 'any' : dateFilter)
+        if (dateFilter === 'custom') {
+            customDateRange.start ? params.set('ticketFrom', customDateRange.start) : params.delete('ticketFrom')
+            customDateRange.end ? params.set('ticketTo', customDateRange.end) : params.delete('ticketTo')
+        } else {
+            params.delete('ticketFrom')
+            params.delete('ticketTo')
+        }
+        statusFilter ? params.set('ticketStatus', statusFilter) : params.delete('ticketStatus')
+        teamFilter ? params.set('ticketTeam', teamFilter) : params.delete('ticketTeam')
+        impactFilter ? params.set('ticketImpact', impactFilter) : params.delete('ticketImpact')
+        tagFilter ? params.set('ticketTag', tagFilter) : params.delete('ticketTag')
+        escalatedFilter ? params.set('ticketEscalated', escalatedFilter) : params.delete('ticketEscalated')
+        escalatedToFilter ? params.set('ticketEscalatedTo', escalatedToFilter) : params.delete('ticketEscalatedTo')
+        sortColumn !== 'openedAt' ? params.set('ticketSortBy', sortColumn) : params.delete('ticketSortBy')
+        sortDirection !== 'desc' ? params.set('ticketSortDir', sortDirection) : params.delete('ticketSortDir')
+        currentPage > 0 ? params.set('ticketPage', String(currentPage)) : params.delete('ticketPage')
+
+        const nextQuery = params.toString()
+        const currentQuery = searchParams.toString()
+        if (nextQuery !== currentQuery) {
+            const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname
+            router.replace(nextUrl, { scroll: false })
+        }
+    }, [
+        pathname,
+        router,
+        searchParams,
+        dateFilter,
+        customDateRange.start,
+        customDateRange.end,
+        statusFilter,
+        teamFilter,
+        impactFilter,
+        tagFilter,
+        escalatedFilter,
+        escalatedToFilter,
+        sortColumn,
+        sortDirection,
+        currentPage,
+    ])
 
     // Server pagination for all-teams without client filters; otherwise client-side pagination.
     const paginatedTickets = useMemo(() => {


### PR DESCRIPTION
This PR:

* Implemented strict URL-synced, shareable filters for Support views with clear query namespaces and tab-safe cleanup.
* Tickets now uses only ticket* params and hydrates/writes URL state canonically.
* Escalations continues using esc* params, with matching canonical sync.
* Switching tabs now removes only out-of-scope view params (ticket* / esc* / section) to prevent additive/malformed URLs.
* Added regression tests for hydration, canonical writes, and bidirectional cross-tab param cleanup.