### PR TITLE
chore: bump Spring Boot to 3.5.13

### DIFF
--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -112,7 +112,7 @@ dependencies {
     compileOnly("jakarta.websocket:jakarta.websocket-client-api:2.2.0")
     implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:2.2.0")
     implementation("com.google.guava:guava:33.4.0-jre")
-    implementation("org.kohsuke:github-api:1.327")
+    implementation("org.kohsuke:github-api:1.330")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.80")
     implementation("com.github.ben-manes.caffeine:caffeine")
 

--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     checkstyle
 
     id("net.ltgt.errorprone") version "4.3.0"
-    id("org.springframework.boot") version "3.5.9"
+    id("org.springframework.boot") version "3.5.13"
     id("io.spring.dependency-management") version "1.1.7"
 
     id("org.flywaydb.flyway") version "12.0.0"

--- a/api/testkit/build.gradle.kts
+++ b/api/testkit/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     api("net.datafaker:datafaker:2.4.3")
 
     // Spring Boot for config loading
-    implementation("org.springframework.boot:spring-boot:3.5.6")
+    implementation("org.springframework.boot:spring-boot:3.5.13")
 
     // JSpecify for null annotations
     api("org.jspecify:jspecify:1.0.0")


### PR DESCRIPTION
## What Changed

- Bumps Spring Boot 3.5.9 to 3.5.13 to clear a batch of Dependabot alerts.
- Bumps `org.kohsuke:github-api` 1.327 to 1.330. Spring Boot 3.5.13 pulls Jackson 2.21, which no longer ships a field that `github-api:1.327` depends on, so creating a `GitHub` client throws `NoSuchFieldError`

**References:**
- github-api 1.330 notes: https://github.com/hub4j/github-api/compare/github-api-1.327..github-api-1.330
- Spring Boot 3.5.13: https://github.com/spring-projects/spring-boot/releases/tag/v3.5.13
