### PR TITLE
feat(auth): make Dex identity backends configurable (PT-392)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 ldap/bootstrap/20-users.ldif
 api/k8s/ldap/chart/files/bootstrap/20-users.ldif
 
+# Python bytecode caches (created by `make -C dex test` importing compose_helm_values)
+__pycache__/
+*.pyc
+
 ## Generated
 # Created by https://www.toptal.com/developers/gitignore/api/vim,intellij,intellij+all,intellij+iml,windows,macos,linux,emacs,visualstudiocode,webstorm,webstorm+all,webstorm+iml
 # Edit at https://www.toptal.com/developers/gitignore?templates=vim,intellij,intellij+all,intellij+iml,windows,macos,linux,emacs,visualstudiocode,webstorm,webstorm+all,webstorm+iml

--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ dex-template: ## Validate Dex values by rendering dex/dex chart
 	@$(MAKE) -C dex template
 
 dex-deploy-integration: ## Deploy Dex module to integration environment (OIDC overlay + ephemeral plaintext LDAP)
-	@$(MAKE) -C dex deploy-integration DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true
+	@$(MAKE) -C dex deploy-integration DEX_LDAP_ENABLED=true DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true
 
 dex-deploy-prod: ## Deploy Dex module to production environment
 	@$(MAKE) -C dex deploy-prod

--- a/api/k8s/dex/README.md
+++ b/api/k8s/dex/README.md
@@ -12,13 +12,18 @@ The **dex/dex** chart creates **namespace** `Role` + `RoleBinding` for `dex.core
 
 ## Files
 
-- `values-dexidp.yaml` — baseline: issuer, sqlite storage, web/telemetry ports, static client, optional empty `connectors: []`, namespaced RBAC only (`rbac.createClusterScoped: false`).
-- `values-integration.yaml` — sample integration overrides (issuer, `staticClients`, resource bumps). **No** LDAP connector here. Ingress is **off** by default; reach Dex via full svc FQDN or port-forward.
-- `values-integration-ldap-plaintext-ephemeral.yaml` — **opt-in** LDAP connector on port **389** without TLS (`insecureNoSSL: true`). Only for disposable integration namespaces. `dex/scripts/helm_dex.sh deploy-integration` requires **`DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true`** to apply it; `helm_dex.sh template` always merges it to validate the chart. Layer **before** `values-dex-oidc-incluster.yaml` when using both.
-- `values-dex-oidc-incluster.yaml` — Tier 2 overlay: in-cluster issuer (full svc FQDN) and `staticClients` for `http://127.0.0.1:8765/api/oauth/callback/dex`. Does **not** define `connectors` (LDAP comes from the ephemeral plaintext overlay or TLS overlay). Set `DEX_ISSUER_URI` and `DEX_INTERNAL_BASE_URL` to match `config.issuer`.
-- `values-tls.yaml` — LDAP over StartTLS/LDAPS for non-ephemeral environments (see runbook).
+- `values-dexidp.yaml` — baseline: issuer, sqlite storage, web/telemetry ports, static client, empty `connectors: []`, namespaced RBAC only (`rbac.createClusterScoped: false`).
+- `values-integration.yaml` — sample integration overrides (issuer, `staticClients`, resource bumps). **No** connector here. Ingress is **off** by default; reach Dex via full svc FQDN or port-forward.
+- `values-dex-oidc-incluster.yaml` — Tier 2 overlay: in-cluster issuer (full svc FQDN) and `staticClients` for `http://127.0.0.1:8765/api/oauth/callback/dex`. Does **not** define `connectors`. Set `DEX_ISSUER_URI` and `DEX_INTERNAL_BASE_URL` to match `config.issuer`.
 
-Baseline **`values-dexidp.yaml`** sets **`enablePasswordDB: false`** (connectors only). Add LDAP / Google / Microsoft under `config.connectors` via **`values-integration-ldap-plaintext-ephemeral.yaml`**, **`values-tls.yaml`**, or another overlay, or set `enablePasswordDB: true` and `staticPasswords` in a private overlay if you need Dex’s built-in email login.
+**Per-backend connector overlays** (one connector each — composed by `dex/scripts/compose_helm_values.py`, never passed straight to `helm -f`):
+
+- `values-tls.yaml` — LDAP over **StartTLS/LDAPS** for non-ephemeral environments (see runbook).
+- `values-integration-ldap-plaintext-ephemeral.yaml` — **opt-in** LDAP connector on port **389** without TLS (`insecureNoSSL: true`). Only for disposable integration namespaces. `helm_dex.sh deploy-integration` requires **`DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true`** to use this in place of `values-tls.yaml`.
+- `values-google.yaml` — Dex Google connector (`type: google`). Used when `DEX_GOOGLE_ENABLED=true`.
+- `values-microsoft.yaml` — Dex Microsoft / Entra connector (`type: microsoft`). Used when `DEX_MICROSOFT_ENABLED=true`.
+
+Baseline **`values-dexidp.yaml`** sets **`enablePasswordDB: false`** (connectors only). Operators select connectors with `DEX_LDAP_ENABLED` / `DEX_GOOGLE_ENABLED` / `DEX_MICROSOFT_ENABLED`; the composer concatenates the corresponding overlays into one `config.connectors` list before `helm` runs. Set `enablePasswordDB: true` and `staticPasswords` in a private overlay only if you need Dex’s built-in email login alongside (or instead of) connectors.
 
 ## Required secret (`dex-secrets`)
 
@@ -37,27 +42,36 @@ For **Tier 2** integration tests, Kubernetes Secret `dex-secrets` is expected wi
 
 ## Install / upgrade
 
+Selecting connectors is driven by env flags — `helm_dex.sh` reads them from the deployer's environment (or `dex/.env.local` when invoked through `make -C dex deploy-*`) and feeds the matching per-backend overlays through the composer:
+
 ```bash
-helm repo add dex https://charts.dexidp.io
-helm repo update dex
-helm upgrade --install support-bot-dex dex/dex --version 0.24.0 \
-  -f api/k8s/dex/values-dexidp.yaml \
-  -f api/k8s/dex/values-integration.yaml
+# pick any combination
+export DEX_LDAP_ENABLED=true       # uses values-tls.yaml unless DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true
+export DEX_GOOGLE_ENABLED=true     # adds values-google.yaml
+export DEX_MICROSOFT_ENABLED=true  # adds values-microsoft.yaml
+export DEX_ISSUER=https://dex.example.com
+export DEX_GOOGLE_CLIENT_ID=...    DEX_GOOGLE_CLIENT_SECRET=...
+export DEX_MICROSOFT_CLIENT_ID=... DEX_MICROSOFT_CLIENT_SECRET=... DEX_MICROSOFT_TENANT=common
+export LDAP_BOOTSTRAP_USER_PASSWORD=...
+
+NAMESPACE=support-bot-prod bash dex/scripts/helm_dex.sh deploy-prod
 ```
 
-(`values-integration.yaml` alone leaves `connectors` empty from the baseline — add **`values-integration-ldap-plaintext-ephemeral.yaml`** only on disposable clusters, or **`values-tls.yaml`** with LDAP TLS, plus any Google/Microsoft connector overlays.)
+The script:
+1. composes a single `connectors:` list from the enabled overlays (Helm's last-wins overlay merge cannot append YAML lists, so per-backend overlays must not be layered directly with `-f`),
+2. ensures the `dex-secrets` Kubernetes Secret with `client-id` / `client-secret` (and `ldap-bind-password` / `google-client-*` / `microsoft-client-*` keys when those envs are set),
+3. runs `helm upgrade --install` against the composed values.
 
 **Tier 2 OIDC Job** (in-cluster issuer aligned with `DEX_ISSUER_URI` and `DEX_INTERNAL_BASE_URL` using full svc FQDN; **ephemeral plaintext LDAP** — do not reuse on shared clusters):
 
 ```bash
-helm upgrade --install support-bot-dex dex/dex --version 0.24.0 \
-  -f api/k8s/dex/values-dexidp.yaml \
-  -f api/k8s/dex/values-integration.yaml \
-  -f api/k8s/dex/values-integration-ldap-plaintext-ephemeral.yaml \
-  -f api/k8s/dex/values-dex-oidc-incluster.yaml
+DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true \
+DEX_LDAP_ENABLED=true \
+NAMESPACE=support-bot-integration \
+bash dex/scripts/helm_dex.sh deploy-integration
 ```
 
-Validate render only:
+Validate every supported combination renders against the chart (LDAP TLS, LDAP plaintext, Google, Microsoft, LDAP+Google, all-three TLS, all-three plaintext):
 
 ```bash
 make dex-template
@@ -69,11 +83,22 @@ Ephemeral plaintext LDAP lives in [`values-integration-ldap-plaintext-ephemeral.
 
 ## Connectors: LDAP, Google, Microsoft
 
-- **LDAP** — Bitnami/OpenLDAP DIT example: [`values-integration-ldap-plaintext-ephemeral.yaml`](./values-integration-ldap-plaintext-ephemeral.yaml) (plaintext 389, **ephemeral only**) or [`values-tls.yaml`](./values-tls.yaml). JWT `groups` for Support Bot `jwt-groups` depends on this connector and Dex scopes.
-- **Google** — add a `connectors` entry with `type: google` per [Dex docs](https://dexidp.io/docs/connectors/google/). Register a **Web** OAuth client whose redirect URI is **`{issuer}/callback`** (e.g. `https://dex.example.com/callback`), not the API’s `/login/oauth2/code/...` URL.
-- **Microsoft** — add `type: microsoft` per [Dex docs](https://dexidp.io/docs/connectors/microsoft/) with the same `{issuer}/callback` redirect URI and `tenant` in `config`.
+Each connector lives in its own per-backend overlay. Operators turn them on with env flags — any combination works.
 
-Because `connectors` is a YAML list, merge carefully: the last values file that sets `config.connectors` **replaces** the whole list. Combine LDAP with Google/Microsoft in **one** overlay file, or merge connector lists in your pipeline.
+| Connector  | Overlay                                                 | Enable flag             | Required env                                                                  |
+|------------|---------------------------------------------------------|-------------------------|-------------------------------------------------------------------------------|
+| LDAP (TLS) | [`values-tls.yaml`](./values-tls.yaml)                  | `DEX_LDAP_ENABLED=true` | `LDAP_BOOTSTRAP_USER_PASSWORD`                                                |
+| LDAP (plaintext, ephemeral) | [`values-integration-ldap-plaintext-ephemeral.yaml`](./values-integration-ldap-plaintext-ephemeral.yaml) | `DEX_LDAP_ENABLED=true` + `DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true` | `LDAP_BOOTSTRAP_USER_PASSWORD` |
+| Google     | [`values-google.yaml`](./values-google.yaml)            | `DEX_GOOGLE_ENABLED=true`     | `DEX_GOOGLE_CLIENT_ID`, `DEX_GOOGLE_CLIENT_SECRET`, `DEX_ISSUER`              |
+| Microsoft  | [`values-microsoft.yaml`](./values-microsoft.yaml)      | `DEX_MICROSOFT_ENABLED=true`  | `DEX_MICROSOFT_CLIENT_ID`, `DEX_MICROSOFT_CLIENT_SECRET`, `DEX_ISSUER`, optional `DEX_MICROSOFT_TENANT` (default `common`) |
+
+Setup notes:
+
+- **LDAP** — JWT `groups` for Support Bot `jwt-groups` depends on this connector and Dex scopes. See [Bitnami/OpenLDAP DIT example](./values-tls.yaml).
+- **Google** — register a **Web** OAuth client (Google Cloud Console) whose authorized redirect URI is **`${DEX_ISSUER}/callback`** (Dex's own callback), not the Support Bot API or UI URL. See [Dex docs](https://dexidp.io/docs/connectors/google/).
+- **Microsoft** — register an Entra app with the same `${DEX_ISSUER}/callback` redirect URI; set `DEX_MICROSOFT_TENANT` to a tenant UUID (or `common` / `organizations` / `consumers`). See [Dex docs](https://dexidp.io/docs/connectors/microsoft/).
+
+`dex/scripts/compose_helm_values.py` concatenates the enabled overlays into one `config.connectors` list before invoking `helm`. Per-backend overlays must **not** be layered directly with `-f`: Helm's last-wins overlay merge replaces YAML lists wholesale, so the second `-f` would silently drop the first connector. The composer also fails fast if two overlays produce the same connector `id` (e.g. enabling both LDAP TLS and LDAP plaintext at once).
 
 User-facing SSO against Dex is the **only** OAuth2 client the API registers
 (`DEX_CLIENT_ID`, `DEX_CLIENT_SECRET`, `DEX_ISSUER_URI`). Google, Azure AD, and LDAP
@@ -103,9 +128,9 @@ See [docs/runbooks/auth-dex-ldap.md](../../../docs/runbooks/auth-dex-ldap.md).
 
 ```bash
 make dex-template
-make dex-deploy-integration   # from repo root: sets DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true
+make dex-deploy-integration   # from repo root: sets DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true and DEX_LDAP_ENABLED=true
 ```
 
-Workflow: `.github/workflows/dex-fast-feedback.yaml` (and optional `support-bot-dex-fast-feedback.yaml`) run P2P fast feedback in `dex/` (`make p2p-build` → `helm template`).
+Workflow: `.github/workflows/dex-fast-feedback.yaml` runs P2P fast feedback in `dex/` (`make p2p-build` → `helm template` covering every connector combination).
 
-**Ad-hoc** `make -C dex deploy-integration` must export **`DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true`** before running, or `helm_dex.sh` refuses to install the plaintext LDAP overlay.
+**Ad-hoc** `make -C dex deploy-integration` must export **`DEX_LDAP_ENABLED=true`** plus **`DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true`** before running (or set the flags in `dex/.env.local`), or `helm_dex.sh` refuses to install the plaintext LDAP overlay. Set `DEX_GOOGLE_ENABLED` / `DEX_MICROSOFT_ENABLED` to add cloud IdPs alongside or instead.

--- a/api/k8s/dex/values-google.yaml
+++ b/api/k8s/dex/values-google.yaml
@@ -1,0 +1,25 @@
+# Dex Google connector overlay — adds a single `google` entry to config.connectors.
+#
+# Do not pass directly to `helm -f`; layer alongside other per-backend overlays
+# only via dex/scripts/compose_helm_values.py, which concatenates connector lists
+# (Helm's last-wins overlay merge would otherwise drop earlier connectors).
+# helm_dex.sh enables this overlay automatically when DEX_GOOGLE_ENABLED=true.
+#
+# Register a Web OAuth client (Google Cloud Console) whose authorized redirect URI
+# is `${issuer}/callback` — Dex's own callback, NOT the Support Bot API's
+# /login/oauth2/code/dex. See https://dexidp.io/docs/connectors/google/.
+#
+# Placeholders are substituted by helm_dex.sh prepare_values() via envsubst:
+#   PLACEHOLDER_GOOGLE_CLIENT_ID     ← DEX_GOOGLE_CLIENT_ID
+#   PLACEHOLDER_GOOGLE_CLIENT_SECRET ← DEX_GOOGLE_CLIENT_SECRET
+#   PLACEHOLDER_DEX_ISSUER           ← DEX_ISSUER (must match config.issuer)
+
+config:
+  connectors:
+    - type: google
+      id: google
+      name: Google
+      config:
+        clientID: ${PLACEHOLDER_GOOGLE_CLIENT_ID}
+        clientSecret: ${PLACEHOLDER_GOOGLE_CLIENT_SECRET}
+        redirectURI: ${PLACEHOLDER_DEX_ISSUER}/callback

--- a/api/k8s/dex/values-microsoft.yaml
+++ b/api/k8s/dex/values-microsoft.yaml
@@ -1,0 +1,29 @@
+# Dex Microsoft (Entra) connector overlay — adds a single `microsoft` entry to config.connectors.
+#
+# Do not pass directly to `helm -f`; layer alongside other per-backend overlays
+# only via dex/scripts/compose_helm_values.py, which concatenates connector lists
+# (Helm's last-wins overlay merge would otherwise drop earlier connectors).
+# helm_dex.sh enables this overlay automatically when DEX_MICROSOFT_ENABLED=true.
+#
+# Register an Entra app whose redirect URI is `${issuer}/callback` — Dex's own
+# callback, NOT the Support Bot API's /login/oauth2/code/dex.
+# See https://dexidp.io/docs/connectors/microsoft/.
+#
+# tenant: UUID for a single tenant, or one of common / organizations / consumers.
+#
+# Placeholders are substituted by helm_dex.sh prepare_values() via envsubst:
+#   PLACEHOLDER_MICROSOFT_CLIENT_ID     ← DEX_MICROSOFT_CLIENT_ID
+#   PLACEHOLDER_MICROSOFT_CLIENT_SECRET ← DEX_MICROSOFT_CLIENT_SECRET
+#   PLACEHOLDER_MICROSOFT_TENANT        ← DEX_MICROSOFT_TENANT (default: common)
+#   PLACEHOLDER_DEX_ISSUER              ← DEX_ISSUER (must match config.issuer)
+
+config:
+  connectors:
+    - type: microsoft
+      id: microsoft
+      name: Microsoft
+      config:
+        clientID: ${PLACEHOLDER_MICROSOFT_CLIENT_ID}
+        clientSecret: ${PLACEHOLDER_MICROSOFT_CLIENT_SECRET}
+        redirectURI: ${PLACEHOLDER_DEX_ISSUER}/callback
+        tenant: ${PLACEHOLDER_MICROSOFT_TENANT}

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -304,11 +304,16 @@ Dex deployment), not as separate front doors in this app.
 > live in Dex's own configuration:
 >
 > - Local dev: `DEX_GOOGLE_*` / `DEX_MICROSOFT_*` in [`dex/.env.example`](../../../dex/.env.example).
-> - Kubernetes: `config.connectors[]` in your Dex helm values; see
->   [`api/k8s/dex/README.md`](../../k8s/dex/README.md) and the
->   [auth/Dex/LDAP runbook](../../../docs/runbooks/auth-dex-ldap.md).
+> - Kubernetes: enable per-backend overlays with `DEX_LDAP_ENABLED` /
+>   `DEX_GOOGLE_ENABLED` / `DEX_MICROSOFT_ENABLED` —
+>   [`values-tls.yaml`](../../k8s/dex/values-tls.yaml) /
+>   [`values-google.yaml`](../../k8s/dex/values-google.yaml) /
+>   [`values-microsoft.yaml`](../../k8s/dex/values-microsoft.yaml). The
+>   `dex/scripts/helm_dex.sh` deploy script composes the enabled overlays into a
+>   single connector list; see [`api/k8s/dex/README.md`](../../k8s/dex/README.md)
+>   and the [auth/Dex/LDAP runbook](../../../docs/runbooks/auth-dex-ldap.md).
 >
-> The redirect URI registered with Google/Microsoft must be `{DEX_ISSUER}/callback`
+> The redirect URI registered with Google/Microsoft must be `${DEX_ISSUER}/callback`
 > (Dex's own callback) — **not** `/api/oauth/callback/google` or
 > `/login/oauth2/code/google` (those paths no longer exist on this app).
 

--- a/dex/Makefile
+++ b/dex/Makefile
@@ -2,6 +2,19 @@ SHELL := /bin/bash
 
 DEX_K8S := ../api/k8s/dex
 
+##@ High level p2p targets
+p2p-build: template ## Fast feedback: validate Helm values
+p2p-functional:    
+p2p-nft:           
+p2p-integration: template ## P2P: render then deploy (enables LDAP plaintext overlay for Dex integration)
+	@$(MAKE) deploy-integration DEX_LDAP_ENABLED=true DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true
+p2p-promote-to-extended-test: ## No image artifact to promote for Dex infra module
+	@echo "NOOP: Dex uses upstream images and produces no P2P image artifact"
+p2p-promote-to-prod: ## No image artifact to promote for Dex infra module
+	@echo "NOOP: Dex uses upstream images and produces no P2P image artifact"
+p2p-extended-test: 
+p2p-prod:          
+
 ##@ Local Dex (Docker)
 
 .PHONY: render-config
@@ -29,15 +42,21 @@ template: ## Validate Dex values by rendering dex/dex chart (charts.dexidp.io)
 	@DEX_CHART_VERSION="$(DEX_CHART_VERSION)" bash ./scripts/helm_dex.sh template
 
 .PHONY: deploy-integration
-deploy-integration: ## Deploy Dex to integration (requires DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true unless root Makefile sets it)
+deploy-integration: ## Deploy Dex to integration (LDAP/Google/Microsoft via DEX_*_ENABLED in env or .env.local; plaintext LDAP requires DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true)
 	@bash -c 'set -eo pipefail; cd "$(CURDIR)"; \
 	if [[ -f .env.local ]]; then set -a; source .env.local; set +a; fi; \
+	: $${DEX_LDAP_ENABLED:=$(DEX_LDAP_ENABLED)}; export DEX_LDAP_ENABLED; \
+	: $${DEX_GOOGLE_ENABLED:=$(DEX_GOOGLE_ENABLED)}; export DEX_GOOGLE_ENABLED; \
+	: $${DEX_MICROSOFT_ENABLED:=$(DEX_MICROSOFT_ENABLED)}; export DEX_MICROSOFT_ENABLED; \
+	: $${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:=$(DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT)}; export DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT; \
 	NAMESPACE="$(NAMESPACE)" DEX_CHART_VERSION="$(DEX_CHART_VERSION)" DRY_RUN="$(DRY_RUN)" \
-	DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT="$(DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT)" \
 	bash ./scripts/helm_dex.sh deploy-integration'
 
 .PHONY: deploy-prod
-deploy-prod: ## Deploy Dex module to production environment
+deploy-prod: ## Deploy Dex to production (LDAP/Google/Microsoft via DEX_*_ENABLED in env or .env.local)
 	@bash -c 'set -eo pipefail; cd "$(CURDIR)"; \
 	if [[ -f .env.local ]]; then set -a; source .env.local; set +a; fi; \
+	: $${DEX_LDAP_ENABLED:=$(DEX_LDAP_ENABLED)}; export DEX_LDAP_ENABLED; \
+	: $${DEX_GOOGLE_ENABLED:=$(DEX_GOOGLE_ENABLED)}; export DEX_GOOGLE_ENABLED; \
+	: $${DEX_MICROSOFT_ENABLED:=$(DEX_MICROSOFT_ENABLED)}; export DEX_MICROSOFT_ENABLED; \
 	NAMESPACE="$(NAMESPACE)" DEX_CHART_VERSION="$(DEX_CHART_VERSION)" bash ./scripts/helm_dex.sh deploy-prod'

--- a/dex/Makefile
+++ b/dex/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 DEX_K8S := ../api/k8s/dex
 
 ##@ High level p2p targets
-p2p-build: template ## Fast feedback: validate Helm values
+p2p-build: test template ## Fast feedback: run unit tests + validate Helm values
 p2p-functional:    
 p2p-nft:           
 p2p-integration: template ## P2P: render then deploy (enables LDAP plaintext overlay for Dex integration)
@@ -45,6 +45,10 @@ DEX_LDAP_ENABLED ?=
 DEX_GOOGLE_ENABLED ?=
 DEX_MICROSOFT_ENABLED ?=
 DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT ?=
+
+.PHONY: test
+test: ## Run unit tests for dex scripts (compose_helm_values composer)
+	@python3 -m unittest discover -s scripts -p 'test_*.py' -v
 
 .PHONY: template
 template: ## Validate Dex values by rendering dex/dex chart (charts.dexidp.io)

--- a/dex/Makefile
+++ b/dex/Makefile
@@ -37,6 +37,15 @@ DEX_CHART_VERSION ?= 0.24.0
 NAMESPACE ?= support-bot-integration
 DRY_RUN ?=
 
+# Default to empty so $(DEX_*_ENABLED) references in the recipes below don't
+# trigger --warn-undefined-variables when callers don't pass them. Operators set
+# them via dex/.env.local, the command line, or root Makefile targets
+# (dex-deploy-integration sets DEX_LDAP_ENABLED=true).
+DEX_LDAP_ENABLED ?=
+DEX_GOOGLE_ENABLED ?=
+DEX_MICROSOFT_ENABLED ?=
+DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT ?=
+
 .PHONY: template
 template: ## Validate Dex values by rendering dex/dex chart (charts.dexidp.io)
 	@DEX_CHART_VERSION="$(DEX_CHART_VERSION)" bash ./scripts/helm_dex.sh template

--- a/dex/README.md
+++ b/dex/README.md
@@ -70,7 +70,9 @@ cd api && make run-local
 
 ### Google / Microsoft via Dex (optional)
 
-Set `DEX_GOOGLE_ENABLED=true` or `DEX_MICROSOFT_ENABLED=true` plus the client id/secret variables from `dex/.env.example`, then `make -C dex render-config`. Register OAuth apps whose **authorized redirect URI** is `{DEX_ISSUER}/callback` (e.g. `http://127.0.0.1:5556/callback` for local Dex), not the Support Bot API callback. Aligns with [`api/k8s/dex/README.md`](../api/k8s/dex/README.md) Helm connector settings.
+Set `DEX_GOOGLE_ENABLED=true` or `DEX_MICROSOFT_ENABLED=true` plus the client id/secret variables from `dex/.env.example`, then `make -C dex render-config`. Register OAuth apps whose **authorized redirect URI** is `{DEX_ISSUER}/callback` (e.g. `http://127.0.0.1:5556/callback` for local Dex), not the Support Bot API callback.
+
+The same `DEX_*_ENABLED` flags drive Helm deploys via [`api/k8s/dex/values-google.yaml`](../api/k8s/dex/values-google.yaml) and [`values-microsoft.yaml`](../api/k8s/dex/values-microsoft.yaml); see [`api/k8s/dex/README.md`](../api/k8s/dex/README.md) for the composition flow and combo support matrix.
 
 ## 5) Redirect URIs
 

--- a/dex/scripts/compose_helm_values.py
+++ b/dex/scripts/compose_helm_values.py
@@ -27,27 +27,46 @@ import sys
 from pathlib import Path
 
 
-CONNECTORS_LINE = re.compile(r"^\s{0,2}connectors:\s*$")
+CONFIG_LINE = re.compile(r"^config:\s*$")
+CONNECTORS_LINE = re.compile(r"^  connectors:\s*$")
 ID_LINE = re.compile(r"^\s+id:\s*(\S+)\s*$")
 
 
+def _leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
 def extract_connectors_block(path: Path) -> str:
-    """Return the lines under `  connectors:` from a per-backend overlay."""
-    text = path.read_text()
-    lines = text.splitlines()
+    """Return the lines under `  connectors:` from a per-backend overlay.
+
+    Enforces the documented shape: top-level `config:` containing a single
+    `  connectors:` list. Captures stop as soon as indentation returns to
+    the `config:`-child level so sibling keys (e.g. `staticClients:`) never
+    bleed into the merged connectors list.
+    """
+    lines = path.read_text().splitlines()
     captured: list[str] = []
-    found = False
+    state = "outside"
     for line in lines:
-        if found:
+        if state == "outside":
+            if CONFIG_LINE.match(line):
+                state = "in_config"
+        elif state == "in_config":
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if CONNECTORS_LINE.match(line):
+                state = "in_connectors"
+            elif _leading_spaces(line) == 0:
+                break
+        else:
+            if line.strip() and _leading_spaces(line) <= 2:
+                break
             captured.append(line)
-            continue
-        if CONNECTORS_LINE.match(line):
-            found = True
-    if not found:
-        raise SystemExit(
-            f"{path}: missing 'connectors:' key under 'config:'."
-        )
-    # Strip leading/trailing blank lines but preserve internal indentation.
+
+    if state == "outside":
+        raise SystemExit(f"{path}: missing top-level 'config:' key.")
+    if state == "in_config":
+        raise SystemExit(f"{path}: missing 'connectors:' key under 'config:'.")
     while captured and not captured[0].strip():
         captured.pop(0)
     while captured and not captured[-1].strip():

--- a/dex/scripts/compose_helm_values.py
+++ b/dex/scripts/compose_helm_values.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Compose Dex per-backend Helm overlays into a single connectors values file.
+#
+# Helm's overlay merge replaces YAML lists wholesale, so layering
+# values-tls.yaml + values-google.yaml + values-microsoft.yaml via `-f` would
+# silently drop all but the last connector. This script concatenates the
+# `config.connectors` entries from the inputs into one merged file that
+# helm_dex.sh then passes to helm in place of the per-backend overlays.
+#
+# Stdlib-only (no PyYAML) to match dex/scripts/render_config.py. Each input
+# file MUST be shaped:
+#
+#   config:
+#     connectors:
+#       - <one or more list items>
+#
+# with no other keys under `config:`. Comments and blank lines are tolerated.
+#
+# Usage:
+#   compose_helm_values.py --out <merged.yaml> <overlay.yaml> [<overlay.yaml> ...]
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+CONNECTORS_LINE = re.compile(r"^\s{0,2}connectors:\s*$")
+ID_LINE = re.compile(r"^\s+id:\s*(\S+)\s*$")
+
+
+def extract_connectors_block(path: Path) -> str:
+    """Return the lines under `  connectors:` from a per-backend overlay."""
+    text = path.read_text()
+    lines = text.splitlines()
+    captured: list[str] = []
+    found = False
+    for line in lines:
+        if found:
+            captured.append(line)
+            continue
+        if CONNECTORS_LINE.match(line):
+            found = True
+    if not found:
+        raise SystemExit(
+            f"{path}: missing 'connectors:' key under 'config:'."
+        )
+    # Strip leading/trailing blank lines but preserve internal indentation.
+    while captured and not captured[0].strip():
+        captured.pop(0)
+    while captured and not captured[-1].strip():
+        captured.pop()
+    if not captured:
+        raise SystemExit(f"{path}: 'connectors:' block is empty.")
+    return "\n".join(captured) + "\n"
+
+
+def collect_connector_ids(block: str) -> list[str]:
+    return [m.group(1) for line in block.splitlines() if (m := ID_LINE.match(line))]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, type=Path, help="merged output path")
+    parser.add_argument("overlays", nargs="+", type=Path, help="per-backend overlay YAML files")
+    args = parser.parse_args(argv)
+
+    blocks: list[str] = []
+    seen_ids: dict[str, Path] = {}
+    for overlay in args.overlays:
+        block = extract_connectors_block(overlay)
+        for cid in collect_connector_ids(block):
+            if cid in seen_ids:
+                raise SystemExit(
+                    f"Duplicate connector id '{cid}' in {overlay} (also defined in {seen_ids[cid]})."
+                )
+            seen_ids[cid] = overlay
+        blocks.append(block)
+
+    merged = "config:\n  connectors:\n" + "".join(blocks)
+    args.out.write_text(merged)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/dex/scripts/helm_dex.sh
+++ b/dex/scripts/helm_dex.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 # Render or deploy Dex via dexidp Helm chart (dex/dex).
+#
+# Operator-facing env flags (PT-392) — set in dex/.env.local or the deployer's environment:
+#   DEX_LDAP_ENABLED      — adds LDAP connector overlay (TLS by default; plaintext when
+#                           DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true)
+#   DEX_GOOGLE_ENABLED    — adds Google connector overlay
+#   DEX_MICROSOFT_ENABLED — adds Microsoft connector overlay
+#
+# Connector overlays are merged by dex/scripts/compose_helm_values.py, not by Helm
+# layering — Helm's last-wins overlay merge replaces YAML lists wholesale, which
+# would silently drop earlier connectors when more than one backend is enabled.
 set -euo pipefail
 OP="${1:?usage: $0 template|deploy-integration|deploy-prod}"
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 DEX_K8S="${ROOT}/../api/k8s/dex"
+SCRIPTS="${ROOT}/scripts"
 CHART_REPO_NAME="${DEX_CHART_REPO_NAME:-dex}"
 CHART_REPO_URL="${DEX_CHART_REPO_URL:-https://charts.dexidp.io}"
 CHART_NAME="${DEX_CHART_NAME:-dex}"
@@ -15,44 +26,124 @@ helm repo update "${CHART_REPO_NAME}" >/dev/null
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "${TMPDIR}"' EXIT
 
-# Copy values files with secret placeholders replaced so secrets never appear in
+# Copy values files with placeholders replaced so secrets never appear in
 # the process command line (vs --set-string which is visible in `ps`).
 # Uses envsubst instead of sed to avoid delimiter-escaping issues with special characters in secrets.
 prepare_values() {
 	local src="$1" dest="${TMPDIR}/$(basename "$1")"
 	PLACEHOLDER_CLIENT_SECRET="${DEX_CLIENT_SECRET:-helm-template-placeholder-client-secret}" \
 	PLACEHOLDER_LDAP_BIND="${LDAP_BOOTSTRAP_USER_PASSWORD:-helm-template-placeholder-ldap-bind}" \
-		envsubst '$PLACEHOLDER_CLIENT_SECRET $PLACEHOLDER_LDAP_BIND' < "${src}" > "${dest}"
+	PLACEHOLDER_GOOGLE_CLIENT_ID="${DEX_GOOGLE_CLIENT_ID:-helm-template-placeholder-google-client-id}" \
+	PLACEHOLDER_GOOGLE_CLIENT_SECRET="${DEX_GOOGLE_CLIENT_SECRET:-helm-template-placeholder-google-client-secret}" \
+	PLACEHOLDER_MICROSOFT_CLIENT_ID="${DEX_MICROSOFT_CLIENT_ID:-helm-template-placeholder-microsoft-client-id}" \
+	PLACEHOLDER_MICROSOFT_CLIENT_SECRET="${DEX_MICROSOFT_CLIENT_SECRET:-helm-template-placeholder-microsoft-client-secret}" \
+	PLACEHOLDER_MICROSOFT_TENANT="${DEX_MICROSOFT_TENANT:-common}" \
+	PLACEHOLDER_DEX_ISSUER="${DEX_ISSUER:-https://dex.example.com}" \
+		envsubst '$PLACEHOLDER_CLIENT_SECRET $PLACEHOLDER_LDAP_BIND $PLACEHOLDER_GOOGLE_CLIENT_ID $PLACEHOLDER_GOOGLE_CLIENT_SECRET $PLACEHOLDER_MICROSOFT_CLIENT_ID $PLACEHOLDER_MICROSOFT_CLIENT_SECRET $PLACEHOLDER_MICROSOFT_TENANT $PLACEHOLDER_DEX_ISSUER' < "${src}" > "${dest}"
 	echo "${dest}"
+}
+
+is_truthy() {
+	[[ "${1:-}" =~ ^(true|1|yes)$ ]]
+}
+
+# Emit per-backend overlay paths to stdout (one per line) based on DEX_*_ENABLED flags.
+select_connector_overlays() {
+	if is_truthy "${DEX_LDAP_ENABLED:-}"; then
+		if [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" == "true" ]]; then
+			echo "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml"
+		else
+			echo "${DEX_K8S}/values-tls.yaml"
+		fi
+	fi
+	is_truthy "${DEX_GOOGLE_ENABLED:-}"    && echo "${DEX_K8S}/values-google.yaml"    || true
+	is_truthy "${DEX_MICROSOFT_ENABLED:-}" && echo "${DEX_K8S}/values-microsoft.yaml" || true
+}
+
+# Render placeholders in each overlay then compose them into a single connectors values file.
+# Args: <output-path> <overlay-path...>
+compose_connectors() {
+	local out="$1"; shift
+	if [[ "$#" -eq 0 ]]; then
+		printf 'config:\n  connectors: []\n' > "${out}"
+		return
+	fi
+	local prepared=()
+	local o
+	for o in "$@"; do
+		prepared+=("$(prepare_values "${o}")")
+	done
+	python3 "${SCRIPTS}/compose_helm_values.py" --out "${out}" "${prepared[@]}"
+}
+
+# Run `helm template` for one combo. Args: <label> <connector-overlay-path...>
+helm_template_combo() {
+	local label="$1"; shift
+	local merged="${TMPDIR}/connectors-${label}.yaml"
+	compose_connectors "${merged}" "$@"
+	local vf_base vf_int vf_oidc
+	vf_base=$(prepare_values "${DEX_K8S}/values-dexidp.yaml")
+	vf_int=$(prepare_values "${DEX_K8S}/values-integration.yaml")
+	vf_oidc=$(prepare_values "${DEX_K8S}/values-dex-oidc-incluster.yaml")
+	echo "Rendering combo: ${label}"
+	helm template support-bot-dex "${CHART_REPO_NAME}/${CHART_NAME}" --version "${CHART_VERSION}" \
+		-f "${vf_base}" \
+		-f "${vf_int}" \
+		-f "${vf_oidc}" \
+		-f "${merged}" >/dev/null
 }
 
 ensure_dex_k8s_secret() {
 	local ns="$1"
-	echo "Ensuring K8s secret dex-secrets (client-id, client-secret)..."
-	kubectl create secret generic dex-secrets \
-		--from-literal=client-id="${DEX_CLIENT_ID:?Set DEX_CLIENT_ID}" \
-		--from-literal=client-secret="${DEX_CLIENT_SECRET:?Set DEX_CLIENT_SECRET}" \
+	echo "Ensuring K8s secret dex-secrets..."
+	local args=(
+		--from-literal=client-id="${DEX_CLIENT_ID:?Set DEX_CLIENT_ID}"
+		--from-literal=client-secret="${DEX_CLIENT_SECRET:?Set DEX_CLIENT_SECRET}"
+	)
+	[[ -n "${LDAP_BOOTSTRAP_USER_PASSWORD:-}" ]] && args+=(--from-literal=ldap-bind-password="${LDAP_BOOTSTRAP_USER_PASSWORD}")
+	[[ -n "${DEX_GOOGLE_CLIENT_ID:-}" ]]         && args+=(--from-literal=google-client-id="${DEX_GOOGLE_CLIENT_ID}")
+	[[ -n "${DEX_GOOGLE_CLIENT_SECRET:-}" ]]     && args+=(--from-literal=google-client-secret="${DEX_GOOGLE_CLIENT_SECRET}")
+	[[ -n "${DEX_MICROSOFT_CLIENT_ID:-}" ]]      && args+=(--from-literal=microsoft-client-id="${DEX_MICROSOFT_CLIENT_ID}")
+	[[ -n "${DEX_MICROSOFT_CLIENT_SECRET:-}" ]]  && args+=(--from-literal=microsoft-client-secret="${DEX_MICROSOFT_CLIENT_SECRET}")
+	kubectl create secret generic dex-secrets "${args[@]}" \
 		-n "${ns}" --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Read selected overlays into SELECTED_OVERLAYS (portable to bash 3.2 / macOS).
+read_selected_overlays() {
+	SELECTED_OVERLAYS=()
+	local line
+	while IFS= read -r line; do
+		[[ -n "${line}" ]] && SELECTED_OVERLAYS+=("${line}")
+	done < <(select_connector_overlays)
+}
+
+require_at_least_one_backend() {
+	if [[ "${#SELECTED_OVERLAYS[@]}" -eq 0 ]]; then
+		echo "No connector enabled. Set at least one of DEX_LDAP_ENABLED, DEX_GOOGLE_ENABLED, DEX_MICROSOFT_ENABLED." >&2
+		echo "See dex/.env.example and api/k8s/dex/README.md." >&2
+		exit 1
+	fi
 }
 
 case "${OP}" in
 template)
-	vf_base=$(prepare_values "${DEX_K8S}/values-dexidp.yaml")
-	vf_int=$(prepare_values "${DEX_K8S}/values-integration.yaml")
-	vf_plain=$(prepare_values "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml")
-	vf_oidc=$(prepare_values "${DEX_K8S}/values-dex-oidc-incluster.yaml")
-	helm template support-bot-dex "${CHART_REPO_NAME}/${CHART_NAME}" --version "${CHART_VERSION}" \
-		-f "${vf_base}" \
-		-f "${vf_int}" \
-		-f "${vf_plain}" \
-		-f "${vf_oidc}" >/dev/null
+	# Render every meaningful combination so values mistakes for any backend are caught in CI,
+	# not only when an operator first enables that backend on a real cluster.
+	helm_template_combo "ldap-tls"        "${DEX_K8S}/values-tls.yaml"
+	helm_template_combo "ldap-plaintext"  "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml"
+	helm_template_combo "google"          "${DEX_K8S}/values-google.yaml"
+	helm_template_combo "microsoft"       "${DEX_K8S}/values-microsoft.yaml"
+	helm_template_combo "ldap-tls-google" "${DEX_K8S}/values-tls.yaml" "${DEX_K8S}/values-google.yaml"
+	helm_template_combo "all-three-tls"   "${DEX_K8S}/values-tls.yaml" "${DEX_K8S}/values-google.yaml" "${DEX_K8S}/values-microsoft.yaml"
+	helm_template_combo "all-three-plain" "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml" "${DEX_K8S}/values-google.yaml" "${DEX_K8S}/values-microsoft.yaml"
 	;;
 deploy-integration)
-	if [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" != "true" ]]; then
+	if is_truthy "${DEX_LDAP_ENABLED:-}" && [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" != "true" ]]; then
 		echo "Refusing to deploy Dex with plaintext LDAP (insecureNoSSL on port 389)." >&2
 		echo "That connector must only be used on disposable integration namespaces." >&2
-		echo "Set DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true to confirm, or deploy without" >&2
-		echo "values-integration-ldap-plaintext-ephemeral.yaml and use values-tls.yaml for LDAP/TLS." >&2
+		echo "Set DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true to confirm, or unset DEX_LDAP_ENABLED" >&2
+		echo "and use values-tls.yaml via deploy-prod for LDAP/TLS." >&2
 		echo "Repo Makefile target dex-deploy-integration sets this for integration-test infra." >&2
 		echo "See api/k8s/dex/README.md and docs/runbooks/auth-dex-ldap.md." >&2
 		exit 1
@@ -61,11 +152,14 @@ deploy-integration)
 	NAMESPACE="${NAMESPACE:?Set NAMESPACE}"
 	ensure_dex_k8s_secret "${NAMESPACE}"
 
-	LDAP_BIND_PW="${LDAP_BOOTSTRAP_USER_PASSWORD:?Set LDAP_BOOTSTRAP_USER_PASSWORD}"
+	read_selected_overlays
+	require_at_least_one_backend
+
+	merged="${TMPDIR}/connectors.yaml"
+	compose_connectors "${merged}" "${SELECTED_OVERLAYS[@]}"
 
 	vf_base=$(prepare_values "${DEX_K8S}/values-dexidp.yaml")
 	vf_int=$(prepare_values "${DEX_K8S}/values-integration.yaml")
-	vf_plain=$(prepare_values "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml")
 	vf_oidc=$(prepare_values "${DEX_K8S}/values-dex-oidc-incluster.yaml")
 
 	extra=()
@@ -77,23 +171,31 @@ deploy-integration)
 		-n "${NAMESPACE}" \
 		-f "${vf_base}" \
 		-f "${vf_int}" \
-		-f "${vf_plain}" \
 		-f "${vf_oidc}" \
+		-f "${merged}" \
 		"${extra[@]}"
 	;;
 deploy-prod)
+	if [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" == "true" ]]; then
+		echo "deploy-prod refuses DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true. Use values-tls.yaml (DEX_LDAP_ENABLED=true with the plaintext flag unset)." >&2
+		exit 1
+	fi
+
 	NAMESPACE="${NAMESPACE:?Set NAMESPACE}"
 	ensure_dex_k8s_secret "${NAMESPACE}"
 
-	LDAP_BIND_PW="${LDAP_BOOTSTRAP_USER_PASSWORD:?Set LDAP_BOOTSTRAP_USER_PASSWORD}"
+	read_selected_overlays
+	require_at_least_one_backend
+
+	merged="${TMPDIR}/connectors.yaml"
+	compose_connectors "${merged}" "${SELECTED_OVERLAYS[@]}"
 
 	vf_base=$(prepare_values "${DEX_K8S}/values-dexidp.yaml")
-	vf_tls=$(prepare_values "${DEX_K8S}/values-tls.yaml")
 
 	helm upgrade --install support-bot-dex "${CHART_REPO_NAME}/${CHART_NAME}" --version "${CHART_VERSION}" \
 		-n "${NAMESPACE}" \
 		-f "${vf_base}" \
-		-f "${vf_tls}"
+		-f "${merged}"
 	;;
 *)
 	echo "usage: $0 template|deploy-integration|deploy-prod" >&2

--- a/dex/scripts/helm_dex.sh
+++ b/dex/scripts/helm_dex.sh
@@ -50,7 +50,7 @@ is_truthy() {
 # Emit per-backend overlay paths to stdout (one per line) based on DEX_*_ENABLED flags.
 select_connector_overlays() {
 	if is_truthy "${DEX_LDAP_ENABLED:-}"; then
-		if [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" == "true" ]]; then
+		if is_truthy "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}"; then
 			echo "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml"
 		else
 			echo "${DEX_K8S}/values-tls.yaml"
@@ -164,18 +164,18 @@ template)
 	helm_template_combo "ldap-tls"        "${DEX_K8S}/values-tls.yaml"
 	helm_template_combo "ldap-plaintext"  "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml"
 	helm_template_combo "google"          "${DEX_K8S}/values-google.yaml"
-	helm_template_combo "microsoft"       "${DEX_K8S}/values-microsoft.yaml"
-	helm_template_combo "ldap-tls-google" "${DEX_K8S}/values-tls.yaml" "${DEX_K8S}/values-google.yaml"
+	helm_template_combo "microsoft"        "${DEX_K8S}/values-microsoft.yaml"
+	helm_template_combo "google-microsoft" "${DEX_K8S}/values-google.yaml" "${DEX_K8S}/values-microsoft.yaml"
+	helm_template_combo "ldap-tls-google"  "${DEX_K8S}/values-tls.yaml" "${DEX_K8S}/values-google.yaml"
 	helm_template_combo "all-three-tls"   "${DEX_K8S}/values-tls.yaml" "${DEX_K8S}/values-google.yaml" "${DEX_K8S}/values-microsoft.yaml"
 	helm_template_combo "all-three-plain" "${DEX_K8S}/values-integration-ldap-plaintext-ephemeral.yaml" "${DEX_K8S}/values-google.yaml" "${DEX_K8S}/values-microsoft.yaml"
 	;;
 deploy-integration)
-	if is_truthy "${DEX_LDAP_ENABLED:-}" && [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" != "true" ]]; then
-		echo "Refusing to deploy Dex with plaintext LDAP (insecureNoSSL on port 389)." >&2
-		echo "That connector must only be used on disposable integration namespaces." >&2
-		echo "Set DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true to confirm, or unset DEX_LDAP_ENABLED" >&2
-		echo "and use values-tls.yaml via deploy-prod for LDAP/TLS." >&2
-		echo "Repo Makefile target dex-deploy-integration sets this for integration-test infra." >&2
+	if is_truthy "${DEX_LDAP_ENABLED:-}" && ! is_truthy "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}"; then
+		echo "deploy-integration only supports LDAP when DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true." >&2
+		echo "  - Set DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true to confirm plaintext on this ephemeral namespace." >&2
+		echo "  - Or unset DEX_LDAP_ENABLED and use deploy-prod for LDAP over TLS." >&2
+		echo "The repo Makefile target dex-deploy-integration sets the confirmation flag for integration-test infra." >&2
 		echo "See api/k8s/dex/README.md and docs/runbooks/auth-dex-ldap.md." >&2
 		exit 1
 	fi
@@ -209,7 +209,7 @@ deploy-integration)
 		"${extra[@]}"
 	;;
 deploy-prod)
-	if [[ "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}" == "true" ]]; then
+	if is_truthy "${DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT:-}"; then
 		echo "deploy-prod refuses DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true. Use values-tls.yaml (DEX_LDAP_ENABLED=true with the plaintext flag unset)." >&2
 		exit 1
 	fi

--- a/dex/scripts/helm_dex.sh
+++ b/dex/scripts/helm_dex.sh
@@ -126,6 +126,37 @@ require_at_least_one_backend() {
 	fi
 }
 
+# Fail loudly if a backend is enabled but its credentials are missing — without this,
+# prepare_values() would substitute the helm-template-placeholder-* defaults into a
+# real deploy, producing a Dex pod that starts cleanly but rejects every login.
+# Skipped by the template op (no real cluster, placeholders are fine for chart validation).
+require_credentials_for_enabled_backends() {
+	local missing=()
+	if is_truthy "${DEX_LDAP_ENABLED:-}"; then
+		[[ -n "${LDAP_BOOTSTRAP_USER_PASSWORD:-}" ]] || missing+=("LDAP_BOOTSTRAP_USER_PASSWORD (DEX_LDAP_ENABLED)")
+	fi
+	if is_truthy "${DEX_GOOGLE_ENABLED:-}"; then
+		[[ -n "${DEX_GOOGLE_CLIENT_ID:-}" ]]     || missing+=("DEX_GOOGLE_CLIENT_ID (DEX_GOOGLE_ENABLED)")
+		[[ -n "${DEX_GOOGLE_CLIENT_SECRET:-}" ]] || missing+=("DEX_GOOGLE_CLIENT_SECRET (DEX_GOOGLE_ENABLED)")
+	fi
+	if is_truthy "${DEX_MICROSOFT_ENABLED:-}"; then
+		[[ -n "${DEX_MICROSOFT_CLIENT_ID:-}" ]]     || missing+=("DEX_MICROSOFT_CLIENT_ID (DEX_MICROSOFT_ENABLED)")
+		[[ -n "${DEX_MICROSOFT_CLIENT_SECRET:-}" ]] || missing+=("DEX_MICROSOFT_CLIENT_SECRET (DEX_MICROSOFT_ENABLED)")
+	fi
+	if is_truthy "${DEX_GOOGLE_ENABLED:-}" || is_truthy "${DEX_MICROSOFT_ENABLED:-}"; then
+		[[ -n "${DEX_ISSUER:-}" ]] || missing+=("DEX_ISSUER (required for Google/Microsoft redirectURI; must match config.issuer in your Dex values)")
+	fi
+	if [[ "${#missing[@]}" -gt 0 ]]; then
+		echo "Missing required env vars for enabled Dex connectors:" >&2
+		local m
+		for m in "${missing[@]}"; do
+			echo "  - ${m}" >&2
+		done
+		echo "See dex/.env.example and api/k8s/dex/README.md." >&2
+		exit 1
+	fi
+}
+
 case "${OP}" in
 template)
 	# Render every meaningful combination so values mistakes for any backend are caught in CI,
@@ -150,10 +181,12 @@ deploy-integration)
 	fi
 
 	NAMESPACE="${NAMESPACE:?Set NAMESPACE}"
-	ensure_dex_k8s_secret "${NAMESPACE}"
 
 	read_selected_overlays
 	require_at_least_one_backend
+	require_credentials_for_enabled_backends
+
+	ensure_dex_k8s_secret "${NAMESPACE}"
 
 	merged="${TMPDIR}/connectors.yaml"
 	compose_connectors "${merged}" "${SELECTED_OVERLAYS[@]}"
@@ -182,10 +215,12 @@ deploy-prod)
 	fi
 
 	NAMESPACE="${NAMESPACE:?Set NAMESPACE}"
-	ensure_dex_k8s_secret "${NAMESPACE}"
 
 	read_selected_overlays
 	require_at_least_one_backend
+	require_credentials_for_enabled_backends
+
+	ensure_dex_k8s_secret "${NAMESPACE}"
 
 	merged="${TMPDIR}/connectors.yaml"
 	compose_connectors "${merged}" "${SELECTED_OVERLAYS[@]}"

--- a/dex/scripts/test_compose_helm_values.py
+++ b/dex/scripts/test_compose_helm_values.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Unit tests for compose_helm_values.py — the per-backend overlay composer."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import compose_helm_values as composer  # noqa: E402
+
+
+SCRIPTS_DIR = Path(__file__).parent
+REAL_OVERLAYS_DIR = (SCRIPTS_DIR / ".." / ".." / "api" / "k8s" / "dex").resolve()
+
+
+class TempOverlayMixin:
+    """Helpers for writing throwaway overlay files in each test."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmp.name)
+        self.out = self.tmpdir / "merged.yaml"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def write_overlay(self, name: str, body: str) -> Path:
+        path = self.tmpdir / name
+        path.write_text(body)
+        return path
+
+
+class ExtractConnectorsBlockTests(TempOverlayMixin, unittest.TestCase):
+    def test_returns_lines_under_connectors_key(self) -> None:
+        path = self.write_overlay(
+            "ldap.yaml",
+            "config:\n  connectors:\n    - type: ldap\n      id: ldap\n      name: LDAP\n",
+        )
+        result = composer.extract_connectors_block(path)
+        self.assertEqual(
+            result, "    - type: ldap\n      id: ldap\n      name: LDAP\n"
+        )
+
+    def test_missing_connectors_key_raises(self) -> None:
+        path = self.write_overlay(
+            "no-connectors.yaml", "config:\n  staticClients: []\n"
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            composer.extract_connectors_block(path)
+        self.assertIn("missing 'connectors:'", str(ctx.exception))
+
+    def test_empty_connectors_block_raises(self) -> None:
+        path = self.write_overlay("empty.yaml", "config:\n  connectors:\n\n")
+        with self.assertRaises(SystemExit) as ctx:
+            composer.extract_connectors_block(path)
+        self.assertIn("empty", str(ctx.exception))
+
+    def test_strips_trailing_blank_lines_but_preserves_indentation(self) -> None:
+        path = self.write_overlay(
+            "trailing.yaml",
+            "config:\n  connectors:\n    - type: ldap\n      id: ldap\n\n\n",
+        )
+        result = composer.extract_connectors_block(path)
+        self.assertEqual(result, "    - type: ldap\n      id: ldap\n")
+
+    def test_tolerates_header_and_inline_comments(self) -> None:
+        path = self.write_overlay(
+            "commented.yaml",
+            "# Header comment\n"
+            "# Another header line\n"
+            "config:\n"
+            "  connectors:\n"
+            "    # inline comment\n"
+            "    - type: ldap\n"
+            "      id: ldap\n",
+        )
+        result = composer.extract_connectors_block(path)
+        self.assertIn("- type: ldap", result)
+        self.assertIn("# inline comment", result)
+
+
+class CollectConnectorIdsTests(unittest.TestCase):
+    def test_single_id(self) -> None:
+        block = "    - type: ldap\n      id: ldap\n      name: LDAP\n"
+        self.assertEqual(composer.collect_connector_ids(block), ["ldap"])
+
+    def test_multiple_ids_in_order(self) -> None:
+        block = (
+            "    - type: ldap\n      id: ldap\n"
+            "    - type: google\n      id: google\n"
+            "    - type: microsoft\n      id: microsoft\n"
+        )
+        self.assertEqual(
+            composer.collect_connector_ids(block), ["ldap", "google", "microsoft"]
+        )
+
+    def test_no_ids_returns_empty(self) -> None:
+        self.assertEqual(composer.collect_connector_ids("    - type: ldap\n"), [])
+
+
+class MainTests(TempOverlayMixin, unittest.TestCase):
+    def test_single_overlay_produces_wellformed_merged_file(self) -> None:
+        a = self.write_overlay(
+            "ldap.yaml",
+            "config:\n  connectors:\n    - type: ldap\n      id: ldap\n",
+        )
+        composer.main(["--out", str(self.out), str(a)])
+        text = self.out.read_text()
+        self.assertTrue(text.startswith("config:\n  connectors:\n"))
+        self.assertIn("    - type: ldap", text)
+        self.assertIn("      id: ldap", text)
+
+    def test_two_overlays_concatenate_in_argument_order(self) -> None:
+        a = self.write_overlay(
+            "ldap.yaml",
+            "config:\n  connectors:\n    - type: ldap\n      id: ldap\n",
+        )
+        b = self.write_overlay(
+            "google.yaml",
+            "config:\n  connectors:\n    - type: google\n      id: google\n",
+        )
+        composer.main(["--out", str(self.out), str(a), str(b)])
+        text = self.out.read_text()
+        # Order is preserved by argv order, not filename
+        self.assertLess(text.index("id: ldap"), text.index("id: google"))
+
+    def test_duplicate_connector_id_raises(self) -> None:
+        a = self.write_overlay(
+            "ldap-a.yaml",
+            "config:\n  connectors:\n    - type: ldap\n      id: ldap\n",
+        )
+        b = self.write_overlay(
+            "ldap-b.yaml",
+            "config:\n  connectors:\n    - type: ldap\n      id: ldap\n",
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            composer.main(["--out", str(self.out), str(a), str(b)])
+        msg = str(ctx.exception)
+        self.assertIn("Duplicate connector id 'ldap'", msg)
+        self.assertIn(str(b), msg)
+        self.assertIn(str(a), msg)
+
+
+class RealOverlayIntegrationTests(TempOverlayMixin, unittest.TestCase):
+    """Smoke-test the composer against the actual per-backend overlays we ship.
+
+    Catches regressions where someone adds a key to a real overlay without
+    updating the composer (e.g. adds a sibling to `connectors:` under `config:`).
+    """
+
+    def test_all_three_overlays_merge_into_three_connectors(self) -> None:
+        composer.main(
+            [
+                "--out",
+                str(self.out),
+                str(REAL_OVERLAYS_DIR / "values-tls.yaml"),
+                str(REAL_OVERLAYS_DIR / "values-google.yaml"),
+                str(REAL_OVERLAYS_DIR / "values-microsoft.yaml"),
+            ]
+        )
+        text = self.out.read_text()
+        ids = composer.collect_connector_ids(text)
+        self.assertEqual(ids, ["ldap", "google", "microsoft"])
+
+    def test_two_ldap_overlays_collide_on_id(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            composer.main(
+                [
+                    "--out",
+                    str(self.out),
+                    str(REAL_OVERLAYS_DIR / "values-tls.yaml"),
+                    str(
+                        REAL_OVERLAYS_DIR
+                        / "values-integration-ldap-plaintext-ephemeral.yaml"
+                    ),
+                ]
+            )
+        self.assertIn("Duplicate connector id 'ldap'", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dex/scripts/test_compose_helm_values.py
+++ b/dex/scripts/test_compose_helm_values.py
@@ -81,6 +81,30 @@ class ExtractConnectorsBlockTests(TempOverlayMixin, unittest.TestCase):
         self.assertIn("- type: ldap", result)
         self.assertIn("# inline comment", result)
 
+    def test_stops_capturing_at_sibling_key_under_config(self) -> None:
+        path = self.write_overlay(
+            "with-sibling.yaml",
+            "config:\n"
+            "  connectors:\n"
+            "    - type: ldap\n"
+            "      id: ldap\n"
+            "  staticClients:\n"
+            "    - id: should-not-appear\n",
+        )
+        result = composer.extract_connectors_block(path)
+        self.assertIn("- type: ldap", result)
+        self.assertNotIn("staticClients", result)
+        self.assertNotIn("should-not-appear", result)
+
+    def test_top_level_connectors_without_config_parent_raises(self) -> None:
+        path = self.write_overlay(
+            "no-config.yaml",
+            "connectors:\n  - type: ldap\n    id: ldap\n",
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            composer.extract_connectors_block(path)
+        self.assertIn("config:", str(ctx.exception))
+
 
 class CollectConnectorIdsTests(unittest.TestCase):
     def test_single_id(self) -> None:


### PR DESCRIPTION
## Summary

- Operators can now enable any combination of **LDAP / Google / Microsoft** connectors at Dex deploy time via `DEX_LDAP_ENABLED` / `DEX_GOOGLE_ENABLED` / `DEX_MICROSOFT_ENABLED`. The local Docker flow already supported this — this PR brings the Helm flow in line.
- Adds per-backend overlays `values-google.yaml` and `values-microsoft.yaml` (LDAP overlays already existed) and a Python composer (`dex/scripts/compose_helm_values.py`) that concatenates the enabled overlays' `config.connectors` lists into one merged values file before `helm` runs.
- `helm_dex.sh` now drives selection from env flags, mirrors `google-client-*` / `microsoft-client-*` / `ldap-bind-password` into the `dex-secrets` Kubernetes Secret when set, and renders **every meaningful combo** in the `template` op so CI catches values mistakes for any backend.

## Why a composer at all?

Helm's overlay merge replaces YAML lists wholesale (`config.connectors: [...]` in a later \`-f\` overrides earlier ones), so just stacking per-backend overlays would silently drop all but the last connector. Two viable fixes:

| Option | Approach | Pros | Cons |
|---|---|---|---|
| \`yq\` merge | Use \`yq ea '. *+ \$i'\` inside \`helm_dex.sh\` to deep-merge connector lists | ~8 lines of bash; no new code to maintain | New external dependency (\`mikefarah/yq\`); cryptic merge expression that contributors will Google every time |
| **Python composer** *(this PR)* | Stdlib-only \`compose_helm_values.py\` that extracts \`config.connectors\` blocks and concatenates them | No new system dep; mirrors the existing \`dex/scripts/render_config.py\` pattern (one mental model for local + Helm); plain-Python merge logic is easy to read and debug; fails fast on duplicate connector ids | ~30 LOC we own |

Went with the **Python composer**: consistency with \`render_config.py\`, no new dependency to install on deploy hosts / in CI, and the merge logic stays inspectable without learning yq's expression language.

## Test plan

- [x] \`make -C dex template\` renders all 7 combos cleanly (LDAP TLS, LDAP plaintext, Google, Microsoft, LDAP+Google, all-three TLS, all-three plaintext)
- [x] Decoded the rendered Dex \`Secret\` for the all-three combo — \`config.yaml\` contains \`ldap\`, \`google\`, \`microsoft\` connectors as expected
- [x] Local \`dex/scripts/render_config.py\` flow still produces all 3 connectors when flags set (no regression)
- [x] Composer fails fast on duplicate connector ids (e.g. enabling both LDAP TLS and LDAP plaintext)
- [x] Shell + Python syntax checks pass
- [ ] End-to-end on a disposable integration namespace (\`make dex-deploy-integration\` with \`DEX_LDAP_ENABLED=true DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true\`); confirm \`/.well-known/openid-configuration\` and login page show the enabled connectors
- [ ] CI \`dex-fast-feedback.yaml\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PT-392]: https://cecg-force.atlassian.net/browse/PT-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
