### PR TITLE
feat(helm): allow global values in schema for ArgoCD platform injection

### DIFF
--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -484,6 +484,10 @@
         }
       }
     },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "dex": {
       "type": "object",
       "additionalProperties": true


### PR DESCRIPTION
## Summary

- Adds `global` property with `additionalProperties: true` to `helm-chart/values.schema.json`
- Follows the same pattern used by the Istio gateway chart
- Allows ArgoCD to inject platform-level values via `--set global.*` (e.g. `global.region=eu-west-1`) without failing Helm schema validation

## Test plan

- [x] `helm lint helm-chart` passes with `--set global.region=eu-west-1`
- [x] Existing schema validation still rejects unknown top-level keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)