### PR TITLE
Use last message timestamp on thread closure

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketProcessingService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketProcessingService.java
@@ -263,13 +263,14 @@ public class TicketProcessingService {
             }
         }
 
+        boolean isClosing = submission.status() == TicketStatus.closed;
         Ticket updatedTicket = repository.updateTicket(ticket.toBuilder()
                 .status(submission.status())
                 .team(submission.authorsTeam())
                 .tags(submission.tags())
                 .impact(submission.impact())
                 .assignedTo(submission.assignedTo() != null ? SlackId.user(submission.assignedTo()) : null)
-                .lastInteractedAt(Instant.now())
+                .lastInteractedAt(isClosing ? ticket.lastInteractedAt() : Instant.now())
                 .build());
 
         log.atInfo()
@@ -312,7 +313,6 @@ public class TicketProcessingService {
                 .status(TicketStatus.closed)
                 .tags(tags)
                 .impact(impact)
-                .lastInteractedAt(Instant.now())
                 .build());
         onStatusUpdate(updated);
         log.atInfo()
@@ -391,7 +391,8 @@ public class TicketProcessingService {
     }
 
     @NonNull private Ticket onStatusUpdate(Ticket ticket) {
-        Ticket updatedTicket = repository.insertStatusLog(ticket, Instant.now());
+        Instant statusLogTime = ticket.status() == TicketStatus.closed ? ticket.lastInteractedAt() : Instant.now();
+        Ticket updatedTicket = repository.insertStatusLog(ticket, statusLogTime);
         log.atInfo()
                 .addKeyValue("ticketId", checkNotNull(updatedTicket.id()).id())
                 .log("Ticket status changed");

--- a/api/service/src/test/java/com/coreeng/supportbot/TicketProcessingServiceTests.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/TicketProcessingServiceTests.java
@@ -30,6 +30,7 @@ import com.coreeng.supportbot.ticket.TicketSubmission;
 import com.coreeng.supportbot.ticket.TicketTeam;
 import com.coreeng.supportbot.ticket.slack.TicketSlackService;
 import com.google.common.collect.ImmutableList;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
@@ -629,6 +630,61 @@ public class TicketProcessingServiceTests {
         StalenessTagTarget target = stalenessTagTargetCaptor.getValue();
         assertInstanceOf(StalenessTagTarget.Squad.class, target);
         assertEquals(SUPPORT_GROUP_ID, ((StalenessTagTarget.Squad) target).groupId());
+    }
+
+    @Test
+    public void shouldUseLastThreadMessageTimeAsClosedAtViaCloseForPrResolution() {
+        // given — ticket exists with a known last-message time
+        Ticket ticket = createTrackedTicket();
+        TicketId ticketId = requireNonNull(ticket.id());
+
+        Instant lastMessageTime = Instant.parse("2024-01-15T10:00:00Z");
+        ticketRepository.touchTicketById(ticketId, lastMessageTime);
+
+        // when
+        ticketProcessingService.closeForPrResolution(ticketId, ImmutableList.of("pr-review"), "low");
+
+        // then — the closed status log entry uses the last thread message time
+        Ticket closed = ticketRepository.findTicketById(ticketId);
+        assertNotNull(closed);
+        Instant closedAt = closed.statusLog().stream()
+                .filter(l -> l.status() == TicketStatus.closed)
+                .findFirst()
+                .map(Ticket.StatusLog::date)
+                .orElseThrow(() -> new AssertionError("No closed status log entry found"));
+        assertEquals(lastMessageTime, closedAt, "Closed-at must equal the last thread message time");
+    }
+
+    @Test
+    public void shouldUseLastThreadMessageTimeAsClosedAtViaSubmit() {
+        // given — ticket exists with a known last-message time
+        Ticket ticket = createTrackedTicket();
+        TicketId ticketId = requireNonNull(ticket.id());
+
+        Instant lastMessageTime = Instant.parse("2024-03-20T14:30:00Z");
+        ticketRepository.touchTicketById(ticketId, lastMessageTime);
+
+        TicketSubmission closeSubmission = TicketSubmission.builder()
+                .ticketId(ticketId)
+                .status(TicketStatus.closed)
+                .authorsTeam(new TicketTeam.KnownTeam("platform"))
+                .tags(ImmutableList.of("answered"))
+                .impact("low")
+                .confirmed(true)
+                .build();
+
+        // when
+        ticketProcessingService.submit(closeSubmission);
+
+        // then — the closed status log entry uses the last thread message time
+        Ticket closed = ticketRepository.findTicketById(ticketId);
+        assertNotNull(closed);
+        Instant closedAt = closed.statusLog().stream()
+                .filter(l -> l.status() == TicketStatus.closed)
+                .findFirst()
+                .map(Ticket.StatusLog::date)
+                .orElseThrow(() -> new AssertionError("No closed status log entry found"));
+        assertEquals(lastMessageTime, closedAt, "Closed-at must equal the last thread message time");
     }
 
     private TicketProcessingService serviceWithPrDetection() {


### PR DESCRIPTION
Required by https://cecg-force.atlassian.net/browse/PT-242

Ticket's lastInteractedAt is always updated to the Slack message time every time a thread reply is posted .By not overwriting it during close, it carries the last-message time through to insertStatusLog, which writes  it as the ticket_log.date for the closed event.