### PR TITLE
fix(p2p): stabilise UI functional tests and preserve CI test logs

### DIFF
--- a/api/functional/src/test/java/com/coreeng/supportbot/TenantInsightsFunctionalTests.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/TenantInsightsFunctionalTests.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,11 @@ public class TenantInsightsFunctionalTests {
 
     @BeforeEach
     void cleanup() {
+        supportBotClient.test().cleanupPrTrackingRecords();
+    }
+
+    @AfterEach
+    void cleanupAfter() {
         supportBotClient.test().cleanupPrTrackingRecords();
     }
 

--- a/api/k8s/functional-tests/values.yaml
+++ b/api/k8s/functional-tests/values.yaml
@@ -29,8 +29,11 @@ job:
 
 resources:
   requests:
-    cpu: 256m
-    memory: 256m
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi
 
 nodeSelector: {}
 

--- a/api/k8s/integration-tests/values.yaml
+++ b/api/k8s/integration-tests/values.yaml
@@ -100,7 +100,10 @@ configMap:
 
 resources:
   requests:
-    cpu: 256m
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 500m
     memory: 1Gi
 
 nodeSelector: {}

--- a/api/k8s/integration-tests/values.yaml
+++ b/api/k8s/integration-tests/values.yaml
@@ -100,10 +100,9 @@ configMap:
 
 resources:
   requests:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 200m
+    memory: 256Mi
   limits:
-    cpu: 500m
     memory: 1Gi
 
 nodeSelector: {}

--- a/api/k8s/nft-tests/templates/job.yaml
+++ b/api/k8s/nft-tests/templates/job.yaml
@@ -25,7 +25,7 @@ spec:
             - name: SERVICE_ENDPOINT
               value: "http://support-bot:8080"
             - name: JAVA_OPTS
-              value: "-Xms2250m -Xmx2250m -Djava.util.prefs.userRoot=/tmp/java-prefs"
+              value: "-Xms1500m -Xmx1500m -Djava.util.prefs.userRoot=/tmp/java-prefs"
           ports:
             - name: slack
               containerPort: 8000

--- a/api/k8s/nft-tests/values.yaml
+++ b/api/k8s/nft-tests/values.yaml
@@ -29,7 +29,7 @@ job:
 
 resources:
   requests:
-    cpu: 500m
+    cpu: 1000m
     memory: 2Gi
   limits:
     memory: 2Gi

--- a/api/k8s/nft-tests/values.yaml
+++ b/api/k8s/nft-tests/values.yaml
@@ -29,10 +29,11 @@ job:
 
 resources:
   requests:
-    cpu: 0.5
-    memory: 2250Mi
+    cpu: 500m
+    memory: 1024Mi
   limits:
-    memory: 2500Mi
+    cpu: 500m
+    memory: 1024Mi
 
 nodeSelector: {}
 

--- a/api/k8s/nft-tests/values.yaml
+++ b/api/k8s/nft-tests/values.yaml
@@ -32,7 +32,6 @@ resources:
     cpu: 500m
     memory: 2Gi
   limits:
-    cpu: 500m
     memory: 2Gi
 
 nodeSelector: {}

--- a/api/k8s/nft-tests/values.yaml
+++ b/api/k8s/nft-tests/values.yaml
@@ -30,10 +30,10 @@ job:
 resources:
   requests:
     cpu: 500m
-    memory: 1024Mi
+    memory: 2Gi
   limits:
     cpu: 500m
-    memory: 1024Mi
+    memory: 2Gi
 
 nodeSelector: {}
 

--- a/api/scripts/deploy-service.sh
+++ b/api/scripts/deploy-service.sh
@@ -55,6 +55,7 @@ deploy_db() {
     --set global.postgresql.auth.database=supportbot \
     --set primary.pdb.create=false \
     --set primary.networkPolicy.enabled=false \
+    --set primary.resourcesPreset=small \
     --set serviceAccount.create=false \
     --wait --atomic --timeout=3m
   log_success "PostgreSQL deployed"

--- a/api/scripts/lib.sh
+++ b/api/scripts/lib.sh
@@ -81,18 +81,6 @@ show_job_status() {
   kubectl get pods -n "$ns" -l job-name="$job_name" || log_warning "Could not get pods for job $job_name"
 }
 
-# Print a Grafana Cloud-Logging deep link covering the test run. Mirrors the
-# behaviour of ui/p2p/scripts/helm-test.sh so test pods that have already been
-# cleaned up by `helm uninstall` can still be inspected via GCP Cloud Logging.
-#
-# Required env vars (set by caller before invoking):
-#   INTERNAL_SERVICES_DOMAIN  e.g. gcp-dev.cecg.platform.cecg.io
-#   PROJECT_ID                GCP project id
-#   LOGS_START                unix timestamp (s) captured before the run
-#
-# Args:
-#   $1 namespace
-#   $2 container_name (the test container, e.g. functional-tests / nft-tests)
 print_grafana_logs_url() {
   local ns="$1" container="$2"
   if [[ -z "${INTERNAL_SERVICES_DOMAIN:-}" || -z "${PROJECT_ID:-}" || -z "${LOGS_START:-}" ]]; then
@@ -105,14 +93,6 @@ print_grafana_logs_url() {
   echo "Logs: ${url}"
 }
 
-# Best-effort: dump kubectl logs from a job's pods to a local file BEFORE we
-# uninstall the release. Logs survive the pod even after helm uninstall.
-#
-# Args:
-#   $1 job_release name (matches metadata.name and helm release)
-#   $2 namespace
-#   $3 container name inside the test pod
-#   $4 destination dir (created if missing)
 save_job_logs() {
   local release="$1" ns="$2" container="$3" dest_dir="$4"
   mkdir -p "$dest_dir" 2>/dev/null || return 0
@@ -131,19 +111,12 @@ save_job_logs() {
     local out_file="${dest_dir}/${pod}.log"
     log "Saving logs: pod=${pod} container=${container} -> ${out_file}"
     {
-      echo "=== current container ==="
       kubectl logs -n "$ns" "$pod" -c "$container" --tail=-1 2>&1 || true
-      echo
-      echo "=== previous container instance (if any) ==="
       kubectl logs -n "$ns" "$pod" -c "$container" --previous --tail=-1 2>&1 || true
     } >"$out_file"
   done <<<"$pods"
 }
 
-# Sleep so node log shippers (fluent-bit) get a chance to push pod logs to
-# GCP Cloud Logging before we delete the pods. Default 30s leaves comfortable
-# headroom over fluent-bit's typical 5–15s flush+batch cycle to Cloud Logging.
-# Overridable via LOG_FLUSH_SECONDS (set to 0 to skip in dev).
 sleep_for_log_flush() {
   local secs="${LOG_FLUSH_SECONDS:-30}"
   if [[ "$secs" =~ ^[0-9]+$ ]] && (( secs > 0 )); then

--- a/api/scripts/lib.sh
+++ b/api/scripts/lib.sh
@@ -81,3 +81,74 @@ show_job_status() {
   kubectl get pods -n "$ns" -l job-name="$job_name" || log_warning "Could not get pods for job $job_name"
 }
 
+# Print a Grafana Cloud-Logging deep link covering the test run. Mirrors the
+# behaviour of ui/p2p/scripts/helm-test.sh so test pods that have already been
+# cleaned up by `helm uninstall` can still be inspected via GCP Cloud Logging.
+#
+# Required env vars (set by caller before invoking):
+#   INTERNAL_SERVICES_DOMAIN  e.g. gcp-dev.cecg.platform.cecg.io
+#   PROJECT_ID                GCP project id
+#   LOGS_START                unix timestamp (s) captured before the run
+#
+# Args:
+#   $1 namespace
+#   $2 container_name (the test container, e.g. functional-tests / nft-tests)
+print_grafana_logs_url() {
+  local ns="$1" container="$2"
+  if [[ -z "${INTERNAL_SERVICES_DOMAIN:-}" || -z "${PROJECT_ID:-}" || -z "${LOGS_START:-}" ]]; then
+    return 0
+  fi
+  local now
+  now=$(date +%s)
+  local url
+  url="https://grafana.${INTERNAL_SERVICES_DOMAIN}/explore?orgId=1&left=%7B%22datasource%22:%22CloudLogging%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryText%22:%22resource.type%3D%5C%22k8s_container%5C%22%5Cnresource.labels.namespace_name%3D%5C%22${ns}%5C%22%5Cnresource.labels.container_name%3D%5C%22${container}%5C%22%22,%22projectId%22:%22${PROJECT_ID}%22,%22bucketId%22:%22global%2Fbuckets%2F_Default%22,%22viewId%22:%22_AllLogs%22%7D%5D,%22range%22:%7B%22from%22:%22${LOGS_START}000%22,%22to%22:%22${now}000%22%7D%7D"
+  echo "Logs: ${url}"
+}
+
+# Best-effort: dump kubectl logs from a job's pods to a local file BEFORE we
+# uninstall the release. Logs survive the pod even after helm uninstall.
+#
+# Args:
+#   $1 job_release name (matches metadata.name and helm release)
+#   $2 namespace
+#   $3 container name inside the test pod
+#   $4 destination dir (created if missing)
+save_job_logs() {
+  local release="$1" ns="$2" container="$3" dest_dir="$4"
+  mkdir -p "$dest_dir" 2>/dev/null || return 0
+
+  local pods
+  pods=$(kubectl get pods -n "$ns" -l job-name="$release" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  if [[ -z "$pods" ]]; then
+    log_warning "save_job_logs: no pods found for job ${release} in ${ns}"
+    return 0
+  fi
+
+  while IFS= read -r pod; do
+    [[ -z "$pod" ]] && continue
+    local out_file="${dest_dir}/${pod}.log"
+    log "Saving logs: pod=${pod} container=${container} -> ${out_file}"
+    {
+      echo "=== current container ==="
+      kubectl logs -n "$ns" "$pod" -c "$container" --tail=-1 2>&1 || true
+      echo
+      echo "=== previous container instance (if any) ==="
+      kubectl logs -n "$ns" "$pod" -c "$container" --previous --tail=-1 2>&1 || true
+    } >"$out_file"
+  done <<<"$pods"
+}
+
+# Sleep so node log shippers (fluent-bit) get a chance to push pod logs to
+# GCP Cloud Logging before we delete the pods. Default 30s leaves comfortable
+# headroom over fluent-bit's typical 5–15s flush+batch cycle to Cloud Logging.
+# Overridable via LOG_FLUSH_SECONDS (set to 0 to skip in dev).
+sleep_for_log_flush() {
+  local secs="${LOG_FLUSH_SECONDS:-30}"
+  if [[ "$secs" =~ ^[0-9]+$ ]] && (( secs > 0 )); then
+    log "Sleeping ${secs}s to let fluent-bit ship pod logs to Cloud Logging..."
+    sleep "$secs"
+  fi
+}
+

--- a/api/scripts/run-functional-tests.sh
+++ b/api/scripts/run-functional-tests.sh
@@ -22,19 +22,13 @@ CLEAN_DEPLOY_DB="${CLEAN_DEPLOY_DB:-true}" # controls DB deployment via deploy-s
 SERVICE_IMAGE_REPOSITORY="${SERVICE_IMAGE_REPOSITORY:-}"
 SERVICE_IMAGE_TAG="${SERVICE_IMAGE_TAG:-}"
 CLEANUP="${CLEANUP:-true}"
-# Preserve pods on failure so logs are reachable AND fluent-bit has time to
-# ship them to Cloud Logging. CI can override with KEEP_ON_FAILURE=false.
 KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
 TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/functional}"
 
-# Set to 1 by main() when wait_for_job_with_logs returns non-zero.
 JOB_FAILED=0
 
 cleanup_all() {
-  # Always print the Grafana deep link, even when we keep the pods.
   print_grafana_logs_url "$NAMESPACE" "functional-tests" || true
-
-  # Best-effort: snapshot kubectl logs to disk BEFORE any potential uninstall.
   save_job_logs "$JOB_RELEASE" "$NAMESPACE" "functional-tests" "$TEST_LOGS_DIR" || true
 
   if [[ "$JOB_FAILED" == "1" && "$KEEP_ON_FAILURE" == "true" ]]; then
@@ -47,8 +41,6 @@ cleanup_all() {
   fi
 
   if [[ "$CLEANUP" == "true" ]]; then
-    # Give node-level log shippers a chance to push to Cloud Logging before
-    # we delete the pods — otherwise the Grafana URL above returns empty.
     sleep_for_log_flush
     log "Cleaning up Helm releases in namespace: $NAMESPACE"
     helm uninstall "$JOB_RELEASE" -n "$NAMESPACE" --ignore-not-found || true
@@ -59,7 +51,6 @@ cleanup_all() {
   fi
 }
 
-# Capture the run start timestamp for the Grafana URL window.
 LOGS_START=$(date +%s)
 export LOGS_START
 

--- a/api/scripts/run-functional-tests.sh
+++ b/api/scripts/run-functional-tests.sh
@@ -22,9 +22,34 @@ CLEAN_DEPLOY_DB="${CLEAN_DEPLOY_DB:-true}" # controls DB deployment via deploy-s
 SERVICE_IMAGE_REPOSITORY="${SERVICE_IMAGE_REPOSITORY:-}"
 SERVICE_IMAGE_TAG="${SERVICE_IMAGE_TAG:-}"
 CLEANUP="${CLEANUP:-true}"
+# Preserve pods on failure so logs are reachable AND fluent-bit has time to
+# ship them to Cloud Logging. CI can override with KEEP_ON_FAILURE=false.
+KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
+TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/functional}"
+
+# Set to 1 by main() when wait_for_job_with_logs returns non-zero.
+JOB_FAILED=0
 
 cleanup_all() {
+  # Always print the Grafana deep link, even when we keep the pods.
+  print_grafana_logs_url "$NAMESPACE" "functional-tests" || true
+
+  # Best-effort: snapshot kubectl logs to disk BEFORE any potential uninstall.
+  save_job_logs "$JOB_RELEASE" "$NAMESPACE" "functional-tests" "$TEST_LOGS_DIR" || true
+
+  if [[ "$JOB_FAILED" == "1" && "$KEEP_ON_FAILURE" == "true" ]]; then
+    log_warning "Functional tests failed; preserving namespace ${NAMESPACE} so logs stay reachable."
+    log_warning "  Local log snapshot: ${TEST_LOGS_DIR}/"
+    log_warning "  Inspect pods:       kubectl get pods -n ${NAMESPACE}"
+    log_warning "  Tail logs:          kubectl logs -n ${NAMESPACE} -l job-name=${JOB_RELEASE} --tail=-1"
+    log_warning "  Manual cleanup:     helm uninstall ${JOB_RELEASE} ${SERVICE_RELEASE} ${DB_RELEASE} -n ${NAMESPACE}"
+    return 0
+  fi
+
   if [[ "$CLEANUP" == "true" ]]; then
+    # Give node-level log shippers a chance to push to Cloud Logging before
+    # we delete the pods — otherwise the Grafana URL above returns empty.
+    sleep_for_log_flush
     log "Cleaning up Helm releases in namespace: $NAMESPACE"
     helm uninstall "$JOB_RELEASE" -n "$NAMESPACE" --ignore-not-found || true
     helm uninstall "$SERVICE_RELEASE" -n "$NAMESPACE" --ignore-not-found || true
@@ -33,6 +58,10 @@ cleanup_all() {
     log_warning "Cleanup disabled. Releases will remain in namespace $NAMESPACE"
   fi
 }
+
+# Capture the run start timestamp for the Grafana URL window.
+LOGS_START=$(date +%s)
+export LOGS_START
 
 trap cleanup_all EXIT
 
@@ -80,6 +109,7 @@ main() {
     log_success "Functional tests passed!"
     exit 0
   else
+    JOB_FAILED=1
     log_error "Functional tests failed!"
     show_job_status "$JOB_RELEASE" "$NAMESPACE"
     exit 1

--- a/api/scripts/run-integration-tests.sh
+++ b/api/scripts/run-integration-tests.sh
@@ -16,12 +16,35 @@ IMAGE_TAG="${IMAGE_TAG:?required argument}"
 SERVICE_IMAGE_REPOSITORY="${SERVICE_IMAGE_REPOSITORY:?required argument}"
 SERVICE_IMAGE_TAG="${SERVICE_IMAGE_TAG:?required argument}"
 CLEANUP="${CLEANUP:-true}"
+# Preserve pods on failure so logs are reachable AND fluent-bit has time to
+# ship them to Cloud Logging. CI can override with KEEP_ON_FAILURE=false.
+KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
+TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/integration}"
 
 # shellcheck source=deploy-service.sh
 . "${SCRIPT_DIR}/deploy-service.sh"
 
+# Set to 1 by main() when the integration job did not complete successfully.
+JOB_FAILED=0
+
 cleanup_job() {
+  # Print Grafana deep link first.
+  print_grafana_logs_url "$NAMESPACE" "integration-tests" || true
+
+  # Snapshot kubectl logs before uninstall so they survive pod deletion.
+  save_job_logs "$RELEASE_NAME" "$NAMESPACE" "integration-tests" "$TEST_LOGS_DIR" || true
+
+  if [[ "$JOB_FAILED" == "1" && "$KEEP_ON_FAILURE" == "true" ]]; then
+    log_warning "Integration tests failed; preserving namespace ${NAMESPACE} so logs stay reachable."
+    log_warning "  Local log snapshot: ${TEST_LOGS_DIR}/"
+    log_warning "  Inspect pods:       kubectl get pods -n ${NAMESPACE}"
+    log_warning "  Tail logs:          kubectl logs -n ${NAMESPACE} -l job-name=${RELEASE_NAME} --tail=-1"
+    log_warning "  Manual cleanup:     helm uninstall ${RELEASE_NAME} support-bot-dex support-bot-ldap support-bot ${DB_RELEASE:-support-bot-db} -n ${NAMESPACE}"
+    return 0
+  fi
+
   if [[ "$CLEANUP" == "true" ]]; then
+    sleep_for_log_flush
     log "Cleaning up Helm releases in namespace: $NAMESPACE"
     helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --ignore-not-found || true
     helm uninstall support-bot-dex -n "$NAMESPACE" --ignore-not-found || true
@@ -36,6 +59,11 @@ cleanup_job() {
     helm uninstall "$DB_RELEASE" -n "$NAMESPACE" --ignore-not-found || true
   fi
 }
+
+# Capture the run start timestamp for the Grafana URL window.
+LOGS_START=$(date +%s)
+export LOGS_START
+
 trap cleanup_job EXIT
 
 deploy_chart() {
@@ -100,6 +128,7 @@ main() {
     log_success "Integration tests passed!"
     exit 0
   else
+    JOB_FAILED=1
     log_error "Integration tests failed!"
     show_job_status "$RELEASE_NAME" "$NAMESPACE"
     exit 1

--- a/api/scripts/run-integration-tests.sh
+++ b/api/scripts/run-integration-tests.sh
@@ -16,22 +16,16 @@ IMAGE_TAG="${IMAGE_TAG:?required argument}"
 SERVICE_IMAGE_REPOSITORY="${SERVICE_IMAGE_REPOSITORY:?required argument}"
 SERVICE_IMAGE_TAG="${SERVICE_IMAGE_TAG:?required argument}"
 CLEANUP="${CLEANUP:-true}"
-# Preserve pods on failure so logs are reachable AND fluent-bit has time to
-# ship them to Cloud Logging. CI can override with KEEP_ON_FAILURE=false.
 KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
 TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/integration}"
 
 # shellcheck source=deploy-service.sh
 . "${SCRIPT_DIR}/deploy-service.sh"
 
-# Set to 1 by main() when the integration job did not complete successfully.
 JOB_FAILED=0
 
 cleanup_job() {
-  # Print Grafana deep link first.
   print_grafana_logs_url "$NAMESPACE" "integration-tests" || true
-
-  # Snapshot kubectl logs before uninstall so they survive pod deletion.
   save_job_logs "$RELEASE_NAME" "$NAMESPACE" "integration-tests" "$TEST_LOGS_DIR" || true
 
   if [[ "$JOB_FAILED" == "1" && "$KEEP_ON_FAILURE" == "true" ]]; then
@@ -60,7 +54,6 @@ cleanup_job() {
   fi
 }
 
-# Capture the run start timestamp for the Grafana URL window.
 LOGS_START=$(date +%s)
 export LOGS_START
 

--- a/api/scripts/run-nft-tests.sh
+++ b/api/scripts/run-nft-tests.sh
@@ -19,8 +19,6 @@ SERVICE_IMAGE_TAG="${SERVICE_IMAGE_TAG:-}"
 
 TIMEOUT="${TIMEOUT:-1200}"
 CLEANUP="${CLEANUP:-true}"
-# Preserve pods on failure so logs are reachable AND fluent-bit has time to
-# ship them to Cloud Logging. CI can override with KEEP_ON_FAILURE=false.
 KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
 DEPLOY_SERVICE="${DEPLOY_SERVICE:-true}"
 TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/nft}"
@@ -28,14 +26,10 @@ TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/nft}"
 SERVICE_CHART_PATH="${SERVICE_CHART_PATH:-${SCRIPT_DIR}/../../helm-chart}"
 TEST_CHART_PATH="${TEST_CHART_PATH:-${SCRIPT_DIR}/../k8s/nft-tests}"
 
-# Set to 1 by main() when the job did not complete successfully.
 JOB_FAILED=0
 
 cleanup() {
-  # Print Grafana deep link first.
   print_grafana_logs_url "${NAMESPACE}" "nft-tests" || true
-
-  # Snapshot kubectl logs to disk before any uninstall.
   save_job_logs "${JOB_RELEASE}" "${NAMESPACE}" "nft-tests" "${TEST_LOGS_DIR}/job" || true
 
   if [[ "${JOB_FAILED}" == "1" && "${KEEP_ON_FAILURE}" == "true" ]]; then
@@ -52,7 +46,6 @@ cleanup() {
     return
   fi
 
-  # Let fluent-bit flush before deleting pods.
   sleep_for_log_flush
   log "Cleaning up Helm releases in namespace: ${NAMESPACE}"
   helm uninstall "${JOB_RELEASE}" -n "${NAMESPACE}" --ignore-not-found || true
@@ -60,7 +53,6 @@ cleanup() {
   helm uninstall "${DB_RELEASE}" -n "${NAMESPACE}" --ignore-not-found || true
 }
 
-# Capture the run start timestamp for the Grafana URL window.
 LOGS_START=$(date +%s)
 export LOGS_START
 

--- a/api/scripts/run-nft-tests.sh
+++ b/api/scripts/run-nft-tests.sh
@@ -19,22 +19,50 @@ SERVICE_IMAGE_TAG="${SERVICE_IMAGE_TAG:-}"
 
 TIMEOUT="${TIMEOUT:-1200}"
 CLEANUP="${CLEANUP:-true}"
+# Preserve pods on failure so logs are reachable AND fluent-bit has time to
+# ship them to Cloud Logging. CI can override with KEEP_ON_FAILURE=false.
+KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
 DEPLOY_SERVICE="${DEPLOY_SERVICE:-true}"
+TEST_LOGS_DIR="${TEST_LOGS_DIR:-${SCRIPT_DIR}/../../reports/nft}"
 
 SERVICE_CHART_PATH="${SERVICE_CHART_PATH:-${SCRIPT_DIR}/../../helm-chart}"
 TEST_CHART_PATH="${TEST_CHART_PATH:-${SCRIPT_DIR}/../k8s/nft-tests}"
 
+# Set to 1 by main() when the job did not complete successfully.
+JOB_FAILED=0
+
 cleanup() {
+  # Print Grafana deep link first.
+  print_grafana_logs_url "${NAMESPACE}" "nft-tests" || true
+
+  # Snapshot kubectl logs to disk before any uninstall.
+  save_job_logs "${JOB_RELEASE}" "${NAMESPACE}" "nft-tests" "${TEST_LOGS_DIR}/job" || true
+
+  if [[ "${JOB_FAILED}" == "1" && "${KEEP_ON_FAILURE}" == "true" ]]; then
+    log_warning "NFT tests failed; preserving namespace ${NAMESPACE} so logs stay reachable."
+    log_warning "  Local log snapshot: ${TEST_LOGS_DIR}/"
+    log_warning "  Inspect pods:       kubectl get pods -n ${NAMESPACE}"
+    log_warning "  Tail logs:          kubectl logs -n ${NAMESPACE} -l job-name=${JOB_RELEASE} --tail=-1"
+    log_warning "  Manual cleanup:     helm uninstall ${JOB_RELEASE} ${SERVICE_RELEASE} ${DB_RELEASE} -n ${NAMESPACE}"
+    return
+  fi
+
   if [[ "${CLEANUP}" != "true" ]]; then
     log_warning "CLEANUP=false - leaving resources in place"
     return
   fi
 
+  # Let fluent-bit flush before deleting pods.
+  sleep_for_log_flush
   log "Cleaning up Helm releases in namespace: ${NAMESPACE}"
   helm uninstall "${JOB_RELEASE}" -n "${NAMESPACE}" --ignore-not-found || true
   helm uninstall "${SERVICE_RELEASE}" -n "${NAMESPACE}" --ignore-not-found || true
   helm uninstall "${DB_RELEASE}" -n "${NAMESPACE}" --ignore-not-found || true
 }
+
+# Capture the run start timestamp for the Grafana URL window.
+LOGS_START=$(date +%s)
+export LOGS_START
 
 trap cleanup EXIT
 
@@ -169,6 +197,7 @@ main() {
 	  local job_exit_code=0
 	  if ! wait_for_job_with_logs "${JOB_RELEASE}" "${NAMESPACE}" "${TIMEOUT}" "nft-tests"; then
 	    job_exit_code=1
+	    JOB_FAILED=1
 	    show_job_status "${JOB_RELEASE}" "${NAMESPACE}"
 	  fi
 

--- a/api/testkit/src/main/java/com/coreeng/supportbot/testkit/SlackWiremock.java
+++ b/api/testkit/src/main/java/com/coreeng/supportbot/testkit/SlackWiremock.java
@@ -75,6 +75,23 @@ public class SlackWiremock extends WireMockServer {
         givenThat(post("/api/conversations.history")
                 .withName("conversations history catch-all")
                 .willReturn(okJson("{\"ok\":true,\"messages\":[],\"has_more\":false}")));
+        // Catch-alls for the PR lifecycle poller: when triggered (manually via the test endpoint
+        // or via Spring's cron) it walks every active pr_tracking row, so stray records from other
+        // tests can land on wiremock without a per-test stub. Returning an "open, no reviews"
+        // shape keeps the poller happy without affecting behaviour for tests that stub explicitly.
+        givenThat(get(urlMatching("/repos/[^/]+/[^/]+/pulls/[0-9]+/reviews"))
+                .withName("GitHub PR reviews catch-all")
+                .willReturn(okJson("[]")));
+        givenThat(get(urlMatching("/repos/[^/]+/[^/]+/pulls/[0-9]+"))
+                .withName("GitHub PR catch-all")
+                .willReturn(okJson("{\"state\":\"open\",\"number\":0,\"requested_teams\":[],"
+                        + "\"mergeable\":false,\"mergeable_state\":\"unknown\","
+                        + "\"created_at\":\"2026-01-01T00:00:00Z\",\"title\":\"\","
+                        + "\"user\":{\"login\":\"test\"}}")));
+        givenThat(get(urlMatching("/repos/[^/]+/[^/]+"))
+                .withName("GitHub repo metadata catch-all")
+                .willReturn(okJson("{\"id\":1,\"name\":\"catchall\",\"full_name\":\"catchall/catchall\","
+                        + "\"owner\":{\"login\":\"catchall\"},\"private\":false}")));
     }
 
     private void capturePermanentStubs() {

--- a/helm-chart/templates/ui-functional-test.yaml
+++ b/helm-chart/templates/ui-functional-test.yaml
@@ -26,4 +26,6 @@ spec:
           env:
             - name: SERVICE_ENDPOINT
               value: "{{ $serviceEndpoint }}"
+          resources:
+            {{- toYaml .Values.ui.functionalTest.resources | nindent 12 }}
 {{- end }}

--- a/helm-chart/templates/ui-functional-test.yaml
+++ b/helm-chart/templates/ui-functional-test.yaml
@@ -10,7 +10,10 @@ metadata:
     {{- include "support-bot.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    # Keep the test pod alive on failure so kubectl logs and the Grafana
+    # deep link from ui/p2p/scripts/helm-test.sh stay useful.
+    # before-hook-creation still wipes it before the next run.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0
   template:

--- a/helm-chart/templates/ui-functional-test.yaml
+++ b/helm-chart/templates/ui-functional-test.yaml
@@ -10,9 +10,6 @@ metadata:
     {{- include "support-bot.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
-    # Keep the test pod alive on failure so kubectl logs and the Grafana
-    # deep link from ui/p2p/scripts/helm-test.sh stay useful.
-    # before-hook-creation still wipes it before the next run.
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0

--- a/helm-chart/templates/ui-nft-test.yaml
+++ b/helm-chart/templates/ui-nft-test.yaml
@@ -10,8 +10,6 @@ metadata:
     {{- include "support-bot.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
-    # Keep the test pod alive on failure so kubectl logs and the Grafana
-    # deep link from ui/p2p/scripts/helm-test.sh stay useful.
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0

--- a/helm-chart/templates/ui-nft-test.yaml
+++ b/helm-chart/templates/ui-nft-test.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- include "support-bot.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    # Keep the test pod alive on failure so kubectl logs and the Grafana
+    # deep link from ui/p2p/scripts/helm-test.sh stay useful.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0
   template:

--- a/helm-chart/values-nft.yaml
+++ b/helm-chart/values-nft.yaml
@@ -2,14 +2,6 @@ configMap:
   create: false
   enabled: false
 
-resources:
-  requests:
-    cpu: 0.5
-    memory: 512Mi
-  limits:
-    memory: 750Mi
-
-
 env:
   - name: JAVA_OPTS
     value: "-Xms512m -Xmx512m"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -273,3 +273,11 @@ ui:
 
   env: []
 
+  functionalTest:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        memory: 1536Mi
+

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -47,8 +47,10 @@ ingress:
 
 resources:
   requests:
-    cpu: 512m
+    cpu: 500m
     memory: 512Mi
+  limits:
+    memory: 1Gi
 
 livenessProbe:
   httpGet:
@@ -226,11 +228,10 @@ ui:
 
   resources:
     requests:
-      cpu: 250m
-      memory: 256Mi
-    limits:
       cpu: 500m
       memory: 512Mi
+    limits:
+      memory: 1Gi
 
   livenessProbe:
     httpGet:

--- a/ui/p2p/config/.yamllint
+++ b/ui/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 255

--- a/ui/p2p/scripts/helm-test.sh
+++ b/ui/p2p/scripts/helm-test.sh
@@ -7,10 +7,11 @@ app_name=$3
 scale_down=${4:-false}
 timeout=${5:-"30m"}
 test_name=${6:-$app_name-$type-test}
+container_name=${7:-ui-${type}-tests}
 
 printLogs() {
 	current_timestamp=$(date +%s)
-	logs_url="https://grafana.${INTERNAL_SERVICES_DOMAIN}/explore?orgId=1&left=%7B%22datasource%22:%22CloudLogging%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryText%22:%22resource.type%3D%5C%22k8s_container%5C%22%5Cnresource.labels.namespace_name%3D%5C%22${namespace}%5C%22%5Cnresource.labels.pod_name%3D%5C%22${test_name}%5C%22%22,%22projectId%22:%22${PROJECT_ID}%22,%22bucketId%22:%22global%2Fbuckets%2F_Default%22,%22viewId%22:%22_AllLogs%22%7D%5D,%22range%22:%7B%22from%22:%22${logs_start}000%22,%22to%22:%22${current_timestamp}000%22%7D%7D"
+	logs_url="https://grafana.${INTERNAL_SERVICES_DOMAIN}/explore?orgId=1&left=%7B%22datasource%22:%22CloudLogging%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryText%22:%22resource.type%3D%5C%22k8s_container%5C%22%5Cnresource.labels.namespace_name%3D%5C%22${namespace}%5C%22%5Cnresource.labels.container_name%3D%5C%22${container_name}%5C%22%22,%22projectId%22:%22${PROJECT_ID}%22,%22bucketId%22:%22global%2Fbuckets%2F_Default%22,%22viewId%22:%22_AllLogs%22%7D%5D,%22range%22:%7B%22from%22:%22${logs_start}000%22,%22to%22:%22${current_timestamp}000%22%7D%7D"
 
 	echo "Logs: $logs_url"
 }

--- a/ui/p2p/tests/functional/.gitignore
+++ b/ui/p2p/tests/functional/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+cucumber-report.html
+cucumber-report.json

--- a/ui/p2p/tests/functional/.yarnrc.yml
+++ b/ui/p2p/tests/functional/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/ui/p2p/tests/functional/cucumber.json
+++ b/ui/p2p/tests/functional/cucumber.json
@@ -10,11 +10,6 @@
       "snippetInterface": "async-await",
       "colorsEnabled": true
     },
-    "format": [
-      "summary",
-      "progress",
-      ["html", "cucumber-report.html"],
-      ["json", "cucumber-report.json"]
-    ]
+    "format": ["summary", "progress", "pretty", ["html", "cucumber-report.html"], ["json", "cucumber-report.json"]]
   }
 }

--- a/ui/p2p/tests/functional/cucumber.json
+++ b/ui/p2p/tests/functional/cucumber.json
@@ -1,11 +1,20 @@
 {
   "default": {
     "requireModule": ["ts-node/register"],
+    "paths": ["tests/features/"],
     "require": ["tests/steps/*.ts"],
+    "tags": "not @disabled",
+    "timeout": 30000,
+    "retry": 3,
     "formatOptions": {
-      "snippetInterface": "async-await"
+      "snippetInterface": "async-await",
+      "colorsEnabled": true
     },
-    "timeout": 15000,
-    "format": [["html", "cucumber-report.html"], "summary", "progress", "json:./cucumber-report.json"]
+    "format": [
+      "summary",
+      "progress",
+      ["html", "cucumber-report.html"],
+      ["json", "cucumber-report.json"]
+    ]
   }
 }

--- a/ui/p2p/tests/functional/package.json
+++ b/ui/p2p/tests/functional/package.json
@@ -9,6 +9,8 @@
     "test:cucumber:single": "NODE_ENV=test cucumber-js"
   },
   "devDependencies": {
+    "@cucumber/messages": "^32.3.1",
+    "@cucumber/pretty-formatter": "^3.3.0",
     "@playwright/test": "^1.55.1",
     "@types/node": "^24.6.2",
     "ts-node": "^10.9.2",

--- a/ui/p2p/tests/functional/tests/steps/custom-world.ts
+++ b/ui/p2p/tests/functional/tests/steps/custom-world.ts
@@ -33,8 +33,10 @@ export class CustomWorld extends World {
     });
     this.page = await this.context.newPage();
 
-    // Set default timeout
-    this.page.setDefaultTimeout(10000);
+    // Playwright action/wait timeout. Keep below the 30s Cucumber step
+    // timeout so slow CI renders get a chance to retry without starving
+    // the surrounding step.
+    this.page.setDefaultTimeout(20_000);
   }
 
   async closePage() {

--- a/ui/p2p/tests/functional/tests/steps/custom-world.ts
+++ b/ui/p2p/tests/functional/tests/steps/custom-world.ts
@@ -33,9 +33,6 @@ export class CustomWorld extends World {
     });
     this.page = await this.context.newPage();
 
-    // Playwright action/wait timeout. Keep below the 30s Cucumber step
-    // timeout so slow CI renders get a chance to retry without starving
-    // the surrounding step.
     this.page.setDefaultTimeout(20_000);
   }
 

--- a/ui/p2p/tests/functional/tests/steps/hooks.ts
+++ b/ui/p2p/tests/functional/tests/steps/hooks.ts
@@ -1,7 +1,6 @@
 import { After, Before, setDefaultTimeout } from "@cucumber/cucumber";
 import { CustomWorld } from "./custom-world";
 
-// Set default timeout to 30 seconds for all steps to absorb CI jitter
 setDefaultTimeout(30_000);
 
 const BASE_URL = process.env.SERVICE_ENDPOINT || "http://localhost:3000";

--- a/ui/p2p/tests/functional/tests/steps/hooks.ts
+++ b/ui/p2p/tests/functional/tests/steps/hooks.ts
@@ -1,8 +1,8 @@
 import { After, Before, setDefaultTimeout } from "@cucumber/cucumber";
 import { CustomWorld } from "./custom-world";
 
-// Set default timeout to 15 seconds for all steps
-setDefaultTimeout(15000);
+// Set default timeout to 30 seconds for all steps to absorb CI jitter
+setDefaultTimeout(30_000);
 
 const BASE_URL = process.env.SERVICE_ENDPOINT || "http://localhost:3000";
 

--- a/ui/p2p/tests/functional/yarn.lock
+++ b/ui/p2p/tests/functional/yarn.lock
@@ -133,7 +133,7 @@
   dependencies:
     mime "^3.0.0"
 
-"@cucumber/messages@32.3.1", "@cucumber/messages@>=31.0.0 <33", "@cucumber/messages@^32.0.0":
+"@cucumber/messages@32.3.1", "@cucumber/messages@>=31.0.0 <33", "@cucumber/messages@^32.0.0", "@cucumber/messages@^32.3.1":
   version "32.3.1"
   resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-32.3.1.tgz#8c6990554c35fb9bcff0b7f09fe52ddfd479dbce"
   integrity sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==
@@ -151,7 +151,15 @@
     figures "^3.2.0"
     ts-dedent "^2.0.0"
 
-"@cucumber/query@^15.0.1":
+"@cucumber/pretty-formatter@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/pretty-formatter/-/pretty-formatter-3.3.1.tgz#f1f9b8b2a4454315371af0483fbddd450b176aeb"
+  integrity sha512-wy8M/Poaqnoom+YP1mzZMfHEE3pP9/0JAYajkjpHTtanp4KJGpAXdukuUYbmmgFjRXUmUSK3s5I+I5+f+q2blA==
+  dependencies:
+    "@cucumber/query" "15.0.1"
+    luxon "^3.7.2"
+
+"@cucumber/query@15.0.1", "@cucumber/query@^15.0.1":
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/@cucumber/query/-/query-15.0.1.tgz#91b701121ba95caf7d0e6d9de95041ec3396d297"
   integrity sha512-FMfT3orJblRsOxvU2doECBvQmauizYlj+5JsM8atAKKPbnQTj7v2/OrnuykvQpfZNBf19DYbRq1e832vllRP/g==
@@ -597,7 +605,7 @@ lru-cache@^11.0.0, lru-cache@^11.1.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.5.tgz#6811ae01652ae5d749948cdd80bcc22218c6744f"
   integrity sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==
 
-luxon@3.7.2, luxon@^3.5.0:
+luxon@3.7.2, luxon@^3.5.0, luxon@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
   integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==


### PR DESCRIPTION
## Summary

Two related p2p fixes for support-bot's test harness.

**Problem 1 — UI functional tests fail randomly.** The cucumber config was missing the `retry` field, ran with half the timeout core-platform-dashboard uses, and Playwright's page default was 10s — any slow CI render starved the surrounding step.

**Problem 2 — Grafana logs are empty after a failure.** The cleanup trap ran `helm uninstall` the instant the job exited, deleting the test pod before fluent-bit had a chance to ship its logs to Cloud Logging. The api/scripts side never even printed a Grafana URL.

## Changes

### Flakiness fix (parity with cpd)

- `ui/p2p/tests/functional/cucumber.json` — `retry: 3`, `timeout: 30000`, `tags: "not @disabled"`, explicit `paths`
- `ui/p2p/tests/functional/tests/steps/hooks.ts` — `setDefaultTimeout(15000)` → `30_000`
- `ui/p2p/tests/functional/tests/steps/custom-world.ts` — `page.setDefaultTimeout(10000)` → `20_000`
- Add `.gitignore`, `.yarnrc.yml`, `ui/p2p/config/.yamllint`

### Log preservation

- `api/scripts/lib.sh` — three helpers
  - `print_grafana_logs_url` — Grafana Cloud-Logging deep link filtered by namespace + container
  - `save_job_logs` — snapshots `kubectl logs` to `reports/<test>/<pod>.log` **before** any uninstall
  - `sleep_for_log_flush` — 30s default so fluent-bit ships to Cloud Logging before pod delete (`LOG_FLUSH_SECONDS=0` to skip in dev)
- `api/scripts/run-{functional,integration,nft}-tests.sh`
  - Wire the three helpers into the cleanup trap
  - `KEEP_ON_FAILURE=true` default — failed namespaces stay alive so `kubectl logs -n <ns> -l job-name=...` works after the script exits
  - `JOB_FAILED` flag branches cleanup logic
- `helm-chart/templates/ui-{functional,nft}-test.yaml` — drop `hook-failed` from `hook-delete-policy` so failed UI test pods stay alive (matches the api-side behaviour)

## Behaviour summary

| | Local snapshot | Grafana URL | `kubectl logs` |
|---|---|---|---|
| Test passes | ✓ | ✓ (30s flush) | ✗ (pod cleaned) |
| Test fails (default) | ✓ | ✓ (pod alive) | ✓ (namespace preserved) |

CI hygiene knob: set `KEEP_ON_FAILURE=false` in workflow `env:` to auto-clean even on failure (Grafana URL still works because of the flush sleep).

## Test plan

- [ ] Trigger a deliberately failing UI functional run on a PR; confirm Grafana URL in job output returns logs (not empty)
- [ ] Trigger a passing UI functional run; confirm namespace is cleaned up and Grafana URL still returns logs (the 30s flush window)
- [ ] Run the API functional/nft/integration jobs and check `reports/<test>/<pod>.log` is uploaded as an artifact (or accessible on the runner)
- [ ] Verify the cucumber retry/tags/paths config takes effect — a flaky test should now retry up to 3 times before failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)