### PR TITLE
fix(api): force patched commons-lang3 version

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -17,6 +17,7 @@ val safeDependencyVersions =
         "net.minidev:json-smart" to "2.5.2",
         "net.sourceforge.pmd:pmd-core" to "7.22.0",
         "org.apache.commons:commons-compress" to "1.26.0",
+        "org.apache.commons:commons-lang3" to "3.18.0",
         "org.apache.httpcomponents.client5:httpclient5" to "5.4.3",
         "org.assertj:assertj-core" to "3.27.7",
         "org.eclipse.jetty:jetty-http" to "12.0.35",

--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -62,6 +62,7 @@ repositories {
 extra["byte-buddy.version"] = "1.18.4"
 extra["mockito.version"] = "5.21.0"
 extra["asm.version"] = "9.9.1"
+extra["commons-lang3.version"] = "3.18.0"
 extra["netty.version"] = "4.1.133.Final"
 extra["postgresql.version"] = "42.7.11"
 extra["spring-framework.version"] = "6.2.18"


### PR DESCRIPTION
## Summary
- Forces `org.apache.commons:commons-lang3` to the patched `3.18.0` version across Gradle subprojects.
- Adds the Spring dependency-management property override so `:service:runtimeClasspath` no longer resolves vulnerable `3.17.0`.

## Verification
- `./gradlew :service:dependencyInsight --configuration runtimeClasspath --dependency org.apache.commons:commons-lang3`
- `./gradlew :testkit:dependencyInsight --configuration runtimeClasspath --dependency org.apache.commons:commons-lang3`
- `./gradlew :integration-tests:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.commons:commons-lang3`
- `./gradlew spotlessCheck`