### PR TITLE
fix(integration): clean up configmap Helm release

### DIFF
--- a/api/scripts/run-integration-tests.sh
+++ b/api/scripts/run-integration-tests.sh
@@ -26,6 +26,7 @@ cleanup_job() {
     helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --ignore-not-found || true
     helm uninstall support-bot-dex -n "$NAMESPACE" --ignore-not-found || true
     helm uninstall support-bot-ldap -n "$NAMESPACE" --ignore-not-found || true
+    HELM_DRIVER=configmap helm uninstall support-bot -n "$NAMESPACE" --ignore-not-found || true
     kubectl delete deployment support-bot -n "$NAMESPACE" --ignore-not-found || true
   else
     log_warning "Cleanup disabled. Helm releases will remain in namespace $NAMESPACE"

--- a/api/scripts/run-integration-tests.sh
+++ b/api/scripts/run-integration-tests.sh
@@ -27,7 +27,6 @@ cleanup_job() {
     helm uninstall support-bot-dex -n "$NAMESPACE" --ignore-not-found || true
     helm uninstall support-bot-ldap -n "$NAMESPACE" --ignore-not-found || true
     HELM_DRIVER=configmap helm uninstall support-bot -n "$NAMESPACE" --ignore-not-found || true
-    kubectl delete deployment support-bot -n "$NAMESPACE" --ignore-not-found || true
   else
     log_warning "Cleanup disabled. Helm releases will remain in namespace $NAMESPACE"
   fi


### PR DESCRIPTION
## Summary
- Uninstall the configmap-backed `support-bot` Helm release during integration cleanup.
- Remove the existing kubectl deployment deletion as it's redundant

## Why
`ServiceStartupTest` deploys the API with `HELM_DRIVER=configmap`, so failed or interrupted runs can leave `support-bot` stuck in `pending-install` outside the default Helm secret driver. Cleaning it with the same driver prevents retries from failing with `another operation (install/upgrade/rollback) is in progress`.

## Verification
- `bash -n api/scripts/run-integration-tests.sh`