### PR TITLE
fix(ticket): handle bot message events to update lastInteractedAt

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/slack/events/MessagePosted.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/slack/events/MessagePosted.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.coreeng.supportbot.slack.MessageRef;
 import com.coreeng.supportbot.slack.MessageTs;
 import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.model.event.MessageBotEvent;
 import com.slack.api.model.event.MessageEvent;
 
 public record MessagePosted(String message, String userId, MessageRef messageRef) implements SlackEvent {
@@ -18,6 +19,16 @@ public record MessagePosted(String message, String userId, MessageRef messageRef
         return new MessagePosted(
                 event.getEvent().getText(),
                 event.getEvent().getUser(),
+                new MessageRef(
+                        MessageTs.of(event.getEvent().getTs()),
+                        MessageTs.ofOrNull(event.getEvent().getThreadTs()),
+                        event.getEvent().getChannel()));
+    }
+
+    public static MessagePosted fromBotMessageEvent(EventsApiPayload<MessageBotEvent> event) {
+        return new MessagePosted(
+                event.getEvent().getText(),
+                event.getEvent().getBotId(),
                 new MessageRef(
                         MessageTs.of(event.getEvent().getTs()),
                         MessageTs.ofOrNull(event.getEvent().getThreadTs()),

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/handler/BotMessagePostedHandler.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/handler/BotMessagePostedHandler.java
@@ -1,0 +1,26 @@
+package com.coreeng.supportbot.ticket.handler;
+
+import com.coreeng.supportbot.slack.SlackEventHandler;
+import com.coreeng.supportbot.slack.events.MessagePosted;
+import com.coreeng.supportbot.ticket.TicketProcessingService;
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.bolt.context.builtin.EventContext;
+import com.slack.api.model.event.MessageBotEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BotMessagePostedHandler implements SlackEventHandler<MessageBotEvent> {
+    private final TicketProcessingService ticketProcessingService;
+
+    @Override
+    public Class<MessageBotEvent> getEventClass() {
+        return MessageBotEvent.class;
+    }
+
+    @Override
+    public void apply(EventsApiPayload<MessageBotEvent> event, EventContext context) {
+        ticketProcessingService.handleMessagePosted(MessagePosted.fromBotMessageEvent(event));
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/TicketProcessingServiceTests.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/TicketProcessingServiceTests.java
@@ -687,6 +687,25 @@ public class TicketProcessingServiceTests {
         assertEquals(lastMessageTime, closedAt, "Closed-at must equal the last thread message time");
     }
 
+    @Test
+    public void shouldTouchTicketOnBotThreadReply() {
+        // given — ticket exists
+        Ticket ticket = createTrackedTicket();
+        TicketId ticketId = requireNonNull(ticket.id());
+        Instant initialLastInteracted = ticket.lastInteractedAt();
+
+        // when — a bot message is posted as a thread reply (same shape as a normal message)
+        MessageRef replyRef = new MessageRef(MessageTs.of("bot-reply-ts"), MESSAGE_TS, slackTicketsProps.channelId());
+        ticketProcessingService.handleMessagePosted(new MessagePosted("bot reply", "B_BOT_ID", replyRef));
+
+        // then — lastInteractedAt is updated beyond the initial value
+        Ticket updated = ticketRepository.findTicketById(ticketId);
+        assertNotNull(updated);
+        assertTrue(
+                !updated.lastInteractedAt().isBefore(initialLastInteracted),
+                "lastInteractedAt should be updated after bot thread reply");
+    }
+
     private TicketProcessingService serviceWithPrDetection() {
         return new TicketProcessingService(
                 ticketRepository,


### PR DESCRIPTION
Messages posted via Slack bot API (e.g. from demo-data-generator) arrive as MessageBotEvent instead of MessageEvent. These were silently ignored, causing lastInteractedAt to never update for bot thread replies. When the ticket was later closed, the resolution time was calculated from the creation time, resulting in near-zero durations.

Add BotMessagePostedHandler to process MessageBotEvent and delegate to the existing handleMessagePosted flow, and add a fromBotMessageEvent factory on MessagePosted.