### PR TITLE
fix(ui): keep backend tokens server-side

### DIFF
--- a/ui/src/app/api/_lib/__tests__/proxy-fetch.test.ts
+++ b/ui/src/app/api/_lib/__tests__/proxy-fetch.test.ts
@@ -1,5 +1,9 @@
 import { proxyFetch } from '../backend-fetch'
 
+jest.mock('next-auth/jwt', () => ({
+  getToken: jest.fn(),
+}))
+
 describe('proxyFetch', () => {
   const originalFetch = global.fetch
 

--- a/ui/src/app/api/_lib/backend-fetch.ts
+++ b/ui/src/app/api/_lib/backend-fetch.ts
@@ -1,6 +1,27 @@
-import { auth } from "@/auth";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
 const BACKEND_URL = process.env.BACKEND_URL!;
+
+function sessionCookieName(): string {
+  return process.env.NODE_ENV === "production"
+    ? "__Secure-authjs.session-token"
+    : "authjs.session-token";
+}
+
+export async function backendAccessToken(
+  request: Request | NextRequest
+): Promise<string | null> {
+  const cookieName = sessionCookieName();
+  const token = await getToken({
+    req: request,
+    secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
+    cookieName,
+    salt: cookieName,
+  });
+
+  return typeof token?.accessToken === "string" ? token.accessToken : null;
+}
 
 /**
  * Fetch with logging and error handling.
@@ -36,19 +57,20 @@ export async function proxyFetch(
  * Returns null if user is not authenticated (caller should handle 401).
  */
 export async function backendFetch(
+  request: Request | NextRequest,
   path: string,
   options: RequestInit = {}
 ): Promise<Response | null> {
-  const session = await auth();
+  const accessToken = await backendAccessToken(request);
 
-  if (!session?.accessToken) {
+  if (!accessToken) {
     return null;
   }
 
   const headers = new Headers(options.headers);
   headers.set("Content-Type", "application/json");
   headers.set("Accept", "application/json");
-  headers.set("Authorization", `Bearer ${session.accessToken}`);
+  headers.set("Authorization", `Bearer ${accessToken}`);
 
   const url = path.startsWith("http") ? path : `${BACKEND_URL}${path}`;
   return proxyFetch("proxy", path, url, { ...options, headers });

--- a/ui/src/app/api/analysis/enabled/route.ts
+++ b/ui/src/app/api/analysis/enabled/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/analysis/enabled");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/analysis/enabled");
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/analysis/run/route.ts
+++ b/ui/src/app/api/analysis/run/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams.toString();
   const query = searchParams ? `?${searchParams}` : "";
 
-  const response = await backendFetch(`/analysis/run${query}`, {
+  const response = await backendFetch(request, `/analysis/run${query}`, {
     method: "POST",
   });
   if (!response) return unauthorizedResponse();

--- a/ui/src/app/api/analysis/status/route.ts
+++ b/ui/src/app/api/analysis/status/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/analysis/status");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/analysis/status");
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/assignment/bulk-reassign/route.ts
+++ b/ui/src/app/api/assignment/bulk-reassign/route.ts
@@ -8,7 +8,7 @@ import {
 export async function POST(request: NextRequest) {
   const body = await request.json();
 
-  const response = await backendFetch("/assignment/bulk-reassign", {
+  const response = await backendFetch(request, "/assignment/bulk-reassign", {
     method: "POST",
     body: JSON.stringify(body),
   });

--- a/ui/src/app/api/assignment/enabled/route.ts
+++ b/ui/src/app/api/assignment/enabled/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/assignment/enabled");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/assignment/enabled");
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/dashboard/[endpoint]/route.ts
+++ b/ui/src/app/api/dashboard/[endpoint]/route.ts
@@ -57,7 +57,7 @@ export async function GET(
   const queryString = backendParams.toString();
   const backendPath = `/dashboard/${endpoint}${queryString ? `?${queryString}` : ""}`;
 
-  const response = await backendFetch(backendPath);
+  const response = await backendFetch(request, backendPath);
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/escalations/[id]/permalink/route.ts
+++ b/ui/src/app/api/escalations/[id]/permalink/route.ts
@@ -24,13 +24,13 @@ function errorPage(message: string, status: number) {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
 
   try {
-    const response = await backendFetch(`/escalation/${id}/permalink`);
+    const response = await backendFetch(request, `/escalation/${id}/permalink`);
     if (!response) return unauthorizedResponse();
 
     if (!response.ok) {

--- a/ui/src/app/api/escalations/route.ts
+++ b/ui/src/app/api/escalations/route.ts
@@ -16,6 +16,7 @@ export async function GET(request: NextRequest) {
   const pageSize = searchParams.get("pageSize") ?? "50";
 
   const response = await backendFetch(
+    request,
     `/escalation?page=${page}&pageSize=${pageSize}&escalated=true`
   );
   if (!response) return unauthorizedResponse();

--- a/ui/src/app/api/knowledge-gaps/enabled/route.ts
+++ b/ui/src/app/api/knowledge-gaps/enabled/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/knowledge-gaps/enabled");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/knowledge-gaps/enabled");
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/registry/route.ts
+++ b/ui/src/app/api/registry/route.ts
@@ -1,14 +1,15 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../_lib/backend-fetch";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   // Fetch both impacts and tags in parallel
   const [impactsRes, tagsRes] = await Promise.all([
-    backendFetch("/registry/impact"),
-    backendFetch("/registry/tag"),
+    backendFetch(request, "/registry/impact"),
+    backendFetch(request, "/registry/tag"),
   ]);
 
   if (!impactsRes || !tagsRes) return unauthorizedResponse();

--- a/ui/src/app/api/stats/ratings/route.ts
+++ b/ui/src/app/api/stats/ratings/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
   if (from) statsRequest.from = from;
   if (to) statsRequest.to = to;
 
-  const response = await backendFetch("/stats", {
+  const response = await backendFetch(request, "/stats", {
     method: "POST",
     body: JSON.stringify([statsRequest]),
   });

--- a/ui/src/app/api/summary-data/analysis/route.ts
+++ b/ui/src/app/api/summary-data/analysis/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest } from "next/server";
-import { auth } from "@/auth";
-import { unauthorizedResponse, errorResponse } from "../../_lib/backend-fetch";
+import { backendAccessToken, unauthorizedResponse, errorResponse } from "../../_lib/backend-fetch";
 
 const BACKEND_URL = process.env.BACKEND_URL!;
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
+  const accessToken = await backendAccessToken(request);
 
-  if (!session?.accessToken) {
+  if (!accessToken) {
     return unauthorizedResponse();
   }
 
@@ -35,7 +34,7 @@ export async function GET(request: NextRequest) {
   try {
     const response = await fetch(url, {
       headers: {
-        Authorization: `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
         Accept: "application/zip",
       },
     });
@@ -57,4 +56,3 @@ export async function GET(request: NextRequest) {
     return errorResponse("Failed to fetch analysis bundle from backend", 502);
   }
 }
-

--- a/ui/src/app/api/summary-data/export/route.ts
+++ b/ui/src/app/api/summary-data/export/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest } from "next/server";
-import { auth } from "@/auth";
-import { unauthorizedResponse, errorResponse } from "../../_lib/backend-fetch";
+import { backendAccessToken, unauthorizedResponse, errorResponse } from "../../_lib/backend-fetch";
 
 const BACKEND_URL = process.env.BACKEND_URL!;
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
+  const accessToken = await backendAccessToken(request);
 
-  if (!session?.accessToken) {
+  if (!accessToken) {
     return unauthorizedResponse();
   }
 
@@ -38,7 +37,7 @@ export async function GET(request: NextRequest) {
   try {
     const response = await fetch(url, {
       headers: {
-        Authorization: `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
         Accept: "application/zip",
       },
     });
@@ -60,4 +59,3 @@ export async function GET(request: NextRequest) {
     return errorResponse("Failed to fetch export data from backend", 502);
   }
 }
-

--- a/ui/src/app/api/summary-data/import/route.ts
+++ b/ui/src/app/api/summary-data/import/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest } from "next/server";
-import { auth } from "@/auth";
-import { unauthorizedResponse, errorResponse } from "../../_lib/backend-fetch";
+import { backendAccessToken, unauthorizedResponse, errorResponse } from "../../_lib/backend-fetch";
 
 const BACKEND_URL = process.env.BACKEND_URL!;
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
+  const accessToken = await backendAccessToken(request);
 
-  if (!session?.accessToken) {
+  if (!accessToken) {
     return unauthorizedResponse();
   }
 
@@ -42,7 +41,7 @@ export async function POST(request: NextRequest) {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
       body: formData, // Send the FormData directly
     });
@@ -58,4 +57,3 @@ export async function POST(request: NextRequest) {
     return errorResponse("Failed to upload file", 500);
   }
 }
-

--- a/ui/src/app/api/summary-data/results/route.ts
+++ b/ui/src/app/api/summary-data/results/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/summary-data/results");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/summary-data/results");
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/teams/route.ts
+++ b/ui/src/app/api/teams/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     return errorResponse("Invalid type parameter", 400);
   }
 
-  const response = await backendFetch(`/team?type=${type}`);
+  const response = await backendFetch(request, `/team?type=${type}`);
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/tenant-insights/enabled/route.ts
+++ b/ui/src/app/api/tenant-insights/enabled/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/tenant-insights/enabled");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/tenant-insights/enabled");
   if (!response) return unauthorizedResponse();
 
   if (response.status === 404) {

--- a/ui/src/app/api/tenant-insights/escalation-breakdown/route.ts
+++ b/ui/src/app/api/tenant-insights/escalation-breakdown/route.ts
@@ -15,6 +15,7 @@ export async function GET(request: Request) {
   const query = params.toString();
 
   const response = await backendFetch(
+    request,
     `/tenant-insights/escalation-breakdown${query ? `?${query}` : ""}`
   );
   if (!response) return unauthorizedResponse();

--- a/ui/src/app/api/tenant-insights/in-flight-prs/route.ts
+++ b/ui/src/app/api/tenant-insights/in-flight-prs/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: Request) {
   const query = params.toString();
 
   const response = await backendFetch(
+    request,
     `/tenant-insights/in-flight-prs${query ? `?${query}` : ""}`
   );
   if (!response) return unauthorizedResponse();

--- a/ui/src/app/api/tenant-insights/stats/route.ts
+++ b/ui/src/app/api/tenant-insights/stats/route.ts
@@ -15,6 +15,7 @@ export async function GET(request: Request) {
   const query = params.toString();
 
   const response = await backendFetch(
+    request,
     `/tenant-insights/pr-stats${query ? `?${query}` : ""}`
   );
   if (!response) return unauthorizedResponse();

--- a/ui/src/app/api/tickets/[id]/route.ts
+++ b/ui/src/app/api/tickets/[id]/route.ts
@@ -7,12 +7,12 @@ import {
 import { mapTicket } from "../_lib/map-ticket";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
 
-  const response = await backendFetch(`/ticket/${id}`);
+  const response = await backendFetch(request, `/ticket/${id}`);
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {
@@ -30,7 +30,7 @@ export async function PATCH(
   const { id } = await params;
   const body = await request.json();
 
-  const response = await backendFetch(`/ticket/${id}`, {
+  const response = await backendFetch(request, `/ticket/${id}`, {
     method: "PATCH",
     body: JSON.stringify(body),
   });

--- a/ui/src/app/api/tickets/[id]/team-suggestions/route.ts
+++ b/ui/src/app/api/tickets/[id]/team-suggestions/route.ts
@@ -6,12 +6,12 @@ import {
 } from "../../../_lib/backend-fetch";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
 
-  const response = await backendFetch(`/ticket/${id}/team-suggestions`);
+  const response = await backendFetch(request, `/ticket/${id}/team-suggestions`);
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/tickets/route.ts
+++ b/ui/src/app/api/tickets/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
   if (dateFrom) params.append("dateFrom", dateFrom);
   if (dateTo) params.append("dateTo", dateTo);
 
-  const response = await backendFetch(`/ticket?${params}`);
+  const response = await backendFetch(request, `/ticket?${params}`);
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/api/users/support/route.ts
+++ b/ui/src/app/api/users/support/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import {
   backendFetch,
   unauthorizedResponse,
   errorResponse,
 } from "../../_lib/backend-fetch";
 
-export async function GET() {
-  const response = await backendFetch("/user/support");
+export async function GET(request: NextRequest) {
+  const response = await backendFetch(request, "/user/support");
   if (!response) return unauthorizedResponse();
 
   if (!response.ok) {

--- a/ui/src/app/login/__tests__/page.test.tsx
+++ b/ui/src/app/login/__tests__/page.test.tsx
@@ -134,7 +134,7 @@ describe('LoginPage', () => {
   })
 
   // -------------------------------------------------------------------
-  // Popup flow — token/code arrives in popup window (has window.opener)
+  // Popup flow — code arrives in popup window (has window.opener)
   // -------------------------------------------------------------------
 
   describe('popup flow (window.opener present)', () => {
@@ -155,31 +155,7 @@ describe('LoginPage', () => {
     it('calls signIn(redirect:false), sends postMessage to opener, and closes', async () => {
       mockSignIn.mockResolvedValue({ error: undefined, ok: true, status: 200, url: '' } as any)
       mockUseSearchParams.mockReturnValue(
-        new URLSearchParams('token=mytoken&callbackUrl=/dash') as any
-      )
-
-      render(<LoginPage />)
-
-      await waitFor(() => {
-        expect(mockSignIn).toHaveBeenCalledWith('backend-token', {
-          token: 'mytoken',
-          redirect: false,
-        })
-      })
-
-      await waitFor(() => {
-        expect(mockPostMessage).toHaveBeenCalledWith(
-          { type: 'auth:success', callbackUrl: '/dash' },
-          window.location.origin
-        )
-        expect(window.close).toHaveBeenCalled()
-      })
-    })
-
-    it('handles code flow identically', async () => {
-      mockSignIn.mockResolvedValue({ error: undefined, ok: true, status: 200, url: '' } as any)
-      mockUseSearchParams.mockReturnValue(
-        new URLSearchParams('code=mycode&callbackUrl=/home') as any
+        new URLSearchParams('code=mycode&callbackUrl=/dash') as any
       )
 
       render(<LoginPage />)
@@ -193,7 +169,7 @@ describe('LoginPage', () => {
 
       await waitFor(() => {
         expect(mockPostMessage).toHaveBeenCalledWith(
-          { type: 'auth:success', callbackUrl: '/home' },
+          { type: 'auth:success', callbackUrl: '/dash' },
           window.location.origin
         )
         expect(window.close).toHaveBeenCalled()
@@ -204,7 +180,7 @@ describe('LoginPage', () => {
       mockSignIn.mockResolvedValue({
         error: 'CredentialsSignin', ok: false, status: 401, url: '',
       } as any)
-      mockUseSearchParams.mockReturnValue(new URLSearchParams('token=bad') as any)
+      mockUseSearchParams.mockReturnValue(new URLSearchParams('code=bad') as any)
 
       render(<LoginPage />)
 
@@ -221,7 +197,7 @@ describe('LoginPage', () => {
     it('sanitizes callbackUrl sent in postMessage', async () => {
       mockSignIn.mockResolvedValue({ error: undefined, ok: true, status: 200, url: '' } as any)
       mockUseSearchParams.mockReturnValue(
-        new URLSearchParams('token=t&callbackUrl=https://evil.com') as any
+        new URLSearchParams('code=c&callbackUrl=https://evil.com') as any
       )
 
       render(<LoginPage />)
@@ -238,7 +214,7 @@ describe('LoginPage', () => {
     it('does not call signIn a second time on re-render', async () => {
       mockSignIn.mockResolvedValue({ error: undefined, ok: true, status: 200, url: '' } as any)
       mockUseSearchParams.mockReturnValue(
-        new URLSearchParams('token=mytoken') as any
+        new URLSearchParams('code=mycode') as any
       )
 
       const { rerender } = render(<LoginPage />)
@@ -256,26 +232,10 @@ describe('LoginPage', () => {
   })
 
   // -------------------------------------------------------------------
-  // Non-popup flow — token/code arrives in normal page (no opener)
+  // Non-popup flow — code arrives in normal page (no opener)
   // -------------------------------------------------------------------
 
   describe('non-popup flow', () => {
-    it('calls signIn with redirect:false for token', async () => {
-      mockSignIn.mockResolvedValue({ ok: true } as any)
-      mockUseSearchParams.mockReturnValue(
-        new URLSearchParams('token=mytoken&callbackUrl=/dash') as any
-      )
-
-      render(<LoginPage />)
-
-      await waitFor(() => {
-        expect(mockSignIn).toHaveBeenCalledWith('backend-token', {
-          token: 'mytoken',
-          redirect: false,
-        })
-      })
-    })
-
     it('calls signIn with redirect:false for code', async () => {
       mockSignIn.mockResolvedValue({ ok: true } as any)
       mockUseSearchParams.mockReturnValue(
@@ -292,7 +252,7 @@ describe('LoginPage', () => {
       })
     })
 
-    it('sanitizes callbackUrl passed to signIn', async () => {
+    it('ignores token query parameters instead of signing in with bearer tokens', async () => {
       mockSignIn.mockResolvedValue({ ok: true } as any)
       mockUseSearchParams.mockReturnValue(
         new URLSearchParams('token=t&callbackUrl=//evil.com') as any
@@ -301,11 +261,9 @@ describe('LoginPage', () => {
       render(<LoginPage />)
 
       await waitFor(() => {
-        expect(mockSignIn).toHaveBeenCalledWith('backend-token', {
-          token: 't',
-          redirect: false,
-        })
+        expect(screen.getByText('Redirecting to sign-in...')).toBeInTheDocument()
       })
+      expect(mockSignIn).not.toHaveBeenCalled()
     })
 
     it('sanitizes callbackUrl in authenticated redirect', async () => {

--- a/ui/src/app/login/page.tsx
+++ b/ui/src/app/login/page.tsx
@@ -25,7 +25,6 @@ function LoginContent() {
   const [autoRedirecting, setAutoRedirecting] = useState(false);
 
   const code = searchParams.get("code");
-  const token = searchParams.get("token");
   const callbackUrl = sanitizeCallbackUrl(searchParams.get("callbackUrl"));
   const error = searchParams.get("error");
 
@@ -59,7 +58,7 @@ function LoginContent() {
   useEffect(() => {
     if (isLoading) return;
 
-    // Don't retry if we already attempted authentication with this token/code
+    // Don't retry if we already attempted authentication with this code
     if (authAttemptedRef.current) return;
 
     // Detect if we're in a popup opened by the iframe
@@ -89,12 +88,6 @@ function LoginContent() {
         });
     };
 
-    if (token) {
-      authAttemptedRef.current = true;
-      performSignIn("backend-token", { token });
-      return;
-    }
-
     if (code) {
       authAttemptedRef.current = true;
       performSignIn("backend-code", { code });
@@ -105,22 +98,26 @@ function LoginContent() {
     if (isAuthenticated) {
       router.replace(callbackUrl);
     }
-  }, [code, token, isAuthenticated, isLoading, callbackUrl, router]);
+  }, [code, isAuthenticated, isLoading, callbackUrl, router]);
 
   // Auto-redirect to Dex on mount. Skipped on iframes (popups need a user gesture),
-  // when an in-flight code/token is being completed, or when an error is being shown —
+  // when an in-flight code is being completed, or when an error is being shown —
   // those paths need the page to render so the user sees the message or completes the flow.
   useEffect(() => {
     if (autoRedirectAttempted) return;
     if (isLoading) return;
     if (isAuthenticated) return;
-    if (error || code || token) return;
+    if (error || code) return;
     if (isInIframe()) return;
 
-    setAutoRedirectAttempted(true);
-    setAutoRedirecting(true);
-    window.location.href = `/api/oauth/start/dex?callbackUrl=${encodeURIComponent(callbackUrl)}`;
-  }, [autoRedirectAttempted, isLoading, isAuthenticated, error, code, token, callbackUrl]);
+    const redirectTimer = window.setTimeout(() => {
+      setAutoRedirectAttempted(true);
+      setAutoRedirecting(true);
+      window.location.href = `/api/oauth/start/dex?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+    }, 0);
+
+    return () => window.clearTimeout(redirectTimer);
+  }, [autoRedirectAttempted, isLoading, isAuthenticated, error, code, callbackUrl]);
 
   const handleLogin = () => {
     // OAuth goes through API route - server handles redirect to backend
@@ -156,11 +153,11 @@ function LoginContent() {
   // `autoRedirectAttempted` flips and only the `autoRedirecting` state controls the spinner —
   // which the bfcache pageshow handler clears when the user pressed Back from Dex.
   const willAutoRedirectSoon =
-    !autoRedirectAttempted && !isLoading && !isAuthenticated && !error && !code && !token && !isInIframe();
-  const showSpinner = isLoading || autoRedirecting || willAutoRedirectSoon || ((code || token) && !error);
+    !autoRedirectAttempted && !isLoading && !isAuthenticated && !error && !code && !isInIframe();
+  const showSpinner = isLoading || autoRedirecting || willAutoRedirectSoon || (code && !error);
   if (showSpinner) {
     const message =
-      code || token
+      code
         ? "Completing authentication..."
         : autoRedirecting || willAutoRedirectSoon
           ? "Redirecting to sign-in..."

--- a/ui/src/auth.config.ts
+++ b/ui/src/auth.config.ts
@@ -81,7 +81,6 @@ export interface AuthUser {
 declare module "next-auth" {
   interface Session {
     user: AuthUser;
-    accessToken: string;
   }
 
   interface User extends AuthUser {
@@ -208,41 +207,6 @@ export const authConfig: NextAuthConfig = {
         return null;
       }, // authorize()
     }),
-    Credentials({
-      id: "backend-token",
-      name: "Backend Token",
-      credentials: {
-        token: { label: "Token", type: "text" },
-      },
-      async authorize(credentials) {
-        const token = credentials?.token as string;
-        if (!token) return null;
-
-        try {
-          // Token is already a valid backend JWT, just fetch user data
-          const userData = await fetchUserWithToken(token);
-          if (!userData) {
-            console.error("User fetch failed");
-            return null;
-          }
-
-          return {
-            id: userData.email as string,
-            email: userData.email as string,
-            name: userData.name as string,
-            teams: (userData.teams as Array<{ label: string; code: string; types: string[] }>).map((t) => ({
-              ...t,
-              name: t.code || t.label,
-            })),
-            roles: userData.roles as string[],
-            accessToken: token,
-          };
-        } catch (error) {
-          console.error("Authorization error:", error);
-          return null;
-        }
-      },
-    }),
   ],
 
   callbacks: {
@@ -259,7 +223,6 @@ export const authConfig: NextAuthConfig = {
     },
 
     async session({ session, token }) {
-      session.accessToken = token.accessToken as string;
       if (session.user) {
         session.user.id = token.email as string;
         session.user.email = token.email as string;

--- a/ui/src/test-utils/auth-mocks.ts
+++ b/ui/src/test-utils/auth-mocks.ts
@@ -87,13 +87,11 @@ export function mockUnauthenticatedSession(): MockSessionReturn {
  * Creates an authenticated session state with the provided user.
  */
 export function mockAuthenticatedSession(
-  user: AuthUser,
-  accessToken = "test-token"
+  user: AuthUser
 ): MockSessionReturn {
   return {
     data: {
       user,
-      accessToken,
       expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     },
     status: "authenticated",


### PR DESCRIPTION
## Summary
- Remove the backend-token credentials provider and ignore token query parameters on the login page.
- Stop copying backend JWTs into the browser-visible Auth.js session.
- Decode the encrypted Auth.js JWT server-side for UI API proxy forwarding.

## Security Impact
Previously, the UI accepted raw backend bearer tokens via `/login?token=...` and copied the backend JWT into the client-visible Auth.js session. That meant a backend access token could be leaked through browser history, copied URLs, ingress/proxy logs, referrers, screenshots, or any future XSS/session-reading bug, then replayed through the `backend-token` provider to impersonate that user.

This PR removes the token bootstrap path entirely and keeps the backend JWT out of the browser session. The backend JWT remains only in the encrypted Auth.js JWT cookie, and UI API routes decode it server-side when they need to forward authenticated requests to the backend. As a result, the browser can still call the UI BFF normally, but it no longer receives or submits raw backend bearer tokens.

## Validation
- yarn test
- yarn build
- yarn lint *(fails on existing tenant-requests React Compiler purity issue unrelated to this PR: Date.now during render in ui/src/components/tenant-requests/in-flight-prs.tsx)*