### PR TITLE
test(api): stabilize Hub4jGitHubClientTest

### DIFF
--- a/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
@@ -3,21 +3,31 @@ package com.coreeng.supportbot.github;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import org.kohsuke.github.*;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHFileNotFoundException;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHOrganization;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestFileDetail;
+import org.kohsuke.github.GHPullRequestReview;
+import org.kohsuke.github.GHPullRequestReviewState;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTeam;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.HttpException;
+import org.kohsuke.github.PagedIterable;
 
 class Hub4jGitHubClientTest {
 
@@ -26,26 +36,17 @@ class Hub4jGitHubClientTest {
 
     @Test
     void returnsPullRequestOnHappyPath() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        Instant createdAt = Instant.parse("2026-01-01T00:00:00Z");
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setMergeableRaw(pr, true);
-        setMergeableStateRaw(pr, "clean");
-        setRequestedTeamsRaw(pr);
-        stubEmptyReviews(pr);
+        GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
+        when(pr.getMergeable()).thenReturn(true);
+        when(pr.getMergeableState()).thenReturn("clean");
+        when(pr.getRequestedTeams()).thenReturn(List.of());
+        stubReviews(pr, List.of());
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.repositoryName()).isEqualTo("my-org/my-repo");
         assertThat(result.pullRequestNumber()).isEqualTo(42);
-        assertThat(result.createdAt()).isEqualTo(createdAt);
+        assertThat(result.createdAt()).isEqualTo(instant("2026-01-01T00:00:00Z"));
         assertThat(result.state()).isEqualTo(GitHubPullRequest.PrState.OPEN);
         assertThat(result.mergeable()).isTrue();
         assertThat(result.mergeableState()).isEqualTo("clean");
@@ -53,53 +54,36 @@ class Hub4jGitHubClientTest {
 
     @Test
     void returnsMergedStateWhenMergedAtIsNonNull() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "closed");
-        setMergedAtRaw(pr, "2026-01-15T10:00:00Z");
-        setRequestedTeamsRaw(pr);
-        stubEmptyReviews(pr);
+        GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.CLOSED);
+        when(pr.getMergedAt()).thenReturn(date("2026-01-15T10:00:00Z"));
+        when(pr.getMergeable()).thenReturn(true);
+        when(pr.getMergeableState()).thenReturn("clean");
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.state()).isEqualTo(GitHubPullRequest.PrState.MERGED);
+        verify(pr, never()).getRequestedTeams();
+        verify(pr, never()).listReviews();
     }
 
     @Test
     void returnsPullRequestWithNullMergeableWhenNotYetComputed() throws IOException {
-        // given - mergeable/mergeableState not set, GitHub returns null when not yet computed
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
-        stubEmptyReviews(pr);
+        GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
+        when(pr.getMergeable()).thenReturn(null);
+        when(pr.getMergeableState()).thenReturn(null);
+        when(pr.getRequestedTeams()).thenReturn(List.of());
+        stubReviews(pr, List.of());
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.mergeable()).isNull();
         assertThat(result.mergeableState()).isNull();
     }
 
     @Test
     void wrapsNullCreatedAtAsGitHubApiException() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = mock(GHPullRequest.class); // getCreatedAt() returns null by default
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
+        stubPullRequest("my-org/my-repo", 42, null, GHIssueState.OPEN);
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -109,15 +93,9 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsNullStateAsGitHubApiException() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = new GHPullRequest();
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, null);
+        GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
+        when(pr.getState()).thenReturn(null);
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -127,10 +105,8 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsNotFoundAsGitHubApiException() throws IOException {
-        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new GHFileNotFoundException("Not Found"));
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 999))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -140,11 +116,9 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsHttpErrorAsGitHubApiException() throws IOException {
-        // given
         when(gitHub.getRepository("my-org/my-repo"))
                 .thenThrow(new HttpException(401, "Unauthorized", (String) null, null));
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 1))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -154,10 +128,8 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsIOExceptionAsGitHubApiException() throws IOException {
-        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new IOException("Connection refused"));
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 1))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -167,44 +139,36 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getFileContentReturnsDecodedContent() throws IOException {
-        // given
         GHRepository repo = mock(GHRepository.class);
         GHContent ghContent = mock(GHContent.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenReturn(ghContent);
         when(ghContent.getContent()).thenReturn("default: 48h");
 
-        // when
         String result = client.getFileContent("my-org/my-repo", ".pr-sla.yaml");
 
-        // then
         assertThat(result).isEqualTo("default: 48h");
     }
 
     @Test
     void getFileContentReturnsNullOn404() throws IOException {
-        // given
         GHRepository repo = mock(GHRepository.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenThrow(new GHFileNotFoundException("Not Found"));
 
-        // when
         String result = client.getFileContent("my-org/my-repo", ".pr-sla.yaml");
 
-        // then
         assertThat(result).isNull();
     }
 
     @Test
     void getFileContentThrowsOnNullContent() throws IOException {
-        // given
         GHRepository repo = mock(GHRepository.class);
         GHContent ghContent = mock(GHContent.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenReturn(ghContent);
         when(ghContent.getContent()).thenReturn(null);
 
-        // when / then
         assertThatThrownBy(() -> client.getFileContent("my-org/my-repo", ".pr-sla.yaml"))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("null content")
@@ -213,12 +177,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getFileContentWrapsHttpException() throws IOException {
-        // given
         GHRepository repo = mock(GHRepository.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenThrow(new HttpException(403, "Forbidden", (String) null, null));
 
-        // when / then
         assertThatThrownBy(() -> client.getFileContent("my-org/my-repo", ".pr-sla.yaml"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -227,12 +189,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getFileContentWrapsIOException() throws IOException {
-        // given
         GHRepository repo = mock(GHRepository.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenThrow(new IOException("Connection refused"));
 
-        // when / then
         assertThatThrownBy(() -> client.getFileContent("my-org/my-repo", ".pr-sla.yaml"))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining(".pr-sla.yaml");
@@ -240,7 +200,6 @@ class Hub4jGitHubClientTest {
 
     @Test
     void listPullRequestFilesReturnsFileNames() throws IOException {
-        // given
         GHRepository repo = mock(GHRepository.class);
         GHPullRequest pr = mock(GHPullRequest.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
@@ -256,19 +215,15 @@ class Hub4jGitHubClientTest {
         when(pr.listFiles()).thenReturn(iterable);
         when(iterable.toList()).thenReturn(List.of(file1, file2));
 
-        // when
         List<String> result = client.listPullRequestFiles("my-org/my-repo", 42);
 
-        // then
         assertThat(result).containsExactly("src/Main.java", "docs/README.md");
     }
 
     @Test
     void listPullRequestFilesWraps404() throws IOException {
-        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new GHFileNotFoundException("Not Found"));
 
-        // when / then
         assertThatThrownBy(() -> client.listPullRequestFiles("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -277,11 +232,9 @@ class Hub4jGitHubClientTest {
 
     @Test
     void listPullRequestFilesWrapsHttpException() throws IOException {
-        // given
         when(gitHub.getRepository("my-org/my-repo"))
                 .thenThrow(new HttpException(500, "Internal Server Error", (String) null, null));
 
-        // when / then
         assertThatThrownBy(() -> client.listPullRequestFiles("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -290,10 +243,8 @@ class Hub4jGitHubClientTest {
 
     @Test
     void listPullRequestFilesWrapsIOException() throws IOException {
-        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new IOException("Connection refused"));
 
-        // when / then
         assertThatThrownBy(() -> client.listPullRequestFiles("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("my-org/my-repo#42");
@@ -301,29 +252,13 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestFiltersOutPendingReviews() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        Instant createdAt = Instant.parse("2026-01-01T00:00:00Z");
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
-
-        GHUser approvedUser = mock(GHUser.class);
-        GHPullRequestReview approvedReview =
-                spyReview(approvedUser, "alice", GHPullRequestReviewState.APPROVED, "2026-01-02T10:00:00Z");
-        GHUser pendingUser = mock(GHUser.class);
-        GHPullRequestReview pendingReview =
-                spyReview(pendingUser, "bob", GHPullRequestReviewState.PENDING, "2026-01-02T11:00:00Z");
-
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        GHPullRequestReview approvedReview = review("alice", GHPullRequestReviewState.APPROVED, "2026-01-02T10:00:00Z");
+        GHPullRequestReview pendingReview = review("bob", GHPullRequestReviewState.PENDING, "2026-01-02T11:00:00Z");
         stubReviews(pr, List.of(approvedReview, pendingReview));
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.reviews()).hasSize(1);
         assertThat(result.reviews().get(0).userLogin()).isEqualTo("alice");
         assertThat(result.reviews().get(0).state()).isEqualTo(GitHubPullRequestReview.ReviewState.APPROVED);
@@ -331,94 +266,51 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestMapsApprovedReviewCorrectly() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        stubReviews(pr, List.of(review("alice", GHPullRequestReviewState.APPROVED, "2026-01-15T14:30:00Z")));
 
-        GHUser user = mock(GHUser.class);
-        GHPullRequestReview review =
-                spyReview(user, "alice", GHPullRequestReviewState.APPROVED, "2026-01-15T14:30:00Z");
-        stubReviews(pr, List.of(review));
-
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.reviews()).hasSize(1);
         GitHubPullRequestReview mapped = result.reviews().get(0);
         assertThat(mapped.userLogin()).isEqualTo("alice");
         assertThat(mapped.state()).isEqualTo(GitHubPullRequestReview.ReviewState.APPROVED);
-        assertThat(mapped.submittedAt()).isEqualTo(Instant.parse("2026-01-15T14:30:00Z"));
+        assertThat(mapped.submittedAt()).isEqualTo(instant("2026-01-15T14:30:00Z"));
     }
 
     @Test
     void getPullRequestMapsDismissedReviewState() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        stubReviews(pr, List.of(review("bob", GHPullRequestReviewState.DISMISSED, "2026-01-10T08:00:00Z")));
 
-        GHUser user = mock(GHUser.class);
-        GHPullRequestReview review = spyReview(user, "bob", GHPullRequestReviewState.DISMISSED, "2026-01-10T08:00:00Z");
-        stubReviews(pr, List.of(review));
-
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.reviews()).hasSize(1);
         assertThat(result.reviews().get(0).state()).isEqualTo(GitHubPullRequestReview.ReviewState.DISMISSED);
     }
 
     @Test
     void getPullRequestMapsDeprecatedRequestChangesAlias() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
-
-        GHUser user = mock(GHUser.class);
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         @SuppressWarnings("deprecation")
         GHPullRequestReviewState requestChanges = GHPullRequestReviewState.REQUEST_CHANGES;
-        GHPullRequestReview review = spyReview(user, "carol", requestChanges, "2026-01-12T09:00:00Z");
-        stubReviews(pr, List.of(review));
+        stubReviews(pr, List.of(review("carol", requestChanges, "2026-01-12T09:00:00Z")));
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then
         assertThat(result.reviews()).hasSize(1);
         assertThat(result.reviews().get(0).state()).isEqualTo(GitHubPullRequestReview.ReviewState.CHANGES_REQUESTED);
     }
 
     @Test
     void getPullRequestSkipsReviewsForClosedPr() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "closed");
-        // no stubEmptyReviews — listReviews must not be called for closed PRs
+        GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.CLOSED);
+        when(pr.getMergeable()).thenReturn(false);
+        when(pr.getMergeableState()).thenReturn("dirty");
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then — no GitHub API call to /reviews is made
+        verify(pr, never()).getRequestedTeams();
         verify(pr, never()).listReviews();
         assertThat(result.reviews()).isEmpty();
         assertThat(result.requestedTeamReviewerLogins()).isEmpty();
@@ -426,20 +318,14 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestSkipsReviewsForMergedPr() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "closed");
-        setMergedAtRaw(pr, "2026-01-15T10:00:00Z");
-        // no stubEmptyReviews — listReviews must not be called for merged PRs
+        GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.CLOSED);
+        when(pr.getMergedAt()).thenReturn(date("2026-01-15T10:00:00Z"));
+        when(pr.getMergeable()).thenReturn(true);
+        when(pr.getMergeableState()).thenReturn("clean");
 
-        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
-        // then — no GitHub API call to /reviews is made
+        verify(pr, never()).getRequestedTeams();
         verify(pr, never()).listReviews();
         assertThat(result.reviews()).isEmpty();
         assertThat(result.requestedTeamReviewerLogins()).isEmpty();
@@ -447,16 +333,9 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnRequestedTeamsIOException() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        doThrow(new IOException("teams API failed")).when(pr).getRequestedTeams();
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        when(pr.getRequestedTeams()).thenThrow(new IOException("teams API failed"));
 
-        // when / then — IOException from team-member resolution propagates so callers can skip the PR
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("my-org/my-repo#42");
@@ -464,21 +343,13 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnReviewsIOException() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
 
         @SuppressWarnings("unchecked")
         PagedIterable<GHPullRequestReview> iterable = mock(PagedIterable.class);
-        doReturn(iterable).when(pr).listReviews();
+        when(pr.listReviews()).thenReturn(iterable);
         when(iterable.toList()).thenThrow(new IOException("Connection refused"));
 
-        // when / then — IOException propagates as GitHubApiException so callers can skip the PR
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("my-org/my-repo");
@@ -486,22 +357,13 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnNullReviewUser() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
-
-        GHPullRequestReview review = spy(new GHPullRequestReview());
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        GHPullRequestReview review = mock(GHPullRequestReview.class);
         when(review.getUser()).thenReturn(null);
         when(review.getState()).thenReturn(GHPullRequestReviewState.APPROVED);
-        when(review.getSubmittedAt()).thenReturn(Date.from(Instant.parse("2026-01-10T08:00:00Z")));
+        doReturn(date("2026-01-10T08:00:00Z")).when(review).getSubmittedAt();
         stubReviews(pr, List.of(review));
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("null user");
@@ -509,24 +371,11 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnNullReviewSubmittedAt() throws IOException {
-        // given
-        GHRepository repo = mock(GHRepository.class);
-        GHPullRequest pr = spy(new GHPullRequest());
-        when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
-        when(repo.getPullRequest(42)).thenReturn(pr);
-        setCreatedAtRaw(pr, "2026-01-01T00:00:00Z");
-        setStateRaw(pr, "open");
-        setRequestedTeamsRaw(pr);
-
-        GHUser user = mock(GHUser.class);
-        GHPullRequestReview review = spy(new GHPullRequestReview());
-        when(review.getUser()).thenReturn(user);
-        when(user.getLogin()).thenReturn("alice");
-        when(review.getState()).thenReturn(GHPullRequestReviewState.APPROVED);
-        when(review.getSubmittedAt()).thenReturn(null);
+        GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        GHPullRequestReview review = review("alice", GHPullRequestReviewState.APPROVED, "2026-01-10T08:00:00Z");
+        doReturn(null).when(review).getSubmittedAt();
         stubReviews(pr, List.of(review));
 
-        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("null submitted_at");
@@ -534,7 +383,6 @@ class Hub4jGitHubClientTest {
 
     @Test
     void resolveTeamReviewersReturnsLogins() throws IOException {
-        // given
         GHOrganization org = mock(GHOrganization.class);
         GHTeam team = mock(GHTeam.class);
         when(gitHub.getOrganization("my-org")).thenReturn(org);
@@ -550,19 +398,15 @@ class Hub4jGitHubClientTest {
         when(team.listMembers()).thenReturn(iterable);
         when(iterable.toList()).thenReturn(List.of(alice, bob));
 
-        // when
         List<String> result = client.resolveTeamReviewers("my-org", "platform-team");
 
-        // then
         assertThat(result).containsExactly("alice", "bob");
     }
 
     @Test
     void resolveTeamReviewersWraps404() throws IOException {
-        // given
         when(gitHub.getOrganization("my-org")).thenThrow(new GHFileNotFoundException("Not Found"));
 
-        // when / then
         assertThatThrownBy(() -> client.resolveTeamReviewers("my-org", "platform-team"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -571,10 +415,8 @@ class Hub4jGitHubClientTest {
 
     @Test
     void resolveTeamReviewersWrapsHttpException() throws IOException {
-        // given
         when(gitHub.getOrganization("my-org")).thenThrow(new HttpException(403, "Forbidden", (String) null, null));
 
-        // when / then
         assertThatThrownBy(() -> client.resolveTeamReviewers("my-org", "platform-team"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -583,10 +425,8 @@ class Hub4jGitHubClientTest {
 
     @Test
     void resolveTeamReviewersWrapsIOException() throws IOException {
-        // given
         when(gitHub.getOrganization("my-org")).thenThrow(new IOException("Connection refused"));
 
-        // when / then
         assertThatThrownBy(() -> client.resolveTeamReviewers("my-org", "platform-team"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -594,77 +434,50 @@ class Hub4jGitHubClientTest {
                 .hasMessageContaining("my-org/platform-team");
     }
 
-    /**
-     * Creates a spy on a real GHPullRequestReview and stubs the methods we need.
-     * We use spy instead of mock because GHObject.getId() has @WithBridgeMethods
-     * which generates bridge methods that are incompatible with Mockito mock stubbing.
-     */
-    private static GHPullRequestReview spyReview(
-            GHUser user, String login, GHPullRequestReviewState state, String submittedAtIso) throws IOException {
-        GHPullRequestReview review = spy(new GHPullRequestReview());
+    private GHPullRequest stubOpenPullRequest(String repositoryName, int pullNumber) throws IOException {
+        GHPullRequest pr =
+                stubPullRequest(repositoryName, pullNumber, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
+        when(pr.getMergeable()).thenReturn(true);
+        when(pr.getMergeableState()).thenReturn("clean");
+        when(pr.getRequestedTeams()).thenReturn(List.of());
+        return pr;
+    }
+
+    private GHPullRequest stubPullRequest(
+            String repositoryName, int pullNumber, @Nullable Instant createdAt, GHIssueState state) throws IOException {
+        GHRepository repo = mock(GHRepository.class);
+        GHPullRequest pr = mock(GHPullRequest.class);
+        when(gitHub.getRepository(repositoryName)).thenReturn(repo);
+        when(repo.getPullRequest(pullNumber)).thenReturn(pr);
+        doReturn(createdAt == null ? null : Date.from(createdAt)).when(pr).getCreatedAt();
+        when(pr.getState()).thenReturn(state);
+        when(pr.getMergedAt()).thenReturn(null);
+        return pr;
+    }
+
+    private static GHPullRequestReview review(String login, GHPullRequestReviewState state, String submittedAtIso)
+            throws IOException {
+        GHPullRequestReview review = mock(GHPullRequestReview.class);
+        GHUser user = mock(GHUser.class);
         when(review.getUser()).thenReturn(user);
         when(user.getLogin()).thenReturn(login);
         when(review.getState()).thenReturn(state);
-        when(review.getSubmittedAt()).thenReturn(Date.from(Instant.parse(submittedAtIso)));
+        doReturn(date(submittedAtIso)).when(review).getSubmittedAt();
         return review;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void stubEmptyReviews(GHPullRequest pr) throws IOException {
-        PagedIterable<GHPullRequestReview> iterable = mock(PagedIterable.class);
-        doReturn(iterable).when(pr).listReviews();
-        when(iterable.toList()).thenReturn(List.of());
     }
 
     @SuppressWarnings("unchecked")
     private static void stubReviews(GHPullRequest pr, List<GHPullRequestReview> reviews) throws IOException {
         PagedIterable<GHPullRequestReview> iterable = mock(PagedIterable.class);
-        doReturn(iterable).when(pr).listReviews();
+        when(pr.listReviews()).thenReturn(iterable);
         when(iterable.toList()).thenReturn(reviews);
     }
 
-    private static void setCreatedAtRaw(GHPullRequest pr, String createdAtRaw) {
-        setFieldOnClassHierarchy(pr, "createdAt", createdAtRaw);
+    private static Instant instant(String iso) {
+        return Instant.parse(iso);
     }
 
-    private static void setStateRaw(GHPullRequest pr, @Nullable String stateRaw) {
-        setFieldOnClassHierarchy(pr, "state", stateRaw);
-    }
-
-    private static void setMergedAtRaw(GHPullRequest pr, @Nullable String mergedAtRaw) {
-        setFieldOnClassHierarchy(pr, "merged_at", mergedAtRaw);
-    }
-
-    private static void setMergeableRaw(GHPullRequest pr, @Nullable Boolean mergeable) {
-        setFieldOnClassHierarchy(pr, "mergeable", mergeable);
-    }
-
-    private static void setMergeableStateRaw(GHPullRequest pr, @Nullable String mergeableState) {
-        setFieldOnClassHierarchy(pr, "mergeable_state", mergeableState);
-    }
-
-    private static void setRequestedTeamsRaw(GHPullRequest pr) {
-        setFieldOnClassHierarchy(pr, "requested_teams", new GHTeam[0]);
-    }
-
-    private static void setFieldOnClassHierarchy(Object target, String fieldName, @Nullable Object value) {
-        try {
-            Class<?> type = target.getClass();
-            Field field = null;
-            while (type != null && field == null) {
-                try {
-                    field = type.getDeclaredField(fieldName);
-                } catch (NoSuchFieldException ignored) {
-                    type = type.getSuperclass();
-                }
-            }
-            if (field == null) {
-                throw new NoSuchFieldException(fieldName);
-            }
-            field.setAccessible(true);
-            field.set(target, value);
-        } catch (ReflectiveOperationException e) {
-            throw new LinkageError("Failed to set %s on GHPullRequest test object".formatted(fieldName), e);
-        }
+    private static Date date(String iso) {
+        return Date.from(instant(iso));
     }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
@@ -36,14 +36,17 @@ class Hub4jGitHubClientTest {
 
     @Test
     void returnsPullRequestOnHappyPath() throws IOException {
+        // given
         GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
         when(pr.getMergeable()).thenReturn(true);
         when(pr.getMergeableState()).thenReturn("clean");
         when(pr.getRequestedTeams()).thenReturn(List.of());
         stubReviews(pr, List.of());
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.repositoryName()).isEqualTo("my-org/my-repo");
         assertThat(result.pullRequestNumber()).isEqualTo(42);
         assertThat(result.createdAt()).isEqualTo(instant("2026-01-01T00:00:00Z"));
@@ -54,13 +57,16 @@ class Hub4jGitHubClientTest {
 
     @Test
     void returnsMergedStateWhenMergedAtIsNonNull() throws IOException {
+        // given
         GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.CLOSED);
         when(pr.getMergedAt()).thenReturn(date("2026-01-15T10:00:00Z"));
         when(pr.getMergeable()).thenReturn(true);
         when(pr.getMergeableState()).thenReturn("clean");
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.state()).isEqualTo(GitHubPullRequest.PrState.MERGED);
         verify(pr, never()).getRequestedTeams();
         verify(pr, never()).listReviews();
@@ -68,22 +74,27 @@ class Hub4jGitHubClientTest {
 
     @Test
     void returnsPullRequestWithNullMergeableWhenNotYetComputed() throws IOException {
+        // given
         GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
         when(pr.getMergeable()).thenReturn(null);
         when(pr.getMergeableState()).thenReturn(null);
         when(pr.getRequestedTeams()).thenReturn(List.of());
         stubReviews(pr, List.of());
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.mergeable()).isNull();
         assertThat(result.mergeableState()).isNull();
     }
 
     @Test
     void wrapsNullCreatedAtAsGitHubApiException() throws IOException {
+        // given
         stubPullRequest("my-org/my-repo", 42, null, GHIssueState.OPEN);
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -93,9 +104,11 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsNullStateAsGitHubApiException() throws IOException {
+        // given
         GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
         when(pr.getState()).thenReturn(null);
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -105,8 +118,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsNotFoundAsGitHubApiException() throws IOException {
+        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new GHFileNotFoundException("Not Found"));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 999))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -116,9 +131,11 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsHttpErrorAsGitHubApiException() throws IOException {
+        // given
         when(gitHub.getRepository("my-org/my-repo"))
                 .thenThrow(new HttpException(401, "Unauthorized", (String) null, null));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 1))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -128,8 +145,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void wrapsIOExceptionAsGitHubApiException() throws IOException {
+        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new IOException("Connection refused"));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 1))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -139,36 +158,44 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getFileContentReturnsDecodedContent() throws IOException {
+        // given
         GHRepository repo = mock(GHRepository.class);
         GHContent ghContent = mock(GHContent.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenReturn(ghContent);
         when(ghContent.getContent()).thenReturn("default: 48h");
 
+        // when
         String result = client.getFileContent("my-org/my-repo", ".pr-sla.yaml");
 
+        // then
         assertThat(result).isEqualTo("default: 48h");
     }
 
     @Test
     void getFileContentReturnsNullOn404() throws IOException {
+        // given
         GHRepository repo = mock(GHRepository.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenThrow(new GHFileNotFoundException("Not Found"));
 
+        // when
         String result = client.getFileContent("my-org/my-repo", ".pr-sla.yaml");
 
+        // then
         assertThat(result).isNull();
     }
 
     @Test
     void getFileContentThrowsOnNullContent() throws IOException {
+        // given
         GHRepository repo = mock(GHRepository.class);
         GHContent ghContent = mock(GHContent.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenReturn(ghContent);
         when(ghContent.getContent()).thenReturn(null);
 
+        // when / then
         assertThatThrownBy(() -> client.getFileContent("my-org/my-repo", ".pr-sla.yaml"))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("null content")
@@ -177,10 +204,12 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getFileContentWrapsHttpException() throws IOException {
+        // given
         GHRepository repo = mock(GHRepository.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenThrow(new HttpException(403, "Forbidden", (String) null, null));
 
+        // when / then
         assertThatThrownBy(() -> client.getFileContent("my-org/my-repo", ".pr-sla.yaml"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -189,10 +218,12 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getFileContentWrapsIOException() throws IOException {
+        // given
         GHRepository repo = mock(GHRepository.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
         when(repo.getFileContent(".pr-sla.yaml")).thenThrow(new IOException("Connection refused"));
 
+        // when / then
         assertThatThrownBy(() -> client.getFileContent("my-org/my-repo", ".pr-sla.yaml"))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining(".pr-sla.yaml");
@@ -200,6 +231,7 @@ class Hub4jGitHubClientTest {
 
     @Test
     void listPullRequestFilesReturnsFileNames() throws IOException {
+        // given
         GHRepository repo = mock(GHRepository.class);
         GHPullRequest pr = mock(GHPullRequest.class);
         when(gitHub.getRepository("my-org/my-repo")).thenReturn(repo);
@@ -215,15 +247,19 @@ class Hub4jGitHubClientTest {
         when(pr.listFiles()).thenReturn(iterable);
         when(iterable.toList()).thenReturn(List.of(file1, file2));
 
+        // when
         List<String> result = client.listPullRequestFiles("my-org/my-repo", 42);
 
+        // then
         assertThat(result).containsExactly("src/Main.java", "docs/README.md");
     }
 
     @Test
     void listPullRequestFilesWraps404() throws IOException {
+        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new GHFileNotFoundException("Not Found"));
 
+        // when / then
         assertThatThrownBy(() -> client.listPullRequestFiles("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -232,9 +268,11 @@ class Hub4jGitHubClientTest {
 
     @Test
     void listPullRequestFilesWrapsHttpException() throws IOException {
+        // given
         when(gitHub.getRepository("my-org/my-repo"))
                 .thenThrow(new HttpException(500, "Internal Server Error", (String) null, null));
 
+        // when / then
         assertThatThrownBy(() -> client.listPullRequestFiles("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -243,8 +281,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void listPullRequestFilesWrapsIOException() throws IOException {
+        // given
         when(gitHub.getRepository("my-org/my-repo")).thenThrow(new IOException("Connection refused"));
 
+        // when / then
         assertThatThrownBy(() -> client.listPullRequestFiles("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("my-org/my-repo#42");
@@ -252,13 +292,16 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestFiltersOutPendingReviews() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         GHPullRequestReview approvedReview = review("alice", GHPullRequestReviewState.APPROVED, "2026-01-02T10:00:00Z");
         GHPullRequestReview pendingReview = review("bob", GHPullRequestReviewState.PENDING, "2026-01-02T11:00:00Z");
         stubReviews(pr, List.of(approvedReview, pendingReview));
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.reviews()).hasSize(1);
         assertThat(result.reviews().get(0).userLogin()).isEqualTo("alice");
         assertThat(result.reviews().get(0).state()).isEqualTo(GitHubPullRequestReview.ReviewState.APPROVED);
@@ -266,11 +309,14 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestMapsApprovedReviewCorrectly() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         stubReviews(pr, List.of(review("alice", GHPullRequestReviewState.APPROVED, "2026-01-15T14:30:00Z")));
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.reviews()).hasSize(1);
         GitHubPullRequestReview mapped = result.reviews().get(0);
         assertThat(mapped.userLogin()).isEqualTo("alice");
@@ -280,36 +326,45 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestMapsDismissedReviewState() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         stubReviews(pr, List.of(review("bob", GHPullRequestReviewState.DISMISSED, "2026-01-10T08:00:00Z")));
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.reviews()).hasSize(1);
         assertThat(result.reviews().get(0).state()).isEqualTo(GitHubPullRequestReview.ReviewState.DISMISSED);
     }
 
     @Test
     void getPullRequestMapsDeprecatedRequestChangesAlias() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         @SuppressWarnings("deprecation")
         GHPullRequestReviewState requestChanges = GHPullRequestReviewState.REQUEST_CHANGES;
         stubReviews(pr, List.of(review("carol", requestChanges, "2026-01-12T09:00:00Z")));
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         assertThat(result.reviews()).hasSize(1);
         assertThat(result.reviews().get(0).state()).isEqualTo(GitHubPullRequestReview.ReviewState.CHANGES_REQUESTED);
     }
 
     @Test
     void getPullRequestSkipsReviewsForClosedPr() throws IOException {
+        // given
         GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.CLOSED);
         when(pr.getMergeable()).thenReturn(false);
         when(pr.getMergeableState()).thenReturn("dirty");
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         verify(pr, never()).getRequestedTeams();
         verify(pr, never()).listReviews();
         assertThat(result.reviews()).isEmpty();
@@ -318,13 +373,16 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestSkipsReviewsForMergedPr() throws IOException {
+        // given
         GHPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.CLOSED);
         when(pr.getMergedAt()).thenReturn(date("2026-01-15T10:00:00Z"));
         when(pr.getMergeable()).thenReturn(true);
         when(pr.getMergeableState()).thenReturn("clean");
 
+        // when
         GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
 
+        // then
         verify(pr, never()).getRequestedTeams();
         verify(pr, never()).listReviews();
         assertThat(result.reviews()).isEmpty();
@@ -333,9 +391,11 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnRequestedTeamsIOException() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         when(pr.getRequestedTeams()).thenThrow(new IOException("teams API failed"));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("my-org/my-repo#42");
@@ -343,6 +403,7 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnReviewsIOException() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
 
         @SuppressWarnings("unchecked")
@@ -350,6 +411,7 @@ class Hub4jGitHubClientTest {
         when(pr.listReviews()).thenReturn(iterable);
         when(iterable.toList()).thenThrow(new IOException("Connection refused"));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("my-org/my-repo");
@@ -357,6 +419,7 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnNullReviewUser() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         GHPullRequestReview review = mock(GHPullRequestReview.class);
         when(review.getUser()).thenReturn(null);
@@ -364,6 +427,7 @@ class Hub4jGitHubClientTest {
         doReturn(date("2026-01-10T08:00:00Z")).when(review).getSubmittedAt();
         stubReviews(pr, List.of(review));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("null user");
@@ -371,11 +435,13 @@ class Hub4jGitHubClientTest {
 
     @Test
     void getPullRequestThrowsOnNullReviewSubmittedAt() throws IOException {
+        // given
         GHPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
         GHPullRequestReview review = review("alice", GHPullRequestReviewState.APPROVED, "2026-01-10T08:00:00Z");
         doReturn(null).when(review).getSubmittedAt();
         stubReviews(pr, List.of(review));
 
+        // when / then
         assertThatThrownBy(() -> client.getPullRequest("my-org/my-repo", 42))
                 .isInstanceOf(GitHubApiException.class)
                 .hasMessageContaining("null submitted_at");
@@ -383,6 +449,7 @@ class Hub4jGitHubClientTest {
 
     @Test
     void resolveTeamReviewersReturnsLogins() throws IOException {
+        // given
         GHOrganization org = mock(GHOrganization.class);
         GHTeam team = mock(GHTeam.class);
         when(gitHub.getOrganization("my-org")).thenReturn(org);
@@ -398,15 +465,19 @@ class Hub4jGitHubClientTest {
         when(team.listMembers()).thenReturn(iterable);
         when(iterable.toList()).thenReturn(List.of(alice, bob));
 
+        // when
         List<String> result = client.resolveTeamReviewers("my-org", "platform-team");
 
+        // then
         assertThat(result).containsExactly("alice", "bob");
     }
 
     @Test
     void resolveTeamReviewersWraps404() throws IOException {
+        // given
         when(gitHub.getOrganization("my-org")).thenThrow(new GHFileNotFoundException("Not Found"));
 
+        // when / then
         assertThatThrownBy(() -> client.resolveTeamReviewers("my-org", "platform-team"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -415,8 +486,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void resolveTeamReviewersWrapsHttpException() throws IOException {
+        // given
         when(gitHub.getOrganization("my-org")).thenThrow(new HttpException(403, "Forbidden", (String) null, null));
 
+        // when / then
         assertThatThrownBy(() -> client.resolveTeamReviewers("my-org", "platform-team"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(
@@ -425,8 +498,10 @@ class Hub4jGitHubClientTest {
 
     @Test
     void resolveTeamReviewersWrapsIOException() throws IOException {
+        // given
         when(gitHub.getOrganization("my-org")).thenThrow(new IOException("Connection refused"));
 
+        // when / then
         assertThatThrownBy(() -> client.resolveTeamReviewers("my-org", "platform-team"))
                 .isInstanceOf(GitHubApiException.class)
                 .satisfies(


### PR DESCRIPTION
## Summary
Rewrite Hub4jGitHubClientTest to stop spying on real Hub4j objects and stop mutating Hub4j internals by reflection.
Stub only the Hub4j methods that Hub4jGitHubClient actually uses, including bridge-affected accessors via safer Mockito patterns.
Keep the existing coverage for happy paths, review mapping, skipped review loading for closed PRs, and exception wrapping while removing the CI-flaky setup.
