### PR TITLE
Harmonising no sla PRs with SLA backed PRs

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -265,11 +265,21 @@ public class PrDetectionService {
     }
 
     private enum NotificationType {
-        TRACKED,
-        NO_SLA_TRACKED,
-        CHANGES_REQUESTED,
-        APPROVED,
-        ESCALATED
+        TRACKED(true),
+        NO_SLA_TRACKED(false),
+        CHANGES_REQUESTED(false),
+        APPROVED(false),
+        ESCALATED(true);
+
+        private final boolean requiresSla;
+
+        NotificationType(boolean requiresSla) {
+            this.requiresSla = requiresSla;
+        }
+
+        boolean requiresSla() {
+            return requiresSla;
+        }
     }
 
     private record PendingNotification(
@@ -282,7 +292,7 @@ public class PrDetectionService {
         PendingNotification {
             checkNotNull(repo);
             checkNotNull(type);
-            if (type != NotificationType.NO_SLA_TRACKED) {
+            if (type.requiresSla()) {
                 checkNotNull(sla, "sla required for %s", type);
                 checkNotNull(slaDeadline, "slaDeadline required for %s", type);
             }
@@ -315,7 +325,13 @@ public class PrDetectionService {
             if (repoConfig.get().hasNoSla()) {
                 // No-SLA tracking: track by path filter without a deadline or escalation.
                 return processNoSlaOpenPr(
-                        detectedPr, ticket, canAutoCloseTicket, repoConfig.get(), prMetadata, notifications);
+                        detectedPr,
+                        ticket,
+                        canAutoCloseTicket,
+                        repoConfig.get(),
+                        prMetadata,
+                        teamReviewerCache,
+                        notifications);
             } else {
                 return processOpenPr(
                         detectedPr,
@@ -473,6 +489,7 @@ public class PrDetectionService {
             boolean canAutoCloseTicket,
             PrTrackingProps.Repository repoConfig,
             GitHubPullRequest prMetadata,
+            Map<String, Optional<Set<String>>> teamReviewerCache,
             List<PendingNotification> notifications) {
 
         if (!matchesPathFilter(repoConfig.paths(), detectedPr.repositoryName(), detectedPr.pullNumber())) {
@@ -484,15 +501,15 @@ public class PrDetectionService {
         }
 
         TicketId ticketId = checkNotNull(ticket.id());
-        if (prTrackingRepository.insertIfAbsent(new NewPrTracking(
-                        ticketId.id(),
-                        detectedPr.repositoryName(),
-                        detectedPr.pullNumber(),
-                        prMetadata.createdAt(),
-                        null,
-                        repoConfig.owningTeam(),
-                        canAutoCloseTicket))
-                == null) {
+        PrTrackingRecord tracking = prTrackingRepository.insertIfAbsent(new NewPrTracking(
+                ticketId.id(),
+                detectedPr.repositoryName(),
+                detectedPr.pullNumber(),
+                prMetadata.createdAt(),
+                null,
+                repoConfig.owningTeam(),
+                canAutoCloseTicket));
+        if (tracking == null) {
             log.atInfo()
                     .addArgument(detectedPr::repositoryName)
                     .addArgument(detectedPr::pullNumber)
@@ -509,13 +526,41 @@ public class PrDetectionService {
 
         addReaction(prTrackingProps.prEmoji(), ticket.queryTs(), ticket.channelId());
         String teamLabel = resolveTeamLabel(repoConfig.owningTeam());
-        notifications.add(new PendingNotification(
-                detectedPr.repositoryName(),
-                detectedPr.pullNumber(),
-                NotificationType.NO_SLA_TRACKED,
-                null,
-                null,
-                teamLabel));
+
+        // Mirror the SLA branch: inspect reviews already fetched with the PR so that a no-SLA PR
+        // detected while already in CHANGES_REQUESTED or APPROVED state transitions correctly on
+        // first sight, instead of sitting in OPEN until the poller notices and posts a duplicate.
+        List<GitHubPullRequestReview> teamReviews =
+                teamReviewFilter.filterToOwningTeam(prMetadata.reviews(), prMetadata, repoConfig, teamReviewerCache);
+        GitHubPullRequestReview latestVerdict = teamReviewFilter.findLatestActionableReview(teamReviews);
+
+        if (latestVerdict != null && latestVerdict.requestsChanges()) {
+            prTrackingRepository.updateStatus(tracking.id(), PrTrackingStatus.CHANGES_REQUESTED, null, null);
+            notifications.add(new PendingNotification(
+                    detectedPr.repositoryName(),
+                    detectedPr.pullNumber(),
+                    NotificationType.CHANGES_REQUESTED,
+                    null,
+                    null,
+                    teamLabel));
+        } else if (latestVerdict != null && latestVerdict.isApproved()) {
+            prTrackingRepository.updateStatus(tracking.id(), PrTrackingStatus.APPROVED, null, null);
+            notifications.add(new PendingNotification(
+                    detectedPr.repositoryName(),
+                    detectedPr.pullNumber(),
+                    NotificationType.APPROVED,
+                    null,
+                    null,
+                    teamLabel));
+        } else {
+            notifications.add(new PendingNotification(
+                    detectedPr.repositoryName(),
+                    detectedPr.pullNumber(),
+                    NotificationType.NO_SLA_TRACKED,
+                    null,
+                    null,
+                    teamLabel));
+        }
 
         return PerPrResult.TRACKED;
     }

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -693,6 +693,85 @@ class PrDetectionServiceTest {
         }
 
         @Test
+        void groupsMultiplePrsFromSameRepoAndMentionsTeamOnce() {
+            // given — two no-SLA PRs posted to the same repo (same owning team)
+            int prNumber2 = PR_NUMBER + 1;
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(NO_SLA_REPO, TEAM_CODE, null, PATHS, null)));
+            when(prUrlParser.parse(any()))
+                    .thenReturn(
+                            List.of(new DetectedPr(NO_SLA_REPO, PR_NUMBER), new DetectedPr(NO_SLA_REPO, prNumber2)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of()));
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, prNumber2))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            prNumber2,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of()));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, PR_NUMBER)).thenReturn(List.of("infra/main.tf"));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, prNumber2)).thenReturn(List.of("infra/vars.tf"));
+            when(prTrackingRepository.insertIfAbsent(any()))
+                    .thenReturn(
+                            new PrTrackingRecord(
+                                    1L,
+                                    1L,
+                                    NO_SLA_REPO,
+                                    PR_NUMBER,
+                                    prCreatedAt,
+                                    null,
+                                    TEAM_CODE,
+                                    true,
+                                    PrTrackingStatus.OPEN,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null),
+                            new PrTrackingRecord(
+                                    2L,
+                                    1L,
+                                    NO_SLA_REPO,
+                                    prNumber2,
+                                    prCreatedAt,
+                                    null,
+                                    TEAM_CODE,
+                                    true,
+                                    PrTrackingStatus.OPEN,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — a single grouped message is posted, team mentioned once (not duplicated per PR)
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("#" + PR_NUMBER);
+            assertThat(text).contains("#" + prNumber2);
+            assertThat(text).containsOnlyOnce(TEAM_CODE);
+        }
+
+        @Test
         void transitionsToChangesRequestedWhenPrAlreadyHasChangesRequestedReview() {
             // given — a no-SLA PR that already has a CHANGES_REQUESTED review at detection time
             Instant prCreatedAt = Instant.now().minus(Duration.ofHours(2));

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -674,6 +674,82 @@ class PrDetectionServiceTest {
         }
 
         @Test
+        void transitionsToChangesRequestedWhenPrAlreadyHasChangesRequestedReview() {
+            // given — a no-SLA PR that already has a CHANGES_REQUESTED review at detection time
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(2));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(NO_SLA_REPO, TEAM_CODE, null, PATHS, null)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(NO_SLA_REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of(new GitHubPullRequestReview(
+                                    "reviewer",
+                                    GitHubPullRequestReview.ReviewState.CHANGES_REQUESTED,
+                                    Instant.now().minusSeconds(600)))));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, PR_NUMBER)).thenReturn(List.of("infra/main.tf"));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(1L, prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — status flipped to CHANGES_REQUESTED (null remaining, null escalationId)
+            verify(prTrackingRepository)
+                    .updateStatus(eq(1L), eq(PrTrackingStatus.CHANGES_REQUESTED), eq(null), eq(null));
+            verify(prTrackingRepository, never()).pauseSla(anyLong(), any(), any());
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            assertThat(postMessageCaptor.getValue().message().getText()).contains("changes have been requested");
+            verifyNoInteractions(escalationProcessingService);
+        }
+
+        @Test
+        void transitionsToApprovedWhenPrAlreadyHasApprovedReview() {
+            // given — a no-SLA PR that already has an APPROVED review at detection time
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(2));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(NO_SLA_REPO, TEAM_CODE, null, PATHS, null)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(NO_SLA_REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), anyInt()))
+                    .thenReturn(false);
+            when(gitHubClient.getPullRequest(NO_SLA_REPO, PR_NUMBER))
+                    .thenReturn(new GitHubPullRequest(
+                            NO_SLA_REPO,
+                            PR_NUMBER,
+                            prCreatedAt,
+                            GitHubPullRequest.PrState.OPEN,
+                            null,
+                            null,
+                            List.of(),
+                            List.of(new GitHubPullRequestReview(
+                                    "reviewer",
+                                    GitHubPullRequestReview.ReviewState.APPROVED,
+                                    Instant.now().minusSeconds(600)))));
+            when(gitHubClient.listPullRequestFiles(NO_SLA_REPO, PR_NUMBER)).thenReturn(List.of("infra/main.tf"));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(1L, prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — status flipped to APPROVED (null remaining, null escalationId)
+            verify(prTrackingRepository).updateStatus(eq(1L), eq(PrTrackingStatus.APPROVED), eq(null), eq(null));
+            verify(prTrackingRepository, never()).pauseSla(anyLong(), any(), any());
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            assertThat(postMessageCaptor.getValue().message().getText())
+                    .contains("has been approved and is ready to merge");
+            verifyNoInteractions(escalationProcessingService);
+        }
+
+        @Test
         void skipsWhenNoFilesMatchPathFilter() {
             // given
             Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));


### PR DESCRIPTION
## Summary

- Inspect reviews already fetched with the PR when a no-SLA PR is first detected, so a PR that's already in `CHANGES_REQUESTED` or `APPROVED` state transitions on first sight instead of being posted as `NO_SLA_TRACKED` and   then re-posted by the poller.                                                                                                                                                                                                    
- Move the `PendingNotification` "requires SLA fields" invariant onto `NotificationType` itself via `requiresSla()`, so future constants must opt in explicitly at compile time.
