### PR TITLE
fix(ui): increase Support button wait timeout to 15s in tests

### DIFF
--- a/ui/p2p/tests/functional/tests/steps/dashboards.step.ts
+++ b/ui/p2p/tests/functional/tests/steps/dashboards.step.ts
@@ -131,7 +131,7 @@ Given("User navigates to the dashboards page", async function (this: CustomWorld
   });
 
   const supportButton = this.page.getByRole('button', { name: /Support/i }).first();
-  await expect(supportButton).toBeVisible({ timeout: 5000 });
+  await expect(supportButton).toBeVisible({ timeout: 15000 });
 
   const slaDashboardButton = this.page.getByRole('button', { name: /SLA Dashboard/i }).first();
   await expect(slaDashboardButton).toBeVisible({ timeout: 5000 });

--- a/ui/p2p/tests/functional/tests/steps/escalations.step.ts
+++ b/ui/p2p/tests/functional/tests/steps/escalations.step.ts
@@ -297,7 +297,7 @@ When('user logs in', async function (this: CustomWorld) {
     // Navigate and wait for minimal load; avoid long waits that can hang
     await this.page.goto(BASE_URL, { waitUntil: 'domcontentloaded', timeout: 10000 });
     
-    await this.page.getByRole('button', { name: /Support/i }).first().waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.getByRole('button', { name: /Support/i }).first().waitFor({ state: 'visible', timeout: 15000 });
 });
 
 When('user logs in and selects {string} from dropdown', async function (this: CustomWorld, teamName: string) {

--- a/ui/p2p/tests/functional/tests/steps/tickets.step.ts
+++ b/ui/p2p/tests/functional/tests/steps/tickets.step.ts
@@ -248,7 +248,7 @@ When("User navigates to the tickets page", async function (this: CustomWorld) {
     });
     
     // Wait for sidebar to be visible - Support section should be expanded by default
-    await this.page.getByRole('button', { name: /Support/i }).first().waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.getByRole('button', { name: /Support/i }).first().waitFor({ state: 'visible', timeout: 15000 });
     
     // Click on Tickets navigation in sidebar (it's a button)
     const ticketsNav = this.page.getByRole('button', { name: /^Tickets$/i });


### PR DESCRIPTION
 ## Changes 
- Increase `Support` sidebar button wait timeout from 5s to 15s in functional test steps (dashboards, tickets,           
  escalations)                                                                                                             
- Fixes intermittent `BackoffLimitExceeded` failures in CI where the UI takes longer to render in the functional test    
  namespace 
  
**NOTE:** Later on we should look at optimising these visual components load time. This is already planned. 