### PR TITLE
fix(workflows): skip Dex and LDAP image promotion

### DIFF
--- a/dex/Makefile
+++ b/dex/Makefile
@@ -8,10 +8,10 @@ p2p-functional:
 p2p-nft:           
 p2p-integration: template ## P2P: render then deploy (sets DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT for Dex LDAP overlay)
 	@$(MAKE) deploy-integration DEX_DEPLOY_INSECURE_LDAP_PLAINTEXT=true
-p2p-promote-to-extended-test: ## Delegate image promotion to repo root
-	@$(MAKE) -C .. p2p-promote-to-extended-test
-p2p-promote-to-prod: ## Delegate prod promotion to repo root
-	@$(MAKE) -C .. p2p-promote-to-prod
+p2p-promote-to-extended-test: ## No image artifact to promote for Dex infra module
+	@echo "NOOP: Dex uses upstream images and produces no P2P image artifact"
+p2p-promote-to-prod: ## No image artifact to promote for Dex infra module
+	@echo "NOOP: Dex uses upstream images and produces no P2P image artifact"
 p2p-extended-test: 
 p2p-prod:          
 

--- a/ldap/Makefile
+++ b/ldap/Makefile
@@ -8,10 +8,10 @@ p2p-functional:
 p2p-nft:
 p2p-integration: template ## P2P: render then deploy (sets LDAP_DEPLOY_INSECURE_PLAINTEXT for plaintext overlay)
 	@$(MAKE) deploy-integration LDAP_DEPLOY_INSECURE_PLAINTEXT=true
-p2p-promote-to-extended-test: ## Delegate image promotion to repo root
-	@$(MAKE) -C .. p2p-promote-to-extended-test
-p2p-promote-to-prod: ## Delegate prod promotion to repo root
-	@$(MAKE) -C .. p2p-promote-to-prod
+p2p-promote-to-extended-test: ## No image artifact to promote for LDAP infra module
+	@echo "NOOP: LDAP uses upstream images and produces no P2P image artifact"
+p2p-promote-to-prod: ## No image artifact to promote for LDAP infra module
+	@echo "NOOP: LDAP uses upstream images and produces no P2P image artifact"
 p2p-extended-test:
 p2p-prod:
 


### PR DESCRIPTION
## Summary
- Dex / LDAP Fast Feedback will always fail at the promote step when running on main
- Change Dex P2P promote targets to no-op because Dex uses upstream images and produces no P2P image artifact.
- Change LDAP P2P promote targets to no-op because LDAP uses upstream images and produces no P2P image artifact.

## Verification
- Ran `make p2p-promote-to-extended-test` in `dex/`.
- Ran `make p2p-promote-to-prod` in `dex/`.
- Ran `make p2p-promote-to-extended-test` in `ldap/`.
- Ran `make p2p-promote-to-prod` in `ldap/`.