### PR TITLE
chore: add support-bot tenant inputs

### DIFF
--- a/.github/workflows/dex-fast-feedback.yaml
+++ b/.github/workflows/dex-fast-feedback.yaml
@@ -40,5 +40,6 @@ jobs:
         LDAP_BOOTSTRAP_USER_PASSWORD=${{ secrets.LDAP_BOOTSTRAP_USER_PASSWORD }}
     with:
       app-name: dex
+      tenant-name: support-bot
       version: ${{ needs.version.outputs.version }}      
       working-directory: dex

--- a/.github/workflows/ldap-fast-feedback.yaml
+++ b/.github/workflows/ldap-fast-feedback.yaml
@@ -39,5 +39,6 @@ jobs:
         LDAP_BOOTSTRAP_USER_PASSWORD=${{ secrets.LDAP_BOOTSTRAP_USER_PASSWORD }}
     with:
       app-name: ldap
+      tenant-name: support-bot
       version: ${{ needs.version.outputs.version }}
       working-directory: ldap

--- a/.github/workflows/support-bot-extended-test.yaml
+++ b/.github/workflows/support-bot-extended-test.yaml
@@ -14,6 +14,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
     with:
       image-name: support-bot
+      tenant-name: support-bot
 
   extendedtests:
     needs: [get-latest-version]
@@ -22,6 +23,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: support-bot
+      tenant-name: support-bot
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/.github/workflows/support-bot-fast-feedback.yaml
+++ b/.github/workflows/support-bot-fast-feedback.yaml
@@ -46,6 +46,7 @@ jobs:
         LDAP_BOOTSTRAP_USER_PASSWORD=${{ secrets.LDAP_BOOTSTRAP_USER_PASSWORD }}
     with:
       app-name: support-bot
+      tenant-name: support-bot
       version: ${{ needs.version.outputs.version }}
       working-directory: ./
       artifacts: |

--- a/.github/workflows/support-bot-monitoring.yaml
+++ b/.github/workflows/support-bot-monitoring.yaml
@@ -37,6 +37,7 @@ jobs:
     with:
       github_env: gcp-dev
       app-name: support-bot
+      tenant-name: support-bot
       subnamespace: grafana
       version: ${{ needs.version.outputs.version }}
       command: monitoring-deploy

--- a/.github/workflows/support-bot-prod.yaml
+++ b/.github/workflows/support-bot-prod.yaml
@@ -15,6 +15,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
     with:
       image-name: support-bot
+      tenant-name: support-bot
 
   prod:
     needs: [get-latest-version]
@@ -23,6 +24,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: support-bot
+      tenant-name: support-bot
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./


### PR DESCRIPTION
## Summary
- add `tenant-name: support-bot` to the reusable P2P workflow calls in the support-bot workflows
- update the monitoring workflow to pass the same tenant to `p2p-execute-command`
- align the repository's workflow inputs with the current reusable P2P workflow contract