### PR TITLE
fix(api): add atomic ticket rating submission

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/rating/RatingService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/rating/RatingService.java
@@ -4,12 +4,12 @@ import com.coreeng.supportbot.escalation.EscalationQueryService;
 import com.coreeng.supportbot.ticket.Ticket;
 import com.coreeng.supportbot.ticket.TicketId;
 import com.coreeng.supportbot.ticket.TicketRepository;
+import com.coreeng.supportbot.ticket.TicketStatus;
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,19 +23,25 @@ public class RatingService {
     private final EscalationQueryService escalationQueryService;
 
     @Transactional
-    @Nullable public Rating save(TicketId ticketId, int rating) {
+    public Rating save(TicketId ticketId, int rating) {
         log.info("Attempt to submit rating for ticket {}", ticketId);
 
-        if (ticketRepository.isTicketRated(ticketId)) {
-            log.info("Ticket {} has already been rated - ignoring duplicate", ticketId);
-            return null;
+        if (rating < 1 || rating > 5) {
+            throw new IllegalArgumentException("rating must be between 1 and 5");
         }
-
-        // Fetch ticket details for impact and tags
+        if (!ticketRepository.tryMarkTicketAsRated(ticketId)) {
+            Ticket ticket = ticketRepository.findTicketById(ticketId);
+            if (ticket == null) {
+                throw new RatingTicketNotFoundException(ticketId);
+            }
+            if (ticket.status() != TicketStatus.closed) {
+                throw new IllegalArgumentException("Ticket must be closed before rating can be submitted");
+            }
+            throw new IllegalArgumentException("Ticket has already been rated");
+        }
         Ticket ticket = ticketRepository.findTicketById(ticketId);
         if (ticket == null) {
-            log.warn("Ticket {} for rating not found", ticketId);
-            return null;
+            throw new IllegalStateException("Ticket not found after rating claim: " + ticketId.render());
         }
 
         boolean isEscalated = escalationQueryService.existsByTicketId(ticketId);
@@ -51,7 +57,6 @@ public class RatingService {
                 .build();
 
         UUID ratingId = repository.insertRating(ratingRecord);
-        ticketRepository.markTicketAsRated(ticketId);
 
         log.info("Successfully recorded rating for ticket {}", ticketId);
         return ratingRecord.toBuilder().id(ratingId).build();

--- a/api/service/src/main/java/com/coreeng/supportbot/rating/RatingTicketNotFoundException.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/rating/RatingTicketNotFoundException.java
@@ -1,0 +1,9 @@
+package com.coreeng.supportbot.rating;
+
+import com.coreeng.supportbot.ticket.TicketId;
+
+public class RatingTicketNotFoundException extends RuntimeException {
+    public RatingTicketNotFoundException(TicketId ticketId) {
+        super("Ticket not found: " + ticketId.render());
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/rating/handler/RatingActionHandler.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/rating/handler/RatingActionHandler.java
@@ -4,6 +4,7 @@ import com.coreeng.supportbot.rating.Rating;
 import com.coreeng.supportbot.rating.RatingButtonInput;
 import com.coreeng.supportbot.rating.RatingRequestMessageMapper;
 import com.coreeng.supportbot.rating.RatingService;
+import com.coreeng.supportbot.rating.RatingTicketNotFoundException;
 import com.coreeng.supportbot.slack.MessageRef;
 import com.coreeng.supportbot.slack.SlackBlockActionHandler;
 import com.coreeng.supportbot.slack.client.SimpleSlackMessage;
@@ -51,9 +52,11 @@ public class RatingActionHandler implements SlackBlockActionHandler {
 
     private void handleRatingSubmission(BlockActionPayload.Action action, BlockActionPayload payload) {
         RatingButtonInput input = mapper.parseButtonInput(action.getValue());
-        Rating rating = service.save(input.ticketId(), input.rating());
-        if (rating != null) {
+        try {
+            Rating rating = service.save(input.ticketId(), input.rating());
             sendConfirmationReply(rating, MessageRef.from(payload));
+        } catch (IllegalArgumentException | RatingTicketNotFoundException e) {
+            log.warn("Ignoring invalid rating submission for ticket {}: {}", input.ticketId(), e.getMessage());
         }
     }
 

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/JdbcTicketRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/JdbcTicketRepository.java
@@ -553,21 +553,14 @@ public class JdbcTicketRepository implements TicketRepository {
     }
 
     @Override
-    public boolean isTicketRated(TicketId ticketId) {
-        return dsl.select(TICKET.RATING_SUBMITTED)
-                .from(TICKET)
-                .where(TICKET.ID.eq(ticketId.id()))
-                .fetchOptional()
-                .map(r -> r.get(TICKET.RATING_SUBMITTED))
-                .orElse(false);
-    }
-
-    @Override
-    public void markTicketAsRated(TicketId ticketId) {
-        dsl.update(TICKET)
-                .set(TICKET.RATING_SUBMITTED, true)
-                .where(TICKET.ID.eq(ticketId.id()))
-                .execute();
+    public boolean tryMarkTicketAsRated(TicketId ticketId) {
+        return dsl.update(TICKET)
+                        .set(TICKET.RATING_SUBMITTED, true)
+                        .where(TICKET.ID.eq(ticketId.id()))
+                        .and(TICKET.RATING_SUBMITTED.isFalse())
+                        .and(TICKET.STATUS.eq(com.coreeng.supportbot.dbschema.enums.TicketStatus.closed))
+                        .execute()
+                == 1;
     }
 
     @Nullable private String toDbTeam(@Nullable TicketTeam team) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketInMemoryRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketInMemoryRepository.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
@@ -262,16 +263,17 @@ public class TicketInMemoryRepository implements TicketRepository {
     }
 
     @Override
-    public boolean isTicketRated(TicketId ticketId) {
-        Ticket ticket = tickets.get(ticketId);
-        return ticket != null && ticket.ratingSubmitted();
-    }
-
-    @Override
-    public void markTicketAsRated(TicketId ticketId) {
-        Ticket ticket = tickets.get(ticketId);
-        if (ticket != null) {
-            tickets.put(ticketId, ticket.toBuilder().ratingSubmitted(true).build());
-        }
+    public boolean tryMarkTicketAsRated(TicketId ticketId) {
+        AtomicBoolean claimed = new AtomicBoolean(false);
+        tickets.computeIfPresent(ticketId, (id, ticket) -> {
+            if (ticket.ratingSubmitted() || ticket.status() != TicketStatus.closed) {
+                return ticket;
+            }
+            claimed.set(true);
+            Ticket updated = ticket.toBuilder().ratingSubmitted(true).build();
+            ticketsByQuery.put(ticket.queryRef(), updated);
+            return updated;
+        });
+        return claimed.get();
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketRepository.java
@@ -32,9 +32,7 @@ public interface TicketRepository {
 
     ImmutableList<TicketId> listStaleTicketIdsToRemindOf(Instant checkAt, Duration reminderInterval);
 
-    boolean isTicketRated(TicketId ticketId);
-
-    void markTicketAsRated(TicketId ticketId);
+    boolean tryMarkTicketAsRated(TicketId ticketId);
 
     boolean assign(TicketId ticketId, String slackUserId);
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketController.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketController.java
@@ -1,5 +1,7 @@
 package com.coreeng.supportbot.ticket.rest;
 
+import com.coreeng.supportbot.rating.RatingService;
+import com.coreeng.supportbot.rating.RatingTicketNotFoundException;
 import com.coreeng.supportbot.ticket.*;
 import com.coreeng.supportbot.util.Page;
 import com.google.common.collect.ImmutableList;
@@ -19,6 +21,7 @@ public class TicketController {
     private final TicketUpdateService ticketUpdateService;
     private final TicketProcessingService ticketProcessingService;
     private final TicketEscalationValidator ticketEscalationValidator;
+    private final RatingService ratingService;
     private final TicketUIMapper mapper;
     private final TicketTeamSuggestionsService teamSuggestionsService;
 
@@ -76,6 +79,21 @@ public class TicketController {
             TicketUI ticket = ticketUpdateService.update(id, request);
             return ResponseEntity.ok(ticket);
         } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/{id}/rating")
+    public ResponseEntity<?> submitRating(@PathVariable TicketId id, @RequestBody TicketRatingRequest request) {
+        try {
+            if (request.rating() == null) {
+                throw new IllegalArgumentException("rating is required");
+            }
+            ratingService.save(id, request.rating());
+            return ResponseEntity.ok().build();
+        } catch (RatingTicketNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketRatingRequest.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketRatingRequest.java
@@ -1,0 +1,5 @@
+package com.coreeng.supportbot.ticket.rest;
+
+import org.jspecify.annotations.Nullable;
+
+public record TicketRatingRequest(@Nullable Integer rating) {}

--- a/api/service/src/test/java/com/coreeng/supportbot/rating/RatingServiceSaveTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/rating/RatingServiceSaveTest.java
@@ -2,6 +2,7 @@ package com.coreeng.supportbot.rating;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.coreeng.supportbot.escalation.EscalationQueryService;
@@ -37,7 +38,7 @@ class RatingServiceSaveTest {
     }
 
     @Test
-    void returnsNull_whenTicketAlreadyRated() {
+    void rejects_whenTicketAlreadyRated() {
         Ticket ticket = Ticket.builder()
                 .channelId("C123")
                 .queryTs(MessageTs.of("111.222"))
@@ -45,21 +46,57 @@ class RatingServiceSaveTest {
                 .build();
         Ticket created = ticketRepository.createTicketIfNotExists(ticket);
         TicketId createdId = requireNonNull(created.id());
-        ticketRepository.markTicketAsRated(createdId);
+        assertThat(ticketRepository.tryMarkTicketAsRated(createdId)).isTrue();
 
-        Rating result = service.save(createdId, 4);
-
-        assertThat(result).isNull();
+        assertThatThrownBy(() -> service.save(createdId, 4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ticket has already been rated");
         assertThat(ratingRepository.size()).isEqualTo(0);
     }
 
     @Test
-    void returnsNull_whenTicketNotFound() {
+    void rejects_whenTicketNotFound() {
         TicketId missing = new TicketId(99_999);
 
-        Rating result = service.save(missing, 5);
+        assertThatThrownBy(() -> service.save(missing, 5))
+                .isInstanceOf(RatingTicketNotFoundException.class)
+                .hasMessage("Ticket not found: ID-99999");
+        assertThat(ratingRepository.size()).isEqualTo(0);
+    }
 
-        assertThat(result).isNull();
+    @Test
+    void rejects_whenTicketIsNotClosed() {
+        Ticket ticket = Ticket.builder()
+                .channelId("C123")
+                .queryTs(MessageTs.of("555.666"))
+                .status(TicketStatus.opened)
+                .build();
+        Ticket created = ticketRepository.createTicketIfNotExists(ticket);
+        TicketId createdId = requireNonNull(created.id());
+
+        assertThatThrownBy(() -> service.save(createdId, 4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ticket must be closed before rating can be submitted");
+        assertThat(ratingRepository.size()).isEqualTo(0);
+    }
+
+    @Test
+    void rejects_whenRatingIsBelowRange() {
+        TicketId createdId = createClosedTicket("777.888");
+
+        assertThatThrownBy(() -> service.save(createdId, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rating must be between 1 and 5");
+        assertThat(ratingRepository.size()).isEqualTo(0);
+    }
+
+    @Test
+    void rejects_whenRatingIsAboveRange() {
+        TicketId createdId = createClosedTicket("999.000");
+
+        assertThatThrownBy(() -> service.save(createdId, 6))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rating must be between 1 and 5");
         assertThat(ratingRepository.size()).isEqualTo(0);
     }
 
@@ -96,7 +133,8 @@ class RatingServiceSaveTest {
         assertThat(persisted.tags()).containsExactly("ingress", "api");
         assertThat(persisted.isEscalated()).isFalse();
 
-        assertThat(ticketRepository.isTicketRated(createdId)).isTrue();
+        assertThat(requireNonNull(ticketRepository.findTicketById(createdId)).ratingSubmitted())
+                .isTrue();
     }
 
     @Test
@@ -127,6 +165,32 @@ class RatingServiceSaveTest {
         assertThat(persisted).isNotNull();
         assertThat(persisted.isEscalated()).isTrue();
 
-        assertThat(ticketRepository.isTicketRated(createdId)).isTrue();
+        assertThat(requireNonNull(ticketRepository.findTicketById(createdId)).ratingSubmitted())
+                .isTrue();
+    }
+
+    @Test
+    void rejects_secondSubmissionForSameTicket() {
+        TicketId createdId = createClosedTicket("444.555");
+        when(escalationQueryService.existsByTicketId(createdId)).thenReturn(false);
+
+        Rating first = service.save(createdId, 5);
+
+        assertThat(first).isNotNull();
+        assertThatThrownBy(() -> service.save(createdId, 4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ticket has already been rated");
+        assertThat(ratingRepository.size()).isEqualTo(1);
+        assertThat(requireNonNull(ticketRepository.findTicketById(createdId)).ratingSubmitted())
+                .isTrue();
+    }
+
+    private TicketId createClosedTicket(String queryTs) {
+        Ticket created = ticketRepository.createTicketIfNotExists(Ticket.builder()
+                .channelId("C123")
+                .queryTs(MessageTs.of(queryTs))
+                .status(TicketStatus.closed)
+                .build());
+        return requireNonNull(created.id());
     }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketControllerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketControllerTest.java
@@ -3,7 +3,12 @@ package com.coreeng.supportbot.ticket.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.coreeng.supportbot.rating.RatingService;
+import com.coreeng.supportbot.rating.RatingTicketNotFoundException;
 import com.coreeng.supportbot.slack.MessageTs;
 import com.coreeng.supportbot.ticket.*;
 import com.coreeng.supportbot.util.Page;
@@ -18,8 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @ExtendWith(MockitoExtension.class)
 class TicketControllerTest {
@@ -42,7 +50,11 @@ class TicketControllerTest {
     @Mock
     private TicketEscalationValidator ticketEscalationValidator;
 
+    @Mock
+    private RatingService ratingService;
+
     private TicketController controller;
+    private MockMvc mockMvc;
 
     private TicketId ticketId;
 
@@ -53,13 +65,111 @@ class TicketControllerTest {
                 ticketUpdateService,
                 ticketProcessingService,
                 ticketEscalationValidator,
+                ratingService,
                 mapper,
                 teamSuggestionsService);
+        DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService();
+        conversionService.addFormatter(new TicketIdFormatter());
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setConversionService(conversionService)
+                .build();
         ticketId = new TicketId(123L);
         lenient().when(queryService.findById(ticketId)).thenReturn(mock(Ticket.class));
         lenient()
                 .when(ticketEscalationValidator.validate(any(), any()))
                 .thenReturn(TicketEscalationValidator.ValidationResult.valid());
+    }
+
+    @Test
+    void shouldReturnOkWithEmptyBodyWhenRatingSucceeds() throws Exception {
+        mockMvc.perform(post("/ticket/{id}/rating", ticketId.id())
+                        .contentType("application/json")
+                        .content("""
+                                {"rating":4}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+
+        verify(ratingService).save(ticketId, 4);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenRatingTicketDoesNotExist() throws Exception {
+        doThrow(new RatingTicketNotFoundException(ticketId)).when(ratingService).save(ticketId, 4);
+
+        mockMvc.perform(post("/ticket/{id}/rating", ticketId.id())
+                        .contentType("application/json")
+                        .content("""
+                                {"rating":4}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(""));
+
+        verify(ratingService).save(ticketId, 4);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRatingTicketIsOpened() throws Exception {
+        doThrow(new IllegalArgumentException("Ticket must be closed before rating can be submitted"))
+                .when(ratingService)
+                .save(ticketId, 4);
+
+        mockMvc.perform(post("/ticket/{id}/rating", ticketId.id())
+                        .contentType("application/json")
+                        .content("""
+                                {"rating":4}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Ticket must be closed before rating can be submitted"));
+
+        verify(ratingService).save(ticketId, 4);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRatingAlreadyExists() throws Exception {
+        doThrow(new IllegalArgumentException("Ticket has already been rated"))
+                .when(ratingService)
+                .save(ticketId, 4);
+
+        mockMvc.perform(post("/ticket/{id}/rating", ticketId.id())
+                        .contentType("application/json")
+                        .content("""
+                                {"rating":4}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Ticket has already been rated"));
+
+        verify(ratingService).save(ticketId, 4);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRatingIsInvalid() throws Exception {
+        doThrow(new IllegalArgumentException("rating must be between 1 and 5"))
+                .when(ratingService)
+                .save(ticketId, 0);
+
+        mockMvc.perform(post("/ticket/{id}/rating", ticketId.id())
+                        .contentType("application/json")
+                        .content("""
+                                {"rating":0}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("rating must be between 1 and 5"));
+
+        verify(ratingService).save(ticketId, 0);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRatingIsMissing() throws Exception {
+        mockMvc.perform(post("/ticket/{id}/rating", ticketId.id())
+                        .contentType("application/json")
+                        .content("""
+                                {}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("rating is required"));
+
+        verifyNoInteractions(ratingService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add POST /ticket/{id}/rating with shared service validation and empty 200 response
- move rating submission to an atomic ticket claim via rating_submitted to avoid duplicate-rating races
- keep Slack and REST on the same save path and upgrade controller coverage to MockMvc
