### PR TITLE
ci: submit Gradle dependency graph

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -1,0 +1,31 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ 'main' ]
+    paths:
+      - 'api/**/*.gradle.kts'
+      - 'api/gradle/**'
+      - 'api/gradlew'
+      - 'api/gradlew.bat'
+      - '.github/workflows/gradle-dependency-submission.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v6
+        with:
+          build-root-directory: api


### PR DESCRIPTION
## Summary
- Adds a Gradle dependency submission workflow so GitHub receives the resolved API dependency graph.
- Limits automatic runs to API Gradle/wrapper changes, with `workflow_dispatch` for manual refreshes.

## Verification
- Reviewed workflow configuration locally.