### PR TITLE
Handle no-SLA PRs

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/config/PrTrackingProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/config/PrTrackingProps.java
@@ -49,6 +49,7 @@ public record PrTrackingProps(
                                 normalizeRepositoryName(repository.name()),
                                 repository.owningTeam(),
                                 repository.githubTeamSlug(),
+                                repository.paths(),
                                 repository.sla()))
                         .toList();
         this.slaDiscovery = slaDiscovery == null ? new SlaDiscovery(null) : slaDiscovery;
@@ -93,28 +94,40 @@ public record PrTrackingProps(
             if (isBlank(repository.owningTeam())) {
                 throw new IllegalArgumentException("pr-review-tracking.repositories[].owning-team must not be blank");
             }
+
             if (repository.sla() == null) {
-                throw new IllegalArgumentException("pr-review-tracking.repositories[].sla must not be null");
-            }
-            Duration defaultSla = repository.sla().defaultSla();
-            boolean hasFile = !isBlank(repository.sla().file());
-            if (!hasFile && defaultSla == null) {
-                throw new IllegalArgumentException(
-                        "pr-review-tracking.repositories[].sla.default must be set when sla.file is not configured");
-            }
-            if (defaultSla != null && (defaultSla.isZero() || defaultSla.isNegative())) {
-                throw new IllegalArgumentException(
-                        "pr-review-tracking.repositories[].sla.default must be a positive duration");
-            }
-            List<SlaOverride> overrides = repository.sla().overrides();
-            for (SlaOverride override : overrides != null ? overrides : List.<SlaOverride>of()) {
-                if (isBlank(override.path())) {
+                // No-SLA repository: paths are required for selective tracking
+                if (repository.paths().isEmpty()) {
                     throw new IllegalArgumentException(
-                            "pr-review-tracking.repositories[].sla.overrides[].path must not be blank");
+                            "pr-review-tracking.repositories[].paths must not be empty when sla is not configured");
                 }
-                if (override.sla().isZero() || override.sla().isNegative()) {
+                for (String path : repository.paths()) {
+                    if (isBlank(path)) {
+                        throw new IllegalArgumentException(
+                                "pr-review-tracking.repositories[].paths[] must not be blank");
+                    }
+                }
+            } else {
+                Duration defaultSla = repository.sla().defaultSla();
+                boolean hasFile = !isBlank(repository.sla().file());
+                if (!hasFile && defaultSla == null) {
                     throw new IllegalArgumentException(
-                            "pr-review-tracking.repositories[].sla.overrides[].sla must be a positive duration");
+                            "pr-review-tracking.repositories[].sla.default must be set when sla.file is not configured");
+                }
+                if (defaultSla != null && (defaultSla.isZero() || defaultSla.isNegative())) {
+                    throw new IllegalArgumentException(
+                            "pr-review-tracking.repositories[].sla.default must be a positive duration");
+                }
+                List<SlaOverride> overrides = repository.sla().overrides();
+                for (SlaOverride override : overrides != null ? overrides : List.<SlaOverride>of()) {
+                    if (isBlank(override.path())) {
+                        throw new IllegalArgumentException(
+                                "pr-review-tracking.repositories[].sla.overrides[].path must not be blank");
+                    }
+                    if (override.sla().isZero() || override.sla().isNegative()) {
+                        throw new IllegalArgumentException(
+                                "pr-review-tracking.repositories[].sla.overrides[].sla must be a positive duration");
+                    }
                 }
             }
 
@@ -164,14 +177,23 @@ public record PrTrackingProps(
     }
 
     public record Repository(
-            String name, String owningTeam, @Nullable String githubTeamSlug, Sla sla) {
+            String name,
+            String owningTeam,
+            @Nullable String githubTeamSlug,
+            List<String> paths,
+            @Nullable Sla sla) {
         public Repository {
             requireNonNull(name, "name must not be null");
             requireNonNull(owningTeam, "owningTeam must not be null");
             if (githubTeamSlug != null && githubTeamSlug.isBlank()) {
                 throw new IllegalArgumentException("githubTeamSlug must not be blank when provided");
             }
-            requireNonNull(sla, "sla must not be null");
+            paths = paths == null ? List.of() : List.copyOf(paths);
+        }
+
+        /** Returns true when this repository has no SLA configured (no-SLA tracking mode). */
+        public boolean hasNoSla() {
+            return sla == null;
         }
     }
 

--- a/api/service/src/main/java/com/coreeng/supportbot/config/PrTrackingProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/config/PrTrackingProps.java
@@ -96,7 +96,7 @@ public record PrTrackingProps(
             }
 
             if (repository.sla() == null) {
-                // No-SLA repository: paths are required for selective tracking
+                // No-SLA repository: paths are required to filter which PRs are tracked (by changed-file matching)
                 if (repository.paths().isEmpty()) {
                     throw new IllegalArgumentException(
                             "pr-review-tracking.repositories[].paths must not be empty when sla is not configured");

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/NewPrTracking.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/NewPrTracking.java
@@ -3,19 +3,19 @@ package com.coreeng.supportbot.prtracking;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Instant;
+import org.jspecify.annotations.Nullable;
 
 public record NewPrTracking(
         long ticketId,
         String githubRepo,
         int prNumber,
         Instant prCreatedAt,
-        Instant slaDeadline,
+        @Nullable Instant slaDeadline,
         String owningTeam,
         boolean canAutoCloseTicket) {
     public NewPrTracking {
         requireNonNull(githubRepo, "githubRepo must not be null");
         requireNonNull(prCreatedAt, "prCreatedAt must not be null");
-        requireNonNull(slaDeadline, "slaDeadline must not be null");
         requireNonNull(owningTeam, "owningTeam must not be null");
     }
 
@@ -24,7 +24,7 @@ public record NewPrTracking(
             String githubRepo,
             int prNumber,
             Instant prCreatedAt,
-            Instant slaDeadline,
+            @Nullable Instant slaDeadline,
             String owningTeam) {
         this(ticketId, githubRepo, prNumber, prCreatedAt, slaDeadline, owningTeam, true);
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -50,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
+import org.springframework.util.AntPathMatcher;
 
 @Service
 @ConditionalOnProperty(name = "pr-review-tracking.enabled", havingValue = "true")
@@ -59,6 +60,8 @@ public class PrDetectionService {
 
     private static final DateTimeFormatter DEADLINE_FMT =
             DateTimeFormatter.ofPattern("EEE dd MMM 'at' HH:mm 'UTC'").withZone(ZoneOffset.UTC);
+
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
     private final GitHubPrUrlParser prUrlParser;
     private final GitHubClient gitHubClient;
@@ -246,19 +249,22 @@ public class PrDetectionService {
 
     private enum NotificationType {
         TRACKED,
+        NO_SLA_TRACKED,
         CHANGES_REQUESTED,
         APPROVED,
         ESCALATED
     }
 
     private record PendingNotification(
-            String repo, int prNumber, NotificationType type, Duration sla, Instant slaDeadline, String teamLabel) {
+            String repo,
+            int prNumber,
+            NotificationType type,
+            @Nullable Duration sla,
+            @Nullable Instant slaDeadline,
+            @Nullable String teamLabel) {
         PendingNotification {
             checkNotNull(repo);
             checkNotNull(type);
-            checkNotNull(sla);
-            checkNotNull(slaDeadline);
-            checkNotNull(teamLabel);
         }
     }
 
@@ -276,42 +282,45 @@ public class PrDetectionService {
             Map<String, Optional<Set<String>>> teamReviewerCache,
             List<PendingNotification> notifications,
             List<PendingEscalation> pendingEscalations) {
-        PrTrackingProps.Repository repoConfig = prTrackingProps.repositories().stream()
-                .filter(r -> r.name().equals(detectedPr.repositoryName()))
-                .findFirst()
-                .orElseThrow(
-                        () -> new IllegalStateException("Repo config not found for " + detectedPr.repositoryName()));
 
-        GitHubPullRequest prMetadata;
         try {
-            prMetadata = gitHubClient.getPullRequest(detectedPr.repositoryName(), detectedPr.pullNumber());
+            Optional<PrTrackingProps.Repository> repoConfig = prTrackingProps.repositories().stream()
+                    .filter(r -> r.name().equals(detectedPr.repositoryName()))
+                    .findFirst();
+
+            if (repoConfig.isPresent()) {
+                // Repo is configured for RR tracking with or without SLA
+                GitHubPullRequest prMetadata = gitHubClient.getPullRequest(detectedPr.repositoryName(), detectedPr.pullNumber());
+
+                if (prMetadata.isOpen()) {
+                    if (repoConfig.get().hasNoSla()) {
+                        // No-SLA tracking: track by path filter without a deadline or escalation.
+                        return processNoSlaOpenPr(detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata, notifications);
+                    } else {
+                        return processOpenPr(detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata,
+                                teamReviewerCache, notifications, pendingEscalations);
+                    }
+                } else {
+                    log.atInfo()
+                            .addArgument(detectedPr::repositoryName)
+                            .addArgument(detectedPr::pullNumber)
+                            .addArgument(prMetadata::state)
+                            .log("PR {}#{} is {} — skipping tracking");
+                }
+            } else {
+                log.atInfo()
+                        .addArgument(detectedPr::repositoryName)
+                        .log("Repo {} is not configured for PR tracking, skipping");
+            }
         } catch (GitHubApiException e) {
             log.atWarn()
                     .addArgument(detectedPr::repositoryName)
                     .addArgument(detectedPr::pullNumber)
                     .addArgument(e::getMessage)
                     .log("Could not fetch PR metadata for {}#{}, skipping: {}");
-            return PerPrResult.SKIPPED;
         }
 
-        if (!prMetadata.isOpen()) {
-            log.atInfo()
-                    .addArgument(detectedPr::repositoryName)
-                    .addArgument(detectedPr::pullNumber)
-                    .addArgument(prMetadata::state)
-                    .log("PR {}#{} is {} — skipping tracking");
-            return PerPrResult.SKIPPED;
-        }
-
-        return processOpenPr(
-                detectedPr,
-                ticket,
-                canAutoCloseTicket,
-                repoConfig,
-                prMetadata,
-                teamReviewerCache,
-                notifications,
-                pendingEscalations);
+        return PerPrResult.SKIPPED;
     }
 
     private PerPrResult processOpenPr(
@@ -446,6 +455,85 @@ public class PrDetectionService {
         return PerPrResult.TRACKED;
     }
 
+    private PerPrResult processNoSlaOpenPr(
+            DetectedPr detectedPr,
+            Ticket ticket,
+            boolean canAutoCloseTicket,
+            PrTrackingProps.Repository repoConfig,
+            GitHubPullRequest prMetadata,
+            List<PendingNotification> notifications) {
+
+        if (matchesPathFilter(repoConfig.paths(), detectedPr.repositoryName(), detectedPr.pullNumber())) {
+            TicketId ticketId = checkNotNull(ticket.id());
+            if (prTrackingRepository.insertIfAbsent(new NewPrTracking(
+                    ticketId.id(),
+                    detectedPr.repositoryName(),
+                    detectedPr.pullNumber(),
+                    prMetadata.createdAt(),
+                    null,
+                    repoConfig.owningTeam(),
+                    canAutoCloseTicket)) != null) {
+
+                log.atInfo()
+                        .addArgument(detectedPr::repositoryName)
+                        .addArgument(detectedPr::pullNumber)
+                        .addArgument(ticketId::id)
+                        .log("PR {}#{} tracking record created for ticket {} (no-SLA repo)");
+
+                addReaction(prTrackingProps.prEmoji(), ticket.queryTs(), ticket.channelId());
+                String teamLabel = resolveTeamLabel(repoConfig.owningTeam());
+                notifications.add(new PendingNotification(
+                        detectedPr.repositoryName(),
+                        detectedPr.pullNumber(),
+                        NotificationType.NO_SLA_TRACKED,
+                        null,
+                        null,
+                        teamLabel));
+
+                return PerPrResult.TRACKED;
+            } else {
+                log.atInfo()
+                        .addArgument(detectedPr::repositoryName)
+                        .addArgument(detectedPr::pullNumber)
+                        .addArgument(ticketId::id)
+                        .log("PR {}#{} was already tracked for ticket {}, skipping");
+            }
+        } else {
+            log.atDebug()
+                    .addArgument(detectedPr::repositoryName)
+                    .addArgument(detectedPr::pullNumber)
+                    .log("PR {}#{} does not match configured paths for no-SLA repo, skipping");
+        }
+
+        return PerPrResult.SKIPPED;
+    }
+
+    private boolean matchesPathFilter(List<String> paths, String repositoryName, int pullNumber) {
+
+        if (paths.isEmpty()) {
+            return true;
+        }
+
+        try {
+            List<String> prFiles = gitHubClient.listPullRequestFiles(repositoryName, pullNumber);
+
+            for (String pattern : paths) {
+                for (String prFile : prFiles) {
+                    if (PATH_MATCHER.match(pattern, prFile)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (GitHubApiException e) {
+            log.atWarn()
+                    .addArgument(repositoryName)
+                    .addArgument(pullNumber)
+                    .addArgument(e::getMessage)
+                    .log("Could not list files for {}#{} during path filter check, skipping: {}");
+        }
+        return false;
+    }
+
     private Ticket initializePrMetadataIfNeeded(Ticket ticket, MessagePosted event) {
         TicketTeam resolvedTeam = ticket.team() != null ? ticket.team() : resolveFirstSuggestedTeam(event.userId());
         ImmutableList<String> resolvedTags =
@@ -545,18 +633,21 @@ public class PrDetectionService {
                         "Pull requests submitted to `%s` are expected to be reviewed within %s. You don't have to ping us for reviews, but I'll keep an eye on this one. If <%s|PR #%d> hasn't been reviewed by %s, I'll automatically escalate it to the owning team (%s)."
                                 .formatted(
                                         n.repo(),
-                                        formatDuration(n.sla()),
+                                        formatDuration(checkNotNull(n.sla())),
                                         prUrl(n.repo(), n.prNumber()),
                                         n.prNumber(),
-                                        DEADLINE_FMT.format(n.slaDeadline()),
-                                        n.teamLabel());
+                                        DEADLINE_FMT.format(checkNotNull(n.slaDeadline())),
+                                        checkNotNull(n.teamLabel()));
+                    case NO_SLA_TRACKED ->
+                        "PRs to %s have no automated SLAs, they are monitored by %s team."
+                                .formatted(n.repo(), checkNotNull(n.teamLabel()));
                     case CHANGES_REQUESTED ->
                         "<%s|PR #%d> for `%s` has been reviewed and changes have been requested. :eyes:"
                                 .formatted(prUrl(n.repo(), n.prNumber()), n.prNumber(), n.repo());
                     case APPROVED ->
                         "<%s|PR #%d> for `%s` has been approved and is ready to merge. :white_check_mark:"
                                 .formatted(prUrl(n.repo(), n.prNumber()), n.prNumber(), n.repo());
-                    case ESCALATED -> formatEscalatedText(n.repo(), n.prNumber(), n.sla());
+                    case ESCALATED -> formatEscalatedText(n.repo(), n.prNumber(), checkNotNull(n.sla()));
                 };
         postText(text, n.repo(), n.prNumber(), n.type(), queryTs, channelId);
     }
@@ -585,6 +676,9 @@ public class PrDetectionService {
             String text =
                     switch (type) {
                         case TRACKED -> formatTrackedGroup(repo, group, prList);
+                        case NO_SLA_TRACKED ->
+                                "PRs %s have no automated SLAs, they are monitored by %s team(s)."
+                                        .formatted(prList, teams(group));
                         case CHANGES_REQUESTED ->
                             "PRs %s for `%s` have been reviewed and changes have been requested. :eyes:"
                                     .formatted(prList, repo);
@@ -596,10 +690,17 @@ public class PrDetectionService {
                                     .formatted(
                                             prList,
                                             repo,
-                                            formatDuration(group.getFirst().sla()));
+                                            formatDuration(checkNotNull(
+                                                    group.getFirst().sla())));
                     };
             postText(text, repo, 0, type, queryTs, channelId);
         }
+    }
+
+    private static String teams(List<PendingNotification> group) {
+        return group.stream()
+                .map(n -> "%s".formatted(n.teamLabel()))
+                .collect(Collectors.joining(", "));
     }
 
     private String formatTrackedGroup(String repo, List<PendingNotification> group, String prList) {
@@ -608,8 +709,8 @@ public class PrDetectionService {
                 group.stream().map(PendingNotification::slaDeadline).distinct().count() == 1;
 
         if (sameSla) {
-            Instant deadline = group.getFirst().slaDeadline();
-            Duration sla = group.getFirst().sla();
+            Instant deadline = checkNotNull(group.getFirst().slaDeadline());
+            Duration sla = checkNotNull(group.getFirst().sla());
             return ("I'm tracking PRs %s for `%s`. Pull requests are expected to be reviewed within %s. "
                             + "You don't have to ping for reviews — I'll keep an eye on these. "
                             + "If not reviewed by %s, I'll automatically escalate to the owning team (%s).")

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -290,15 +290,24 @@ public class PrDetectionService {
 
             if (repoConfig.isPresent()) {
                 // Repo is configured for RR tracking with or without SLA
-                GitHubPullRequest prMetadata = gitHubClient.getPullRequest(detectedPr.repositoryName(), detectedPr.pullNumber());
+                GitHubPullRequest prMetadata =
+                        gitHubClient.getPullRequest(detectedPr.repositoryName(), detectedPr.pullNumber());
 
                 if (prMetadata.isOpen()) {
                     if (repoConfig.get().hasNoSla()) {
                         // No-SLA tracking: track by path filter without a deadline or escalation.
-                        return processNoSlaOpenPr(detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata, notifications);
+                        return processNoSlaOpenPr(
+                                detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata, notifications);
                     } else {
-                        return processOpenPr(detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata,
-                                teamReviewerCache, notifications, pendingEscalations);
+                        return processOpenPr(
+                                detectedPr,
+                                ticket,
+                                canAutoCloseTicket,
+                                repoConfig.get(),
+                                prMetadata,
+                                teamReviewerCache,
+                                notifications,
+                                pendingEscalations);
                     }
                 } else {
                     log.atInfo()
@@ -466,13 +475,14 @@ public class PrDetectionService {
         if (matchesPathFilter(repoConfig.paths(), detectedPr.repositoryName(), detectedPr.pullNumber())) {
             TicketId ticketId = checkNotNull(ticket.id());
             if (prTrackingRepository.insertIfAbsent(new NewPrTracking(
-                    ticketId.id(),
-                    detectedPr.repositoryName(),
-                    detectedPr.pullNumber(),
-                    prMetadata.createdAt(),
-                    null,
-                    repoConfig.owningTeam(),
-                    canAutoCloseTicket)) != null) {
+                            ticketId.id(),
+                            detectedPr.repositoryName(),
+                            detectedPr.pullNumber(),
+                            prMetadata.createdAt(),
+                            null,
+                            repoConfig.owningTeam(),
+                            canAutoCloseTicket))
+                    != null) {
 
                 log.atInfo()
                         .addArgument(detectedPr::repositoryName)
@@ -677,8 +687,8 @@ public class PrDetectionService {
                     switch (type) {
                         case TRACKED -> formatTrackedGroup(repo, group, prList);
                         case NO_SLA_TRACKED ->
-                                "PRs %s have no automated SLAs, they are monitored by %s team(s)."
-                                        .formatted(prList, teams(group));
+                            "PRs %s have no automated SLAs, they are monitored by %s team(s)."
+                                    .formatted(prList, teams(group));
                         case CHANGES_REQUESTED ->
                             "PRs %s for `%s` have been reviewed and changes have been requested. :eyes:"
                                     .formatted(prList, repo);
@@ -698,9 +708,7 @@ public class PrDetectionService {
     }
 
     private static String teams(List<PendingNotification> group) {
-        return group.stream()
-                .map(n -> "%s".formatted(n.teamLabel()))
-                .collect(Collectors.joining(", "));
+        return group.stream().map(n -> "%s".formatted(n.teamLabel())).collect(Collectors.joining(", "));
     }
 
     private String formatTrackedGroup(String repo, List<PendingNotification> group, String prList) {

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -105,11 +105,39 @@ public class PrDetectionService {
                         .log("PR {}#{} already tracked for ticket {}, skipping");
                 continue;
             }
+
+            GitHubPullRequest prMetadata;
+            try {
+                prMetadata = gitHubClient.getPullRequest(pr.repositoryName(), pr.pullNumber());
+            } catch (GitHubApiException e) {
+                log.atWarn()
+                        .addArgument(pr::repositoryName)
+                        .addArgument(pr::pullNumber)
+                        .addArgument(e::getMessage)
+                        .log("Could not fetch PR metadata for {}#{}, skipping: {}");
+                continue;
+            }
+
+            if (!prMetadata.isOpen()) {
+                log.atInfo()
+                        .addArgument(pr::repositoryName)
+                        .addArgument(pr::pullNumber)
+                        .addArgument(prMetadata::state)
+                        .log("PR {}#{} is {} — skipping tracking");
+                continue;
+            }
+
             boolean canAutoCloseTicket = !event.messageRef().isReply();
             PerPrResult result;
             try {
-                result =
-                        processPr(pr, ticket, canAutoCloseTicket, teamReviewerCache, notifications, pendingEscalations);
+                result = processPr(
+                        pr,
+                        ticket,
+                        canAutoCloseTicket,
+                        prMetadata,
+                        teamReviewerCache,
+                        notifications,
+                        pendingEscalations);
             } catch (Exception e) {
                 log.atError()
                         .setCause(e)
@@ -161,6 +189,27 @@ public class PrDetectionService {
         for (DetectedPr pr : detectedPrs) {
             try {
 
+                GitHubPullRequest prMetadata;
+                try {
+                    prMetadata = gitHubClient.getPullRequest(pr.repositoryName(), pr.pullNumber());
+                } catch (GitHubApiException e) {
+                    log.atWarn()
+                            .addArgument(pr::repositoryName)
+                            .addArgument(pr::pullNumber)
+                            .addArgument(e::getMessage)
+                            .log("Could not fetch PR metadata for {}#{}, skipping: {}");
+                    continue;
+                }
+
+                if (!prMetadata.isOpen()) {
+                    log.atInfo()
+                            .addArgument(pr::repositoryName)
+                            .addArgument(pr::pullNumber)
+                            .addArgument(prMetadata::state)
+                            .log("PR {}#{} is {} — skipping tracking");
+                    continue;
+                }
+
                 if (ticket == null) {
                     ticket = ticketSupplier.get();
                     ticketId = checkNotNull(ticket.id());
@@ -176,7 +225,8 @@ public class PrDetectionService {
                     continue;
                 }
 
-                PerPrResult result = processPr(pr, ticket, true, teamReviewerCache, notifications, pendingEscalations);
+                PerPrResult result =
+                        processPr(pr, ticket, true, prMetadata, teamReviewerCache, notifications, pendingEscalations);
 
                 if (result == PerPrResult.TRACKED) {
                     if (!baseReactionsAdded) {
@@ -246,57 +296,38 @@ public class PrDetectionService {
             DetectedPr detectedPr,
             Ticket ticket,
             boolean canAutoCloseTicket,
+            GitHubPullRequest prMetadata,
             Map<String, Optional<Set<String>>> teamReviewerCache,
             List<PendingNotification> notifications,
             List<PendingEscalation> pendingEscalations) {
 
-        try {
-            Optional<PrTrackingProps.Repository> repoConfig = prTrackingProps.repositories().stream()
-                    .filter(r -> r.name().equals(detectedPr.repositoryName()))
-                    .findFirst();
+        Optional<PrTrackingProps.Repository> repoConfig = prTrackingProps.repositories().stream()
+                .filter(r -> r.name().equals(detectedPr.repositoryName()))
+                .findFirst();
 
-            if (repoConfig.isPresent()) {
-                // Repo is configured for RR tracking with or without SLA
-                GitHubPullRequest prMetadata =
-                        gitHubClient.getPullRequest(detectedPr.repositoryName(), detectedPr.pullNumber());
-
-                if (prMetadata.isOpen()) {
-                    if (repoConfig.get().hasNoSla()) {
-                        // No-SLA tracking: track by path filter without a deadline or escalation.
-                        return processNoSlaOpenPr(
-                                detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata, notifications);
-                    } else {
-                        return processOpenPr(
-                                detectedPr,
-                                ticket,
-                                canAutoCloseTicket,
-                                repoConfig.get(),
-                                prMetadata,
-                                teamReviewerCache,
-                                notifications,
-                                pendingEscalations);
-                    }
-                } else {
-                    log.atInfo()
-                            .addArgument(detectedPr::repositoryName)
-                            .addArgument(detectedPr::pullNumber)
-                            .addArgument(prMetadata::state)
-                            .log("PR {}#{} is {} — skipping tracking");
-                }
+        if (repoConfig.isPresent()) {
+            // Repo is configured for RR tracking with or without SLA
+            if (repoConfig.get().hasNoSla()) {
+                // No-SLA tracking: track by path filter without a deadline or escalation.
+                return processNoSlaOpenPr(
+                        detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata, notifications);
             } else {
-                log.atInfo()
-                        .addArgument(detectedPr::repositoryName)
-                        .log("Repo {} is not configured for PR tracking, skipping");
+                return processOpenPr(
+                        detectedPr,
+                        ticket,
+                        canAutoCloseTicket,
+                        repoConfig.get(),
+                        prMetadata,
+                        teamReviewerCache,
+                        notifications,
+                        pendingEscalations);
             }
-        } catch (GitHubApiException e) {
-            log.atWarn()
+        } else {
+            log.atInfo()
                     .addArgument(detectedPr::repositoryName)
-                    .addArgument(detectedPr::pullNumber)
-                    .addArgument(e::getMessage)
-                    .log("Could not fetch PR metadata for {}#{}, skipping: {}");
+                    .log("Repo {} is not configured for PR tracking, skipping");
+            return PerPrResult.SKIPPED;
         }
-
-        return PerPrResult.SKIPPED;
     }
 
     private PerPrResult processOpenPr(

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -160,32 +160,6 @@ public class PrDetectionService {
 
         for (DetectedPr pr : detectedPrs) {
             try {
-                PrTrackingProps.Repository repoConfig = prTrackingProps.repositories().stream()
-                        .filter(r -> r.name().equals(pr.repositoryName()))
-                        .findFirst()
-                        .orElseThrow(
-                                () -> new IllegalStateException("Repo config not found for " + pr.repositoryName()));
-
-                GitHubPullRequest prMetadata;
-                try {
-                    prMetadata = gitHubClient.getPullRequest(pr.repositoryName(), pr.pullNumber());
-                } catch (GitHubApiException e) {
-                    log.atWarn()
-                            .addArgument(pr::repositoryName)
-                            .addArgument(pr::pullNumber)
-                            .addArgument(e::getMessage)
-                            .log("Could not fetch PR metadata for {}#{}, skipping: {}");
-                    continue;
-                }
-
-                if (!prMetadata.isOpen()) {
-                    log.atInfo()
-                            .addArgument(pr::repositoryName)
-                            .addArgument(pr::pullNumber)
-                            .addArgument(prMetadata::state)
-                            .log("PR {}#{} is {} — skipping tracking");
-                    continue;
-                }
 
                 if (ticket == null) {
                     ticket = ticketSupplier.get();
@@ -202,15 +176,8 @@ public class PrDetectionService {
                     continue;
                 }
 
-                PerPrResult result = processOpenPr(
-                        pr,
-                        checkNotNull(ticket),
-                        true,
-                        repoConfig,
-                        prMetadata,
-                        teamReviewerCache,
-                        notifications,
-                        pendingEscalations);
+                PerPrResult result = processPr(pr, ticket, true, teamReviewerCache, notifications, pendingEscalations);
+
                 if (result == PerPrResult.TRACKED) {
                     if (!baseReactionsAdded) {
                         addReaction(slackTicketsProps.expectedInitialReaction(), ticket.queryTs(), ticket.channelId());

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -287,7 +287,8 @@ public class PrDetectionService {
                 checkNotNull(slaDeadline, "slaDeadline required for %s", type);
             }
             checkNotNull(teamLabel, "teamLabel required for all notification types");
-        }    }
+        }
+    }
 
     private record PendingEscalation(PrTrackingRecord tracking, Ticket ticket) {
         PendingEscalation {
@@ -490,7 +491,8 @@ public class PrDetectionService {
                         prMetadata.createdAt(),
                         null,
                         repoConfig.owningTeam(),
-                        canAutoCloseTicket)) == null) {
+                        canAutoCloseTicket))
+                == null) {
             log.atInfo()
                     .addArgument(detectedPr::repositoryName)
                     .addArgument(detectedPr::pullNumber)
@@ -729,7 +731,10 @@ public class PrDetectionService {
                     .formatted(repo));
             for (PendingNotification n : group) {
                 sb.append("- <%s|#%d> — review by %s\n"
-                        .formatted(prUrl(n.repo(), n.prNumber()), n.prNumber(), DEADLINE_FMT.format(checkNotNull(n.slaDeadline()))));
+                        .formatted(
+                                prUrl(n.repo(), n.prNumber()),
+                                n.prNumber(),
+                                DEADLINE_FMT.format(checkNotNull(n.slaDeadline()))));
             }
             sb.append("If not reviewed by their deadline, I'll escalate to the owning team (%s).".formatted(teamLabel));
             return sb.toString();

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -282,8 +282,12 @@ public class PrDetectionService {
         PendingNotification {
             checkNotNull(repo);
             checkNotNull(type);
-        }
-    }
+            if (type != NotificationType.NO_SLA_TRACKED) {
+                checkNotNull(sla, "sla required for %s", type);
+                checkNotNull(slaDeadline, "slaDeadline required for %s", type);
+            }
+            checkNotNull(teamLabel, "teamLabel required for all notification types");
+        }    }
 
     private record PendingEscalation(PrTrackingRecord tracking, Ticket ticket) {
         PendingEscalation {
@@ -306,7 +310,7 @@ public class PrDetectionService {
                 .findFirst();
 
         if (repoConfig.isPresent()) {
-            // Repo is configured for RR tracking with or without SLA
+            // Repo is configured for PR tracking with or without SLA
             if (repoConfig.get().hasNoSla()) {
                 // No-SLA tracking: track by path filter without a deadline or escalation.
                 return processNoSlaOpenPr(
@@ -470,50 +474,48 @@ public class PrDetectionService {
             GitHubPullRequest prMetadata,
             List<PendingNotification> notifications) {
 
-        if (matchesPathFilter(repoConfig.paths(), detectedPr.repositoryName(), detectedPr.pullNumber())) {
-            TicketId ticketId = checkNotNull(ticket.id());
-            if (prTrackingRepository.insertIfAbsent(new NewPrTracking(
-                            ticketId.id(),
-                            detectedPr.repositoryName(),
-                            detectedPr.pullNumber(),
-                            prMetadata.createdAt(),
-                            null,
-                            repoConfig.owningTeam(),
-                            canAutoCloseTicket))
-                    != null) {
-
-                log.atInfo()
-                        .addArgument(detectedPr::repositoryName)
-                        .addArgument(detectedPr::pullNumber)
-                        .addArgument(ticketId::id)
-                        .log("PR {}#{} tracking record created for ticket {} (no-SLA repo)");
-
-                addReaction(prTrackingProps.prEmoji(), ticket.queryTs(), ticket.channelId());
-                String teamLabel = resolveTeamLabel(repoConfig.owningTeam());
-                notifications.add(new PendingNotification(
-                        detectedPr.repositoryName(),
-                        detectedPr.pullNumber(),
-                        NotificationType.NO_SLA_TRACKED,
-                        null,
-                        null,
-                        teamLabel));
-
-                return PerPrResult.TRACKED;
-            } else {
-                log.atInfo()
-                        .addArgument(detectedPr::repositoryName)
-                        .addArgument(detectedPr::pullNumber)
-                        .addArgument(ticketId::id)
-                        .log("PR {}#{} was already tracked for ticket {}, skipping");
-            }
-        } else {
+        if (!matchesPathFilter(repoConfig.paths(), detectedPr.repositoryName(), detectedPr.pullNumber())) {
             log.atDebug()
                     .addArgument(detectedPr::repositoryName)
                     .addArgument(detectedPr::pullNumber)
                     .log("PR {}#{} does not match configured paths for no-SLA repo, skipping");
+            return PerPrResult.SKIPPED;
         }
 
-        return PerPrResult.SKIPPED;
+        TicketId ticketId = checkNotNull(ticket.id());
+        if (prTrackingRepository.insertIfAbsent(new NewPrTracking(
+                        ticketId.id(),
+                        detectedPr.repositoryName(),
+                        detectedPr.pullNumber(),
+                        prMetadata.createdAt(),
+                        null,
+                        repoConfig.owningTeam(),
+                        canAutoCloseTicket)) == null) {
+            log.atInfo()
+                    .addArgument(detectedPr::repositoryName)
+                    .addArgument(detectedPr::pullNumber)
+                    .addArgument(ticketId::id)
+                    .log("PR {}#{} was already tracked for ticket {}, skipping");
+            return PerPrResult.SKIPPED;
+        }
+
+        log.atInfo()
+                .addArgument(detectedPr::repositoryName)
+                .addArgument(detectedPr::pullNumber)
+                .addArgument(ticketId::id)
+                .log("PR {}#{} tracking record created for ticket {} (no-SLA repo)");
+
+        addReaction(prTrackingProps.prEmoji(), ticket.queryTs(), ticket.channelId());
+        String teamLabel = resolveTeamLabel(repoConfig.owningTeam());
+        notifications.add(new PendingNotification(
+                detectedPr.repositoryName(),
+                detectedPr.pullNumber(),
+                NotificationType.NO_SLA_TRACKED,
+                null,
+                null,
+                teamLabel));
+
+        return PerPrResult.TRACKED;
     }
 
     private boolean matchesPathFilter(List<String> paths, String repositoryName, int pullNumber) {
@@ -533,7 +535,7 @@ public class PrDetectionService {
                 }
             }
         } catch (GitHubApiException e) {
-            log.atWarn()
+            log.atError()
                     .addArgument(repositoryName)
                     .addArgument(pullNumber)
                     .addArgument(e::getMessage)
@@ -706,7 +708,7 @@ public class PrDetectionService {
     }
 
     private static String teams(List<PendingNotification> group) {
-        return group.stream().map(n -> "%s".formatted(n.teamLabel())).collect(Collectors.joining(", "));
+        return group.stream().map(PendingNotification::teamLabel).collect(Collectors.joining(", "));
     }
 
     private String formatTrackedGroup(String repo, List<PendingNotification> group, String prList) {
@@ -727,7 +729,7 @@ public class PrDetectionService {
                     .formatted(repo));
             for (PendingNotification n : group) {
                 sb.append("- <%s|#%d> — review by %s\n"
-                        .formatted(prUrl(n.repo(), n.prNumber()), n.prNumber(), DEADLINE_FMT.format(n.slaDeadline())));
+                        .formatted(prUrl(n.repo(), n.prNumber()), n.prNumber(), DEADLINE_FMT.format(checkNotNull(n.slaDeadline()))));
             }
             sb.append("If not reviewed by their deadline, I'll escalate to the owning team (%s).".formatted(teamLabel));
             return sb.toString();

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
@@ -192,6 +192,12 @@ public class PrLifecyclePoller {
                         .addArgument(record::githubRepo)
                         .addArgument(record::prNumber)
                         .log("PR {}#{} approved — SLA paused, awaiting merge");
+            } else {
+                prTrackingRepository.updateStatus(record.id(), PrTrackingStatus.APPROVED, null, record.escalationId());
+                log.atInfo()
+                        .addArgument(record::githubRepo)
+                        .addArgument(record::prNumber)
+                        .log("PR {}#{} approved — awaiting merge");
             }
         } else {
             prTrackingRepository.updateStatus(record.id(), PrTrackingStatus.APPROVED, null, record.escalationId());

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
@@ -118,15 +118,16 @@ public class PrLifecyclePoller {
             PrTrackingRecord record, GitHubPullRequest pr, @Nullable GitHubPullRequestReview latestVerdict) {
         if (latestVerdict != null && latestVerdict.requestsChanges()) {
             Duration remaining = computeRemainingDuration(record);
+
             if (remaining != null) {
                 prTrackingRepository.pauseSla(record.id(), PrTrackingStatus.CHANGES_REQUESTED, remaining);
-                notifyChangesRequested(record);
-            } else {
-                log.atWarn()
-                        .addArgument(record::githubRepo)
-                        .addArgument(record::prNumber)
-                        .log("Skipping CHANGES_REQUESTED transition for {}#{} — no SLA deadline available");
+            } else if (record.slaRemaining() == null) {
+                // No-SLA PR tracking record (slaDeadline and slaRemaining are not set)
+                prTrackingRepository.updateStatus(
+                        record.id(), PrTrackingStatus.CHANGES_REQUESTED, null, record.escalationId());
             }
+            notifyChangesRequested(record);
+
         } else if (latestVerdict != null && latestVerdict.isApproved()) {
             handleApproval(record, pr);
         } else if (record.slaDeadline() != null && Instant.now().isAfter(record.slaDeadline())) {
@@ -184,9 +185,9 @@ public class PrLifecyclePoller {
     private void handleApproval(PrTrackingRecord record, GitHubPullRequest pr) {
         if (pr.isMergeable()) {
             handleApprovalClosure(record);
-        } else if (record.status() == PrTrackingStatus.OPEN) {
+        } else {
             Duration remaining = computeRemainingDuration(record);
-            if (remaining != null) {
+            if (record.status() == PrTrackingStatus.OPEN && remaining != null) {
                 prTrackingRepository.pauseSla(record.id(), PrTrackingStatus.APPROVED, remaining);
                 log.atInfo()
                         .addArgument(record::githubRepo)
@@ -199,12 +200,6 @@ public class PrLifecyclePoller {
                         .addArgument(record::prNumber)
                         .log("PR {}#{} approved — awaiting merge");
             }
-        } else {
-            prTrackingRepository.updateStatus(record.id(), PrTrackingStatus.APPROVED, null, record.escalationId());
-            log.atInfo()
-                    .addArgument(record::githubRepo)
-                    .addArgument(record::prNumber)
-                    .log("PR {}#{} approved — awaiting merge");
         }
     }
 
@@ -337,9 +332,6 @@ public class PrLifecyclePoller {
 
     private @Nullable Duration computeRemainingDuration(PrTrackingRecord record) {
         if (record.slaDeadline() == null) {
-            log.atWarn()
-                    .addArgument(record::id)
-                    .log("Record {} has no SLA deadline — cannot compute remaining duration");
             return null;
         }
         Duration remaining = Duration.between(Instant.now(), record.slaDeadline());

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
@@ -186,18 +186,13 @@ public class PrLifecyclePoller {
             handleApprovalClosure(record);
         } else if (record.status() == PrTrackingStatus.OPEN) {
             Duration remaining = computeRemainingDuration(record);
-            if (remaining == null) {
-                log.atWarn()
+            if (remaining != null) {
+                prTrackingRepository.pauseSla(record.id(), PrTrackingStatus.APPROVED, remaining);
+                log.atInfo()
                         .addArgument(record::githubRepo)
                         .addArgument(record::prNumber)
-                        .log("Skipping APPROVED transition for {}#{} — no SLA deadline available");
-                return;
+                        .log("PR {}#{} approved — SLA paused, awaiting merge");
             }
-            prTrackingRepository.pauseSla(record.id(), PrTrackingStatus.APPROVED, remaining);
-            log.atInfo()
-                    .addArgument(record::githubRepo)
-                    .addArgument(record::prNumber)
-                    .log("PR {}#{} approved — SLA paused, awaiting merge");
         } else {
             prTrackingRepository.updateStatus(record.id(), PrTrackingStatus.APPROVED, null, record.escalationId());
             log.atInfo()

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/SlaLookup.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/SlaLookup.java
@@ -71,6 +71,9 @@ public class SlaLookup {
      * @return the SLA, or null if none could be determined
      */
     @Nullable public Duration getSla(PrTrackingProps.Repository repoConfig, String repositoryName, int pullNumber) {
+        if (repoConfig.sla() == null) {
+            return null;
+        }
         PrTrackingProps.Sla configSla = repoConfig.sla();
         Duration defaultSla = configSla.defaultSla();
         List<PrTrackingProps.SlaOverride> overrides = configSla.overrides() != null ? configSla.overrides() : List.of();

--- a/api/service/src/main/resources/application.yaml
+++ b/api/service/src/main/resources/application.yaml
@@ -123,6 +123,12 @@ pr-review-tracking:
   #       overrides:            # optional: path-specific SLA overrides
   #         - path: infra/**
   #           sla: 7d
+  #   - name: my-org/no-sla-repo
+  #     owning-team: <team-code from enums.escalation-teams>
+  #     github-team-slug: <slug>  # optional: GitHub team slug for review validation; when absent, falls back to PR requested teams
+  #     paths:
+  #     - infra/**
+  #     - rbac/**
   sla-discovery:
     cache: PT24H                           # How long to cache SLA files fetched from repositories
   github:

--- a/api/service/src/test/java/com/coreeng/supportbot/config/PrTrackingConfigValidationTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/config/PrTrackingConfigValidationTest.java
@@ -160,7 +160,7 @@ class PrTrackingConfigValidationTest {
     void rejectsRepoNameWithExtraSlashes() {
         // given
         PrTrackingProps.Repository badName =
-                new PrTrackingProps.Repository("my-org/sub/repo", "wow", null, sla(Duration.ofDays(2)));
+                new PrTrackingProps.Repository("my-org/sub/repo", "wow", null, List.of(), sla(Duration.ofDays(2)));
 
         // when / then
         assertThatThrownBy(() -> new PrTrackingProps(
@@ -181,7 +181,7 @@ class PrTrackingConfigValidationTest {
     void rejectsZeroSlaWhenEnabled() {
         // given
         PrTrackingProps.Repository zeroSla =
-                new PrTrackingProps.Repository("my-org/repo", "wow", null, sla(Duration.ZERO));
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), sla(Duration.ZERO));
 
         // when / then
         assertThatThrownBy(() -> new PrTrackingProps(
@@ -202,7 +202,7 @@ class PrTrackingConfigValidationTest {
     void rejectsNegativeSlaWhenEnabled() {
         // given
         PrTrackingProps.Repository negativeSla =
-                new PrTrackingProps.Repository("my-org/repo", "wow", null, sla(Duration.ofHours(-1)));
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), sla(Duration.ofHours(-1)));
 
         // when / then
         assertThatThrownBy(() -> new PrTrackingProps(
@@ -224,7 +224,7 @@ class PrTrackingConfigValidationTest {
         // given
         PrTrackingProps.Sla slaWithNullDefault = new PrTrackingProps.Sla(null, null, null);
         PrTrackingProps.Repository repo =
-                new PrTrackingProps.Repository("my-org/repo", "wow", null, slaWithNullDefault);
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), slaWithNullDefault);
 
         // when / then
         assertThatThrownBy(() -> new PrTrackingProps(
@@ -247,7 +247,7 @@ class PrTrackingConfigValidationTest {
         PrTrackingProps.Sla slaWithBadOverride = new PrTrackingProps.Sla(
                 null, Duration.ofDays(2), List.of(new PrTrackingProps.SlaOverride("infra/**", Duration.ZERO)));
         PrTrackingProps.Repository repo =
-                new PrTrackingProps.Repository("my-org/repo", "wow", null, slaWithBadOverride);
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), slaWithBadOverride);
 
         // when / then
         assertThatThrownBy(() -> new PrTrackingProps(
@@ -269,7 +269,8 @@ class PrTrackingConfigValidationTest {
         // given
         PrTrackingProps.Sla slaWithBlankPath = new PrTrackingProps.Sla(
                 null, Duration.ofDays(2), List.of(new PrTrackingProps.SlaOverride("  ", Duration.ofDays(7))));
-        PrTrackingProps.Repository repo = new PrTrackingProps.Repository("my-org/repo", "wow", null, slaWithBlankPath);
+        PrTrackingProps.Repository repo =
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), slaWithBlankPath);
 
         // when / then
         assertThatThrownBy(() -> new PrTrackingProps(
@@ -293,7 +294,8 @@ class PrTrackingConfigValidationTest {
                 ".pr-sla.yaml",
                 Duration.ofDays(2),
                 List.of(new PrTrackingProps.SlaOverride("infra/**", Duration.ofDays(7))));
-        PrTrackingProps.Repository repo = new PrTrackingProps.Repository("my-org/repo", "wow", null, fullSla);
+        PrTrackingProps.Repository repo =
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), fullSla);
 
         // when / then
         assertThatCode(() -> new PrTrackingProps(
@@ -313,7 +315,8 @@ class PrTrackingConfigValidationTest {
     void acceptsFileOnlyRepoWithNoDefaultSla() {
         // given (file set, no default, no overrides)
         PrTrackingProps.Sla fileOnlySla = new PrTrackingProps.Sla(".pr-sla.yaml", null, null);
-        PrTrackingProps.Repository repo = new PrTrackingProps.Repository("my-org/repo", "wow", null, fileOnlySla);
+        PrTrackingProps.Repository repo =
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), fileOnlySla);
 
         // when / then
         assertThatCode(() -> new PrTrackingProps(
@@ -383,7 +386,8 @@ class PrTrackingConfigValidationTest {
     @Test
     void skipsAllValidationWhenDisabled() {
         // given
-        PrTrackingProps.Repository badRepo = new PrTrackingProps.Repository("", "", null, sla(Duration.ZERO));
+        PrTrackingProps.Repository badRepo =
+                new PrTrackingProps.Repository("", "", null, List.of(), sla(Duration.ZERO));
 
         // when / then
         assertThatCode(() -> new PrTrackingProps(
@@ -403,7 +407,7 @@ class PrTrackingConfigValidationTest {
     void normalizesRepositoryNamesToLowerCase() {
         // given
         PrTrackingProps.Repository mixedCase =
-                new PrTrackingProps.Repository("My-Org/My-Repo", "wow", null, sla(Duration.ofDays(2)));
+                new PrTrackingProps.Repository("My-Org/My-Repo", "wow", null, List.of(), sla(Duration.ofDays(2)));
 
         // when
         PrTrackingProps props = new PrTrackingProps(
@@ -489,22 +493,86 @@ class PrTrackingConfigValidationTest {
 
     @Test
     void rejectsBlankGithubTeamSlug() {
-        assertThatThrownBy(() -> new PrTrackingProps.Repository("my-org/repo", "wow", "", sla(Duration.ofDays(2))))
+        assertThatThrownBy(() ->
+                        new PrTrackingProps.Repository("my-org/repo", "wow", "", List.of(), sla(Duration.ofDays(2))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("githubTeamSlug must not be blank");
     }
 
     @Test
     void acceptsNullGithubTeamSlug() {
-        assertThatCode(() -> new PrTrackingProps.Repository("my-org/repo", "wow", null, sla(Duration.ofDays(2))))
+        assertThatCode(() ->
+                        new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), sla(Duration.ofDays(2))))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void acceptsValidGithubTeamSlug() {
-        assertThatCode(() ->
-                        new PrTrackingProps.Repository("my-org/repo", "wow", "platform-team", sla(Duration.ofDays(2))))
+        assertThatCode(() -> new PrTrackingProps.Repository(
+                        "my-org/repo", "wow", "platform-team", List.of(), sla(Duration.ofDays(2))))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsNoSlaRepoWithPaths() {
+        // given
+        PrTrackingProps.Repository noSlaRepo =
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of("infra/**"), null);
+
+        // when / then
+        assertThatCode(() -> new PrTrackingProps(
+                        true,
+                        "0 0 9-18 * * 1-5",
+                        "pr",
+                        List.of("tag"),
+                        "low",
+                        DEFAULT_DURATION_UNIT,
+                        List.of(noSlaRepo),
+                        validTokenGithub(),
+                        DEFAULT_SLA_DISCOVERY))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsNoSlaRepoWithoutPaths() {
+        // given
+        PrTrackingProps.Repository noSlaNoPathsRepo =
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of(), null);
+
+        // when / then
+        assertThatThrownBy(() -> new PrTrackingProps(
+                        true,
+                        "0 0 9-18 * * 1-5",
+                        "pr",
+                        List.of("tag"),
+                        "low",
+                        DEFAULT_DURATION_UNIT,
+                        List.of(noSlaNoPathsRepo),
+                        validTokenGithub(),
+                        DEFAULT_SLA_DISCOVERY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("paths must not be empty when sla is not configured");
+    }
+
+    @Test
+    void rejectsNoSlaRepoWithBlankPath() {
+        // given
+        PrTrackingProps.Repository blankPathRepo =
+                new PrTrackingProps.Repository("my-org/repo", "wow", null, List.of("infra/**", "  "), null);
+
+        // when / then
+        assertThatThrownBy(() -> new PrTrackingProps(
+                        true,
+                        "0 0 9-18 * * 1-5",
+                        "pr",
+                        List.of("tag"),
+                        "low",
+                        DEFAULT_DURATION_UNIT,
+                        List.of(blankPathRepo),
+                        validTokenGithub(),
+                        DEFAULT_SLA_DISCOVERY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("paths[] must not be blank");
     }
 
     private static PrTrackingProps.Repository validRepo() {
@@ -512,7 +580,7 @@ class PrTrackingConfigValidationTest {
     }
 
     private static PrTrackingProps.Repository validRepoWithName(String name) {
-        return new PrTrackingProps.Repository(name, "wow", null, sla(Duration.ofDays(2)));
+        return new PrTrackingProps.Repository(name, "wow", null, List.of(), sla(Duration.ofDays(2)));
     }
 
     private static PrTrackingProps.Sla sla(Duration defaultSla) {

--- a/api/service/src/test/java/com/coreeng/supportbot/config/PrTrackingGitHubConfigTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/config/PrTrackingGitHubConfigTest.java
@@ -74,7 +74,11 @@ class PrTrackingGitHubConfigTest {
                 "low",
                 "days",
                 List.of(new PrTrackingProps.Repository(
-                        "my-org/my-repo", "wow", null, new PrTrackingProps.Sla(null, Duration.ofDays(2), null))),
+                        "my-org/my-repo",
+                        "wow",
+                        null,
+                        List.of(),
+                        new PrTrackingProps.Sla(null, Duration.ofDays(2), null))),
                 appGithub,
                 DEFAULT_SLA_DISCOVERY);
 
@@ -102,7 +106,11 @@ class PrTrackingGitHubConfigTest {
                 "low",
                 "days",
                 List.of(new PrTrackingProps.Repository(
-                        "my-org/my-repo", "wow", null, new PrTrackingProps.Sla(null, Duration.ofDays(2), null))),
+                        "my-org/my-repo",
+                        "wow",
+                        null,
+                        List.of(),
+                        new PrTrackingProps.Sla(null, Duration.ofDays(2), null))),
                 appGithub,
                 DEFAULT_SLA_DISCOVERY);
 
@@ -133,7 +141,11 @@ class PrTrackingGitHubConfigTest {
                 "low",
                 "days",
                 List.of(new PrTrackingProps.Repository(
-                        "my-org/my-repo", "wow", null, new PrTrackingProps.Sla(null, Duration.ofDays(2), null))),
+                        "my-org/my-repo",
+                        "wow",
+                        null,
+                        List.of(),
+                        new PrTrackingProps.Sla(null, Duration.ofDays(2), null))),
                 appGithub,
                 DEFAULT_SLA_DISCOVERY);
 

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -423,9 +423,6 @@ class PrDetectionServiceTest {
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
-            when(prTrackingProps.repositories())
-                    .thenReturn(
-                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenThrow(new GitHubApiException(404, "PR not found: " + REPO + "#" + PR_NUMBER));
 
@@ -447,9 +444,6 @@ class PrDetectionServiceTest {
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
-            when(prTrackingProps.repositories())
-                    .thenReturn(
-                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenReturn(new GitHubPullRequest(
                             REPO,
@@ -480,9 +474,6 @@ class PrDetectionServiceTest {
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
-            when(prTrackingProps.repositories())
-                    .thenReturn(
-                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenReturn(new GitHubPullRequest(
                             REPO,

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -590,6 +590,38 @@ class PrDetectionServiceTest {
             verify(slackClient, never()).postMessage(any());
             verifyNoInteractions(escalationProcessingService);
         }
+
+        @Test
+        void skipsSideEffectsForNoSlaPrWhenInsertCollidesWithConcurrentTracker() {
+            // given
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            // No-SLA Repo
+            when(prTrackingProps.repositories())
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), null)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of()));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(null);
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then
+            verify(slackClient, never()).addReaction(any());
+            verify(slackClient, never()).postMessage(any());
+            verifyNoInteractions(escalationProcessingService);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -186,7 +187,8 @@ class PrDetectionServiceTest {
         void setUpHappyPathStubs() {
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
         }
@@ -422,7 +424,8 @@ class PrDetectionServiceTest {
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenThrow(new GitHubApiException(404, "PR not found: " + REPO + "#" + PR_NUMBER));
 
@@ -445,7 +448,8 @@ class PrDetectionServiceTest {
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenReturn(new GitHubPullRequest(
                             REPO,
@@ -477,7 +481,8 @@ class PrDetectionServiceTest {
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenReturn(new GitHubPullRequest(
                             REPO,
@@ -507,7 +512,8 @@ class PrDetectionServiceTest {
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenReturn(new GitHubPullRequest(
                             REPO,
@@ -538,7 +544,8 @@ class PrDetectionServiceTest {
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
                     .thenReturn(new GitHubPullRequest(
                             REPO,
@@ -567,7 +574,8 @@ class PrDetectionServiceTest {
             // given
             Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);
@@ -590,6 +598,119 @@ class PrDetectionServiceTest {
             verify(slackClient, never()).addReaction(any());
             verify(slackClient, never()).postMessage(any());
             verifyNoInteractions(escalationProcessingService);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // No-SLA repository tracking
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class NoSlaRepositoryTracking {
+
+        private static final String NO_SLA_REPO = "my-org/no-sla-repo";
+        private static final List<String> PATHS = List.of("infra/**");
+
+        @Test
+        void tracksWithNullDeadlineWhenPrMatchesPathFilter() {
+            // given
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(NO_SLA_REPO, TEAM_CODE, null, PATHS, null)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(NO_SLA_REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of()));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, PR_NUMBER)).thenReturn(List.of("infra/main.tf"));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(1L, prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — inserted with null slaDeadline
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            assertThat(newTrackingCaptor.getValue().githubRepo()).isEqualTo(NO_SLA_REPO);
+            // Slack: pr emoji reaction + base "eyes" reaction (2 total) + tracking message (no SLA info)
+            verify(slackClient, times(2)).addReaction(any());
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            assertThat(postMessageCaptor.getValue().message().getText())
+                    .contains("PRs to %s have no automated SLAs, they are monitored by %s team.".formatted(NO_SLA_REPO, TEAM_CODE));
+            // no escalation
+            verifyNoInteractions(escalationProcessingService);
+        }
+
+        @Test
+        void skipsWhenNoFilesMatchPathFilter() {
+            // given
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(NO_SLA_REPO, TEAM_CODE, null, PATHS, null)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(NO_SLA_REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of()));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(List.of("src/main/java/Foo.java")); // does not match "infra/**"
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — PR skipped entirely
+            verify(prTrackingRepository, never()).insertIfAbsent(any());
+            verify(slackClient, never()).addReaction(any());
+            verify(slackClient, never()).postMessage(any());
+            verifyNoInteractions(escalationProcessingService);
+        }
+
+        @Test
+        void skipsWhenListPullRequestFilesThrows() {
+            // given
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(NO_SLA_REPO, TEAM_CODE, null, PATHS, null)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(NO_SLA_REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of()));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, PR_NUMBER))
+                    .thenThrow(new GitHubApiException(500, "server error"));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — conservative: skip the PR when file listing fails
+            verify(prTrackingRepository, never()).insertIfAbsent(any());
+            verify(slackClient, never()).addReaction(any());
+            verify(slackClient, never()).postMessage(any());
         }
     }
 
@@ -804,8 +925,8 @@ class PrDetectionServiceTest {
             Instant slaDeadline = prCreatedAt.plus(SLA_24H);
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(
-                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, "platform-team", sla(SLA_24H))));
+                    .thenReturn(List.of(
+                            new PrTrackingProps.Repository(REPO, TEAM_CODE, "platform-team", List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
@@ -848,7 +969,8 @@ class PrDetectionServiceTest {
             Instant slaDeadline = prCreatedAt.plus(SLA_24H);
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
@@ -871,7 +993,8 @@ class PrDetectionServiceTest {
             Instant slaDeadline = prCreatedAt.plus(SLA_24H);
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
@@ -908,8 +1031,8 @@ class PrDetectionServiceTest {
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
                     .thenReturn(List.of(
-                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H)),
-                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, sla(SLA_24H))));
+                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H)),
+                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any()))
@@ -955,8 +1078,8 @@ class PrDetectionServiceTest {
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
                     .thenReturn(List.of(
-                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H)),
-                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, sla(SLA_24H))));
+                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H)),
+                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any()))
@@ -989,8 +1112,8 @@ class PrDetectionServiceTest {
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
                     .thenReturn(List.of(
-                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H)),
-                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, sla(SLA_24H))));
+                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H)),
+                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, List.of(), sla(SLA_24H))));
 
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
@@ -1039,7 +1162,8 @@ class PrDetectionServiceTest {
 
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any()))
@@ -1080,7 +1204,8 @@ class PrDetectionServiceTest {
 
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any()))
@@ -1136,7 +1261,8 @@ class PrDetectionServiceTest {
 
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any()))
@@ -1190,7 +1316,8 @@ class PrDetectionServiceTest {
         void setUpStubs() {
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
 
@@ -1312,7 +1439,7 @@ class PrDetectionServiceTest {
             Instant createdAt = Instant.now().minus(Duration.ofHours(1));
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(sla))));
+                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(sla))));
             when(slaLookup.getSla(any(), eq(REPO), eq(PR_NUMBER))).thenReturn(sla);
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
@@ -1354,7 +1481,8 @@ class PrDetectionServiceTest {
             Instant createdAt = Instant.now().minus(Duration.ofHours(1));
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam("Infra Integration", TEAM_CODE, "SG123"));
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
@@ -1387,7 +1515,8 @@ class PrDetectionServiceTest {
             Instant createdAt = Instant.now().minus(Duration.ofHours(1));
             when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, "unknown-team", null, sla(SLA_24H))));
+                    .thenReturn(List.of(
+                            new PrTrackingProps.Repository(REPO, "unknown-team", null, List.of(), sla(SLA_24H))));
             when(escalationTeamsRegistry.findEscalationTeamByCode("unknown-team"))
                     .thenReturn(null);
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
@@ -1427,7 +1556,8 @@ class PrDetectionServiceTest {
             lenient().when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
             lenient()
                     .when(prTrackingProps.repositories())
-                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H))));
+                    .thenReturn(
+                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             lenient()
                     .when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE))
                     .thenReturn(new EscalationTeam(TEAM_LABEL, TEAM_CODE, "SG123"));
@@ -1552,8 +1682,8 @@ class PrDetectionServiceTest {
 
             when(prTrackingProps.repositories())
                     .thenReturn(List.of(
-                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, sla(SLA_24H)),
-                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, sla(SLA_24H))));
+                            new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), sla(SLA_24H)),
+                            new PrTrackingProps.Repository(repoB, TEAM_CODE, null, List.of(), sla(SLA_24H))));
             when(prUrlParser.parse(any()))
                     .thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER), new DetectedPr(repoB, prB)));
             when(gitHubClient.getPullRequest(REPO, PR_NUMBER))
@@ -1615,11 +1745,11 @@ class PrDetectionServiceTest {
         return new PrTrackingProps.Sla(null, defaultSla, null);
     }
 
-    private static PrTrackingRecord stubTrackingRecord(Instant prCreatedAt, Instant slaDeadline) {
+    private static PrTrackingRecord stubTrackingRecord(Instant prCreatedAt, @Nullable Instant slaDeadline) {
         return stubTrackingRecord(1L, prCreatedAt, slaDeadline);
     }
 
-    private static PrTrackingRecord stubTrackingRecord(long id, Instant prCreatedAt, Instant slaDeadline) {
+    private static PrTrackingRecord stubTrackingRecord(long id, Instant prCreatedAt, @Nullable Instant slaDeadline) {
         return new PrTrackingRecord(
                 id,
                 1L,

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -645,7 +645,8 @@ class PrDetectionServiceTest {
             verify(slackClient, times(2)).addReaction(any());
             verify(slackClient).postMessage(postMessageCaptor.capture());
             assertThat(postMessageCaptor.getValue().message().getText())
-                    .contains("PRs to %s have no automated SLAs, they are monitored by %s team.".formatted(NO_SLA_REPO, TEAM_CODE));
+                    .contains("PRs to %s have no automated SLAs, they are monitored by %s team."
+                            .formatted(NO_SLA_REPO, TEAM_CODE));
             // no escalation
             verifyNoInteractions(escalationProcessingService);
         }

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -597,8 +597,7 @@ class PrDetectionServiceTest {
             Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
             // No-SLA Repo
             when(prTrackingProps.repositories())
-                    .thenReturn(
-                            List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), null)));
+                    .thenReturn(List.of(new PrTrackingProps.Repository(REPO, TEAM_CODE, null, List.of(), null)));
             when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(REPO, PR_NUMBER)));
             when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
                     .thenReturn(false);

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
@@ -946,6 +946,7 @@ class PrLifecyclePollerTest {
                             "my-org/repo-a",
                             "wow",
                             "platform-team",
+                            List.of(),
                             new PrTrackingProps.Sla(null, Duration.ofDays(2), null))));
             when(gitHubClient.resolveTeamReviewers("my-org", "platform-team")).thenReturn(List.of("team-member"));
 
@@ -974,7 +975,11 @@ class PrLifecyclePollerTest {
                             openPrWithReviews(record, List.of(review(GitHubPullRequestReview.ReviewState.APPROVED))));
             when(prTrackingProps.repositories())
                     .thenReturn(List.of(new PrTrackingProps.Repository(
-                            "my-org/repo-a", "wow", null, new PrTrackingProps.Sla(null, Duration.ofDays(2), null))));
+                            "my-org/repo-a",
+                            "wow",
+                            null,
+                            List.of(),
+                            new PrTrackingProps.Sla(null, Duration.ofDays(2), null))));
 
             // when
             poller.poll();
@@ -1004,6 +1009,7 @@ class PrLifecyclePollerTest {
                             "my-org/repo-a",
                             "wow",
                             "platform-team",
+                            List.of(),
                             new PrTrackingProps.Sla(null, Duration.ofDays(2), null))));
             when(gitHubClient.resolveTeamReviewers("my-org", "platform-team"))
                     .thenThrow(new GitHubApiException(403, "forbidden"));
@@ -1041,6 +1047,7 @@ class PrLifecyclePollerTest {
                             "my-org/repo-a",
                             "wow",
                             "platform-team",
+                            List.of(),
                             new PrTrackingProps.Sla(null, Duration.ofDays(2), null))));
             when(gitHubClient.resolveTeamReviewers("my-org", "platform-team")).thenReturn(List.of("team-member"));
 

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
@@ -524,12 +524,17 @@ class PrLifecyclePollerTest {
             poller.poll();
 
             // then
-            verify(prTrackingRepository).updateStatus(eq(record.id()), eq(PrTrackingStatus.CHANGES_REQUESTED), isNull(), eq(record.escalationId()));
+            verify(prTrackingRepository)
+                    .updateStatus(
+                            eq(record.id()),
+                            eq(PrTrackingStatus.CHANGES_REQUESTED),
+                            isNull(),
+                            eq(record.escalationId()));
             ArgumentCaptor<SlackPostMessageRequest> captor = ArgumentCaptor.forClass(SlackPostMessageRequest.class);
             verify(slackClient).postMessage(captor.capture());
-            assertThat(captor.getValue().message().getText()).contains(
-                    "PR `%s#%d` has been reviewed and changes have been requested."
-                    .formatted(record.githubRepo(), record.prNumber()));
+            assertThat(captor.getValue().message().getText())
+                    .contains("PR `%s#%d` has been reviewed and changes have been requested."
+                            .formatted(record.githubRepo(), record.prNumber()));
         }
 
         @Test

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
@@ -495,7 +495,7 @@ class PrLifecyclePollerTest {
         }
 
         @Test
-        void skipsChangesRequestedTransitionWhenSlaDeadlineIsNull() {
+        void changesRequestedTransitionForNoSlaPr() {
             // given — OPEN record with null slaDeadline but a CHANGES_REQUESTED review present
             PrLifecyclePoller poller = createPoller();
             PrTrackingRecord record = new PrTrackingRecord(
@@ -517,14 +517,19 @@ class PrLifecyclePollerTest {
             when(gitHubClient.getPullRequest(record.githubRepo(), record.prNumber()))
                     .thenReturn(openPrWithReviews(
                             record, List.of(review(GitHubPullRequestReview.ReviewState.CHANGES_REQUESTED))));
+            when(ticketRepository.findTicketById(new TicketId(record.ticketId())))
+                    .thenReturn(ticket(100L));
 
             // when
             poller.poll();
 
-            // then — transition is skipped; no state change, no Slack notification
-            verify(prTrackingRepository, never()).pauseSla(anyLong(), any(), any());
-            verify(prTrackingRepository, never()).updateStatus(anyLong(), any(), any(), any());
-            verify(slackClient, never()).postMessage(any());
+            // then
+            verify(prTrackingRepository).updateStatus(eq(record.id()), eq(PrTrackingStatus.CHANGES_REQUESTED), isNull(), eq(record.escalationId()));
+            ArgumentCaptor<SlackPostMessageRequest> captor = ArgumentCaptor.forClass(SlackPostMessageRequest.class);
+            verify(slackClient).postMessage(captor.capture());
+            assertThat(captor.getValue().message().getText()).contains(
+                    "PR `%s#%d` has been reviewed and changes have been requested."
+                    .formatted(record.githubRepo(), record.prNumber()));
         }
 
         @Test

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
@@ -556,7 +556,7 @@ class PrLifecyclePollerTest {
 
             // then — transition is skipped; no state change, no Slack notification
             verify(prTrackingRepository, never()).pauseSla(anyLong(), any(), any());
-            verify(prTrackingRepository, never()).updateStatus(anyLong(), any(), any(), any());
+            verify(prTrackingRepository).updateStatus(eq(1L), eq(PrTrackingStatus.APPROVED), any(), any());
             verify(slackClient, never()).postMessage(any());
         }
 

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/SlaLookupTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/SlaLookupTest.java
@@ -43,7 +43,7 @@ class SlaLookupTest {
                 "low",
                 "days",
                 List.of(new PrTrackingProps.Repository(
-                        REPO, "wow", null, new PrTrackingProps.Sla(null, SLA_48H, null))),
+                        REPO, "wow", null, List.of(), new PrTrackingProps.Sla(null, SLA_48H, null))),
                 new PrTrackingProps.GitHub(
                         PrTrackingProps.AuthMode.TOKEN, "https://api.github.com", "token", "", "", ""),
                 null);
@@ -462,7 +462,7 @@ class SlaLookupTest {
                 "low",
                 durationUnit,
                 List.of(new PrTrackingProps.Repository(
-                        REPO, "wow", null, new PrTrackingProps.Sla(null, SLA_48H, null))),
+                        REPO, "wow", null, List.of(), new PrTrackingProps.Sla(null, SLA_48H, null))),
                 new PrTrackingProps.GitHub(
                         PrTrackingProps.AuthMode.TOKEN, "https://api.github.com", "token", "", "", ""),
                 null);
@@ -470,15 +470,18 @@ class SlaLookupTest {
     }
 
     private static PrTrackingProps.Repository repo(Duration defaultSla) {
-        return new PrTrackingProps.Repository(REPO, "wow", null, new PrTrackingProps.Sla(null, defaultSla, null));
+        return new PrTrackingProps.Repository(
+                REPO, "wow", null, List.of(), new PrTrackingProps.Sla(null, defaultSla, null));
     }
 
     private static PrTrackingProps.Repository repoWithOverrides(
             Duration defaultSla, List<PrTrackingProps.SlaOverride> overrides) {
-        return new PrTrackingProps.Repository(REPO, "wow", null, new PrTrackingProps.Sla(null, defaultSla, overrides));
+        return new PrTrackingProps.Repository(
+                REPO, "wow", null, List.of(), new PrTrackingProps.Sla(null, defaultSla, overrides));
     }
 
     private static PrTrackingProps.Repository repoWithFile(String file, @Nullable Duration defaultSla) {
-        return new PrTrackingProps.Repository(REPO, "wow", null, new PrTrackingProps.Sla(file, defaultSla, null));
+        return new PrTrackingProps.Repository(
+                REPO, "wow", null, List.of(), new PrTrackingProps.Sla(file, defaultSla, null));
     }
 }


### PR DESCRIPTION
Required by https://cecg-force.atlassian.net/browse/PT-327

Changes:

- Configure repositories for PR tracking without sla - instead provide paths list of path strings
- Messages containing PRs to repos without an SLA config trigger the bot to response with a message on the slack thread: “PRs to $repo have no automated SLAs, they are monitored by $team”
- Support messages follow the existing logic for auto-closing - if the opening message contains the PR link, it’s marked as auto-closeable and closes when the bot detects the PR closes
