### PR TITLE
feat(api): add ticket escalation endpoint

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/EscalateViewMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/EscalateViewMapper.java
@@ -9,7 +9,6 @@ import static com.slack.api.model.block.element.BlockElements.*;
 import static com.slack.api.model.view.Views.*;
 
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
-import com.coreeng.supportbot.escalation.EscalationValidator;
 import com.coreeng.supportbot.slack.RenderingUtils;
 import com.coreeng.supportbot.util.JsonMapper;
 import com.google.common.collect.ImmutableList;
@@ -22,7 +21,6 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -30,7 +28,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class EscalateViewMapper {
     private final JsonMapper jsonMapper;
-    private final EscalationValidator escalationValidator;
     private final EscalationTeamsRegistry escalationTeamsRegistry;
 
     public View.ViewBuilder render(TicketEscalateInput input, View.ViewBuilder view) {
@@ -92,31 +89,25 @@ public class EscalateViewMapper {
         String team = checkNotNull(teamValue.getSelectedOption(), "team selection is null in escalation view state")
                 .getValue();
 
-        ViewState.Value threadPermalinkValue = passedValues.get(Fields.threadPermalink.actionId());
-        String threadPermalink = threadPermalinkValue != null ? threadPermalinkValue.getValue() : null;
-
         return EscalateRequest.builder()
                 .tags(tags)
                 .ticketId(input.ticketId())
                 .team(team)
-                .threadPermalink(threadPermalink)
                 .build();
     }
 
-    public Map<String, String> validate(EscalateRequest request) {
-        @Nullable String threadPermalinkError = escalationValidator.validateThreadPermalinkForCreation(request.threadPermalink());
-        if (threadPermalinkError != null) {
-            return Map.of(Fields.threadPermalink.actionId(), threadPermalinkError);
-        }
-        return Map.of();
+    public String toActionId(TicketEscalationValidator.Field field) {
+        return switch (field) {
+            case team -> Fields.team.actionId();
+            case tags -> Fields.tags.actionId();
+        };
     }
 
     @Getter
     @RequiredArgsConstructor
     private enum Fields {
         tags("escalation-tags"),
-        team("escalation-team"),
-        threadPermalink("escalation-thread-permalink");
+        team("escalation-team");
 
         private final String actionId;
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketEscalationValidator.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketEscalationValidator.java
@@ -1,0 +1,49 @@
+package com.coreeng.supportbot.ticket;
+
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TicketEscalationValidator {
+    private final EscalationTeamsRegistry escalationTeamsRegistry;
+
+    public ValidationResult validate(@Nullable String team, @Nullable List<String> tags) {
+        if (team == null || team.isBlank()) {
+            return ValidationResult.invalid(Field.team, "team is required");
+        }
+        if (escalationTeamsRegistry.findEscalationTeamByCode(team) == null) {
+            return ValidationResult.invalid(Field.team, "team must be a valid escalation team");
+        }
+        if (tags != null && tags.stream().anyMatch(Objects::isNull)) {
+            return ValidationResult.invalid(Field.tags, "tags must not contain null");
+        }
+        return ValidationResult.valid();
+    }
+
+    public ValidationResult validate(EscalateRequest request) {
+        return validate(request.team(), request.tags());
+    }
+
+    public enum Field {
+        team,
+        tags,
+    }
+
+    public record ValidationResult(
+            boolean isValid,
+            @Nullable Field field,
+            @Nullable String errorMessage) {
+        public static ValidationResult valid() {
+            return new ValidationResult(true, null, null);
+        }
+
+        public static ValidationResult invalid(Field field, String errorMessage) {
+            return new ValidationResult(false, field, errorMessage);
+        }
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/handler/TicketViewsSubmissionHandler.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/handler/TicketViewsSubmissionHandler.java
@@ -1,12 +1,14 @@
 package com.coreeng.supportbot.ticket.handler;
 
 import static com.slack.api.model.view.Views.view;
+import static java.util.Objects.requireNonNull;
 
 import com.coreeng.supportbot.rbac.RbacService;
 import com.coreeng.supportbot.slack.SlackId;
 import com.coreeng.supportbot.slack.SlackViewSubmitHandler;
 import com.coreeng.supportbot.ticket.EscalateViewMapper;
 import com.coreeng.supportbot.ticket.TicketConfirmSubmissionMapper;
+import com.coreeng.supportbot.ticket.TicketEscalationValidator;
 import com.coreeng.supportbot.ticket.TicketProcessingService;
 import com.coreeng.supportbot.ticket.TicketSubmission;
 import com.coreeng.supportbot.ticket.TicketSubmitResult;
@@ -29,6 +31,7 @@ public class TicketViewsSubmissionHandler implements SlackViewSubmitHandler {
     private final TicketProcessingService ticketProcessingService;
     private final TicketSummaryViewMapper ticketSummaryViewMapper;
     private final EscalateViewMapper escalateViewMapper;
+    private final TicketEscalationValidator ticketEscalationValidator;
     private final TicketConfirmSubmissionMapper confirmSubmissionMapper;
     private final ExecutorService executor;
     private final RbacService rbacService;
@@ -83,11 +86,15 @@ public class TicketViewsSubmissionHandler implements SlackViewSubmitHandler {
             case escalate -> {
                 var escalateRequest = escalateViewMapper.extractSubmittedValues(
                         request.getPayload().getView());
-                Map<String, String> errors = escalateViewMapper.validate(escalateRequest);
-                if (!errors.isEmpty()) {
+                TicketEscalationValidator.ValidationResult validationResult =
+                        ticketEscalationValidator.validate(escalateRequest);
+                if (!validationResult.isValid()) {
+                    TicketEscalationValidator.Field field = requireNonNull(validationResult.field());
                     return ViewSubmissionResponse.builder()
                             .responseAction("errors")
-                            .errors(errors)
+                            .errors(Map.of(
+                                    escalateViewMapper.toActionId(field),
+                                    requireNonNull(validationResult.errorMessage())))
                             .build();
                 }
                 executor.submit(() -> ticketProcessingService.escalate(escalateRequest));

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketController.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketController.java
@@ -5,6 +5,7 @@ import com.coreeng.supportbot.util.Page;
 import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 public class TicketController {
     private final TicketQueryService queryService;
     private final TicketUpdateService ticketUpdateService;
+    private final TicketProcessingService ticketProcessingService;
+    private final TicketEscalationValidator ticketEscalationValidator;
     private final TicketUIMapper mapper;
     private final TicketTeamSuggestionsService teamSuggestionsService;
 
@@ -72,6 +75,32 @@ public class TicketController {
         try {
             TicketUI ticket = ticketUpdateService.update(id, request);
             return ResponseEntity.ok(ticket);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/{id}/escalation")
+    public ResponseEntity<?> escalateTicket(
+            @PathVariable TicketId id, @RequestBody TicketEscalationCreateRequest request) {
+        if (queryService.findById(id) == null) {
+            return ResponseEntity.notFound().build();
+        }
+        TicketEscalationValidator.ValidationResult validationResult =
+                ticketEscalationValidator.validate(request.team(), request.tags());
+        if (!validationResult.isValid()) {
+            return ResponseEntity.badRequest().body(validationResult.errorMessage());
+        }
+        String team = Objects.requireNonNull(request.team());
+
+        try {
+            List<String> tags = Objects.requireNonNullElse(request.tags(), List.of());
+            ticketProcessingService.escalate(EscalateRequest.builder()
+                    .ticketId(id)
+                    .team(team)
+                    .tags(ImmutableList.copyOf(tags))
+                    .build());
+            return ResponseEntity.ok().build();
         } catch (IllegalArgumentException | IllegalStateException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketEscalationCreateRequest.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketEscalationCreateRequest.java
@@ -1,0 +1,6 @@
+package com.coreeng.supportbot.ticket.rest;
+
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public record TicketEscalationCreateRequest(@Nullable String team, List<String> tags) {}

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/EscalateViewMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/EscalateViewMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
-import com.coreeng.supportbot.escalation.EscalationValidator;
 import com.coreeng.supportbot.util.JsonMapper;
 import com.google.common.collect.ImmutableList;
 import com.slack.api.model.view.View;
@@ -25,16 +24,13 @@ class EscalateViewMapperTest {
     private final JsonMapper jsonMapper = new JsonMapper();
 
     @Mock
-    private EscalationValidator escalationValidator;
-
-    @Mock
     private EscalationTeamsRegistry escalationTeamsRegistry;
 
     private EscalateViewMapper mapper;
 
     @BeforeEach
     void setUp() {
-        mapper = new EscalateViewMapper(jsonMapper, escalationValidator, escalationTeamsRegistry);
+        mapper = new EscalateViewMapper(jsonMapper, escalationTeamsRegistry);
     }
 
     @Test
@@ -80,6 +76,12 @@ class EscalateViewMapperTest {
         EscalateRequest result = mapper.extractSubmittedValues(view);
 
         assertThat(result.tags()).containsExactly("networking");
+    }
+
+    @Test
+    void toActionId_returnsExpectedFieldIds() {
+        assertThat(mapper.toActionId(TicketEscalationValidator.Field.team)).isEqualTo("escalation-team");
+        assertThat(mapper.toActionId(TicketEscalationValidator.Field.tags)).isEqualTo("escalation-tags");
     }
 
     private View buildView(String privateMetadata, Map<String, ViewState.Value> actionValues) {

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketEscalationValidatorTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketEscalationValidatorTest.java
@@ -1,0 +1,57 @@
+package com.coreeng.supportbot.ticket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.teams.fakes.FakeEscalationTeamsRegistry;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TicketEscalationValidatorTest {
+    private TicketEscalationValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new TicketEscalationValidator(
+                new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Core Support", "core-support", "S123"))));
+    }
+
+    @Test
+    void validate_returnsErrorWhenTeamIsMissing() {
+        TicketEscalationValidator.ValidationResult result = validator.validate((String) null, List.of("bug"));
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.field()).isEqualTo(TicketEscalationValidator.Field.team);
+        assertThat(result.errorMessage()).isEqualTo("team is required");
+    }
+
+    @Test
+    void validate_returnsErrorWhenTeamIsUnknown() {
+        TicketEscalationValidator.ValidationResult result = validator.validate("unknown-team", List.of("bug"));
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.field()).isEqualTo(TicketEscalationValidator.Field.team);
+        assertThat(result.errorMessage()).isEqualTo("team must be a valid escalation team");
+    }
+
+    @Test
+    void validate_returnsErrorWhenTagsContainNull() {
+        TicketEscalationValidator.ValidationResult result =
+                validator.validate("core-support", Arrays.asList("bug", null));
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.field()).isEqualTo(TicketEscalationValidator.Field.tags);
+        assertThat(result.errorMessage()).isEqualTo("tags must not contain null");
+    }
+
+    @Test
+    void validate_returnsValidForKnownTeamAndTags() {
+        TicketEscalationValidator.ValidationResult result = validator.validate("core-support", List.of("bug"));
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.field()).isNull();
+        assertThat(result.errorMessage()).isNull();
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/handler/TicketViewsSubmissionHandlerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/handler/TicketViewsSubmissionHandlerTest.java
@@ -3,6 +3,7 @@ package com.coreeng.supportbot.ticket.handler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -10,10 +11,14 @@ import static org.mockito.Mockito.when;
 
 import com.coreeng.supportbot.rbac.RbacService;
 import com.coreeng.supportbot.slack.SlackId;
+import com.coreeng.supportbot.ticket.EscalateRequest;
 import com.coreeng.supportbot.ticket.EscalateViewMapper;
 import com.coreeng.supportbot.ticket.TicketConfirmSubmissionMapper;
+import com.coreeng.supportbot.ticket.TicketEscalationValidator;
 import com.coreeng.supportbot.ticket.TicketProcessingService;
 import com.coreeng.supportbot.ticket.TicketSummaryViewMapper;
+import com.coreeng.supportbot.ticket.TicketViewType;
+import com.google.common.collect.ImmutableList;
 import com.slack.api.app_backend.views.payload.ViewSubmissionPayload;
 import com.slack.api.app_backend.views.response.ViewSubmissionResponse;
 import com.slack.api.bolt.context.builtin.ViewSubmissionContext;
@@ -38,6 +43,9 @@ class TicketViewsSubmissionHandlerTest {
     private EscalateViewMapper escalateViewMapper;
 
     @Mock
+    private TicketEscalationValidator ticketEscalationValidator;
+
+    @Mock
     private TicketConfirmSubmissionMapper confirmSubmissionMapper;
 
     @Mock
@@ -54,6 +62,7 @@ class TicketViewsSubmissionHandlerTest {
                 ticketProcessingService,
                 ticketSummaryViewMapper,
                 escalateViewMapper,
+                ticketEscalationValidator,
                 confirmSubmissionMapper,
                 executor,
                 rbacService);
@@ -101,5 +110,38 @@ class TicketViewsSubmissionHandlerTest {
         verify(rbacService).isSupportBySlackId(SlackId.user(userId));
         assertFalse(response.getErrors().isEmpty());
         assertNull(response.getView());
+    }
+
+    @Test
+    void whenEscalationValidationFails_returnsSlackFieldErrors() {
+        String userId = "U123456";
+        ViewSubmissionContext context = mock(ViewSubmissionContext.class);
+        ViewSubmissionRequest request = mock(ViewSubmissionRequest.class);
+        View view =
+                View.builder().callbackId(TicketViewType.escalate.callbackId()).build();
+        ViewSubmissionPayload payload =
+                ViewSubmissionPayload.builder().view(view).build();
+        EscalateRequest escalateRequest = EscalateRequest.builder()
+                .ticketId(new com.coreeng.supportbot.ticket.TicketId(42))
+                .team("unknown")
+                .tags(ImmutableList.of())
+                .build();
+
+        when(context.getRequestUserId()).thenReturn(userId);
+        when(rbacService.isSupportBySlackId(SlackId.user(userId))).thenReturn(true);
+        when(request.getPayload()).thenReturn(payload);
+        when(escalateViewMapper.extractSubmittedValues(view)).thenReturn(escalateRequest);
+        when(ticketEscalationValidator.validate(escalateRequest))
+                .thenReturn(TicketEscalationValidator.ValidationResult.invalid(
+                        TicketEscalationValidator.Field.team, "team must be a valid escalation team"));
+        when(escalateViewMapper.toActionId(TicketEscalationValidator.Field.team))
+                .thenReturn("escalation-team");
+
+        ViewSubmissionResponse response = handler.apply(request, context);
+
+        assertEquals("errors", response.getResponseAction());
+        assertEquals(
+                "team must be a valid escalation team", response.getErrors().get("escalation-team"));
+        verify(ticketProcessingService, org.mockito.Mockito.never()).escalate(any());
     }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketControllerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketControllerTest.java
@@ -10,6 +10,7 @@ import com.coreeng.supportbot.util.Page;
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,14 +36,30 @@ class TicketControllerTest {
     @Mock
     private TicketTeamSuggestionsService teamSuggestionsService;
 
+    @Mock
+    private TicketProcessingService ticketProcessingService;
+
+    @Mock
+    private TicketEscalationValidator ticketEscalationValidator;
+
     private TicketController controller;
 
     private TicketId ticketId;
 
     @BeforeEach
     void setUp() {
-        controller = new TicketController(queryService, ticketUpdateService, mapper, teamSuggestionsService);
+        controller = new TicketController(
+                queryService,
+                ticketUpdateService,
+                ticketProcessingService,
+                ticketEscalationValidator,
+                mapper,
+                teamSuggestionsService);
         ticketId = new TicketId(123L);
+        lenient().when(queryService.findById(ticketId)).thenReturn(mock(Ticket.class));
+        lenient()
+                .when(ticketEscalationValidator.validate(any(), any()))
+                .thenReturn(TicketEscalationValidator.ValidationResult.valid());
     }
 
     @Test
@@ -98,6 +115,112 @@ class TicketControllerTest {
         assertThat(response.getBody()).isInstanceOf(String.class);
         assertThat((String) response.getBody()).contains("Update failed");
         verify(ticketUpdateService).update(ticketId, request);
+    }
+
+    @Test
+    void shouldEscalateTicketViaProcessingService() {
+        // given
+        TicketEscalationCreateRequest request =
+                new TicketEscalationCreateRequest("core-support", List.of("bug", "urgent"));
+
+        // when
+        ResponseEntity<?> response = controller.escalateTicket(ticketId, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(ticketProcessingService)
+                .escalate(argThat(escalateRequest -> ticketId.equals(escalateRequest.ticketId())
+                        && "core-support".equals(escalateRequest.team())
+                        && ImmutableList.of("bug", "urgent").equals(escalateRequest.tags())
+                        && escalateRequest.threadPermalink() == null));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenEscalationTicketDoesNotExist() {
+        // given
+        when(queryService.findById(ticketId)).thenReturn(null);
+
+        // when
+        ResponseEntity<?> response =
+                controller.escalateTicket(ticketId, new TicketEscalationCreateRequest("core-support", List.of()));
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        verifyNoInteractions(ticketEscalationValidator);
+        verify(ticketProcessingService, never()).escalate(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEscalationTeamIsMissing() {
+        // given
+        TicketEscalationCreateRequest request = new TicketEscalationCreateRequest(null, List.of("bug"));
+        when(ticketEscalationValidator.validate(request.team(), request.tags()))
+                .thenReturn(TicketEscalationValidator.ValidationResult.invalid(
+                        TicketEscalationValidator.Field.team, "team is required"));
+
+        // when
+        ResponseEntity<?> response = controller.escalateTicket(ticketId, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isEqualTo("team is required");
+        verify(ticketProcessingService, never()).escalate(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEscalationTeamIsUnknown() {
+        // given
+        TicketEscalationCreateRequest request = new TicketEscalationCreateRequest("unknown-team", List.of("bug"));
+        when(ticketEscalationValidator.validate(request.team(), request.tags()))
+                .thenReturn(TicketEscalationValidator.ValidationResult.invalid(
+                        TicketEscalationValidator.Field.team, "team must be a valid escalation team"));
+
+        // when
+        ResponseEntity<?> response = controller.escalateTicket(ticketId, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isEqualTo("team must be a valid escalation team");
+        verify(ticketProcessingService, never()).escalate(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEscalationTagsContainNull() {
+        // given
+        TicketEscalationCreateRequest request =
+                new TicketEscalationCreateRequest("core-support", Arrays.asList("bug", null));
+        when(ticketEscalationValidator.validate(request.team(), request.tags()))
+                .thenReturn(TicketEscalationValidator.ValidationResult.invalid(
+                        TicketEscalationValidator.Field.tags, "tags must not contain null"));
+
+        // when
+        ResponseEntity<?> response = controller.escalateTicket(ticketId, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isEqualTo("tags must not contain null");
+        verify(ticketProcessingService, never()).escalate(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEscalationFails() {
+        // given
+        TicketEscalationCreateRequest request = new TicketEscalationCreateRequest("core-support", List.of());
+        doThrow(new IllegalArgumentException("Ticket is closed"))
+                .when(ticketProcessingService)
+                .escalate(any());
+
+        // when
+        ResponseEntity<?> response = controller.escalateTicket(ticketId, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isEqualTo("Ticket is closed");
+        verify(ticketProcessingService)
+                .escalate(argThat(escalateRequest -> ticketId.equals(escalateRequest.ticketId())
+                        && "core-support".equals(escalateRequest.team())
+                        && ImmutableList.of().equals(escalateRequest.tags())
+                        && escalateRequest.threadPermalink() == null));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a ticket escalation API endpoint under /ticket/{id}/escalation
- share escalation validation across API and Slack via TicketEscalationValidator
- add controller, Slack handler, mapper, and validator tests for the new flow
