### PR TITLE
docs: document UI roles and how to configure them via Slack groups

### DIFF
--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -765,8 +765,23 @@ This path requires `platform-integration.jwt-groups.enabled: true` and only appl
 
 ### `ROLE_ESCALATION`
 
-`ROLE_ESCALATION` is for teams that *receive* escalations — typically product or platform teams outside the core support team. Escalation team members must be in the support channel to see and respond to escalations.
+`ROLE_ESCALATION` is for teams that *receive* escalations — typically product or platform teams outside the core support team.
 
-When a support engineer escalates a ticket, the bot posts in the Slack thread and tags the team's Slack group (`enums.escalation-teams[].slack-group-id`). Escalation team members need to be in the support channel to see and respond to the thread. Those who log into the UI get `ROLE_ESCALATION`, which allows them to view and resolve escalations assigned to their team.
+When a support engineer escalates a ticket, the bot tags the team's Slack group in the thread — no UI login required. Those who do log into the UI get `ROLE_ESCALATION`, which gives them a dedicated view of escalations assigned to their team.
 
-**How membership is resolved:** unlike `ROLE_SUPPORT_ENGINEER` and `ROLE_LEADERSHIP` which use a simple `group-ref: slack:<ID>`, `ROLE_ESCALATION` is resolved through `platform-integration` (Azure, GCP, Kubernetes). This made sense when escalation teams mirrored tenant teams already tracked in those identity sources. However, since the Slack group ID is already configured on each escalation team for tagging, using it for membership resolution too (the same way support/leadership work) would be simpler and sufficient for Slack-first deployments — this is a known limitation.
+Unlike `ROLE_SUPPORT_ENGINEER` and `ROLE_LEADERSHIP`, membership is not resolved via a direct Slack group lookup. It comes from `platform-integration` (Azure, GCP, or Kubernetes), which scrapes team membership from your cloud identity source:
+
+```yaml
+enums:
+  escalation-teams:
+    - label: Platform Team
+      code: platform-team
+      group-ref: <CLOUD_GROUP_ID>           # Azure group ID, GCP group email, etc.
+
+platform-integration:
+  enabled: true
+  gcp:
+    enabled: true                           # or azure / teams-scraping depending on your setup
+```
+
+> **Known limitation:** since the Slack group ID is already configured on each escalation team for tagging, using it for membership resolution too (as support/leadership do) would be simpler for Slack-first deployments — but this is not currently supported.

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -705,3 +705,62 @@ Available CEL variables:
 | `provider`      | string | `github` or `gitlab`                                        |
 
 Setting an `escalated` message on a no-SLA repo is rejected at startup.
+
+## Roles
+
+Every authenticated user is assigned one or more roles that control what they can do in the UI.
+
+| Role | Who it's for | Capabilities |
+|---|---|---|
+| `ROLE_USER` | Everyone — assigned automatically on login | View tickets |
+| `ROLE_SUPPORT_ENGINEER` | Support team members | Manage tickets: update status, assign, tag, close |
+| `ROLE_LEADERSHIP` | Support leads | Everything in `ROLE_SUPPORT_ENGINEER` plus metrics dashboards and aggregate views |
+| `ROLE_ESCALATION` | Teams that *receive* escalations | Resolve escalations raised against their team |
+
+Roles are additive — a user can hold multiple roles simultaneously.
+
+### Assigning roles via Slack groups (recommended)
+
+The simplest way to manage roles is to point `team.support.group-ref` and `team.leadership.group-ref` at Slack user groups. At login time the API resolves group members from Slack and assigns the corresponding role — no redeployment needed when membership changes.
+
+```yaml
+team:
+  support:
+    name: Core Support
+    group-ref: slack:<SLACK_GROUP_ID>       # members get ROLE_SUPPORT_ENGINEER
+  leadership:
+    name: Support Leadership
+    group-ref: slack:<SLACK_GROUP_ID>       # members get ROLE_LEADERSHIP
+```
+
+Add or remove people from those Slack groups and their role takes effect at their next login.
+
+> **Prerequisite:** the Slack bot token must have the `usergroups:read` scope. If the scope is missing, group membership resolution fails silently and no support/leadership roles are assigned.
+
+### Assigning roles via LDAP groups (Dex)
+
+When authenticating through Dex with an LDAP backend, roles can alternatively be derived from LDAP group membership via the `platform-integration.jwt-groups` config. Dex populates a `groups` claim in the ID token with the user's LDAP groups; the API maps those to team codes which resolve to roles.
+
+```yaml
+platform-integration:
+  jwt-groups:
+    enabled: true
+    claim-name: groups          # LDAP groups claim emitted by Dex
+    mappings:
+      - claim-values: [support-admins]
+        team-code: support      # Must match team.support.code → ROLE_SUPPORT_ENGINEER
+      - claim-values: [support-leads]
+        team-code: support-leadership  # Must match team.leadership.code → ROLE_LEADERSHIP
+```
+
+This path requires `platform-integration.jwt-groups.enabled: true` and only applies to the `dex` OAuth provider — Google and Azure logins are not affected.
+
+### `ROLE_ESCALATION`
+
+`ROLE_ESCALATION` is for teams that *receive* escalations — typically product or platform teams outside the core support team. Escalation team members must be in the support channel to see and respond to escalations.
+
+When a support engineer escalates a ticket, the bot posts in the Slack thread and tags the team's Slack group (`enums.escalation-teams[].slack-group-id`). That tag is the primary notification mechanism — no UI login required.
+
+`ROLE_ESCALATION` in the UI is secondary: it allows escalation team members who do log in to see and resolve escalations assigned to their team.
+
+**How membership is resolved:** unlike `ROLE_SUPPORT_ENGINEER` and `ROLE_LEADERSHIP` which use a simple `group-ref: slack:<ID>`, `ROLE_ESCALATION` is resolved through `platform-integration` (Azure, GCP, Kubernetes). This made sense when escalation teams mirrored tenant teams already tracked in those identity sources. However, since the Slack group ID is already configured on each escalation team for tagging, using it for membership resolution too (the same way support/leadership work) would be simpler and sufficient for Slack-first deployments — this is a known limitation.

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -759,8 +759,6 @@ This path requires `platform-integration.jwt-groups.enabled: true` and only appl
 
 `ROLE_ESCALATION` is for teams that *receive* escalations — typically product or platform teams outside the core support team. Escalation team members must be in the support channel to see and respond to escalations.
 
-When a support engineer escalates a ticket, the bot posts in the Slack thread and tags the team's Slack group (`enums.escalation-teams[].slack-group-id`). That tag is the primary notification mechanism — no UI login required.
-
-`ROLE_ESCALATION` in the UI is secondary: it allows escalation team members who do log in to see and resolve escalations assigned to their team.
+When a support engineer escalates a ticket, the bot posts in the Slack thread and tags the team's Slack group (`enums.escalation-teams[].slack-group-id`). Escalation team members need to be in the support channel to see and respond to the thread. Those who log into the UI get `ROLE_ESCALATION`, which allows them to view and resolve escalations assigned to their team.
 
 **How membership is resolved:** unlike `ROLE_SUPPORT_ENGINEER` and `ROLE_LEADERSHIP` which use a simple `group-ref: slack:<ID>`, `ROLE_ESCALATION` is resolved through `platform-integration` (Azure, GCP, Kubernetes). This made sense when escalation teams mirrored tenant teams already tracked in those identity sources. However, since the Slack group ID is already configured on each escalation team for tagging, using it for membership resolution too (the same way support/leadership work) would be simpler and sufficient for Slack-first deployments — this is a known limitation.

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -775,13 +775,17 @@ Unlike `ROLE_SUPPORT_ENGINEER` and `ROLE_LEADERSHIP`, membership is not resolved
 enums:
   escalation-teams:
     - label: Platform Team
-      code: platform-team
-      group-ref: <CLOUD_GROUP_ID>           # Azure group ID, GCP group email, etc.
+      code: platform-team                   # must match platform-integration.teams-scraping name below
+      group-ref: <CLOUD_GROUP_ID>           # Slack group ID tagged on escalation
 
 platform-integration:
   enabled: true
-  gcp:
-    enabled: true                           # or azure / teams-scraping depending on your setup
+  teams-scraping:
+    static:                                 # or core-platform / k8s-generic / gcp / azure
+      enabled: true
+      teams:
+        - name: platform-team              # must match enums.escalation-teams[].code above
+          group-ref: <CLOUD_GROUP_ID>      # cloud group whose members get ROLE_ESCALATION
 ```
 
 > **Known limitation:** since the Slack group ID is already configured on each escalation team for tagging, using it for membership resolution too (as support/leadership do) would be simpler for Slack-first deployments — but this is not currently supported.

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -713,8 +713,8 @@ Every authenticated user is assigned one or more roles that control what they ca
 | Role | Who it's for | Capabilities |
 |---|---|---|
 | `ROLE_USER` | Everyone — assigned automatically on login | View tickets |
-| `ROLE_SUPPORT_ENGINEER` | Support team members | Manage tickets: update status, assign, tag, close |
-| `ROLE_LEADERSHIP` | Support leads | Everything in `ROLE_SUPPORT_ENGINEER` plus metrics dashboards and aggregate views |
+| `ROLE_LEADERSHIP` | Support leads | View tickets, metrics dashboards, and aggregate views |
+| `ROLE_SUPPORT_ENGINEER` | Support team members | Everything in `ROLE_LEADERSHIP` plus manage tickets: update status, assign, tag, close |
 | `ROLE_ESCALATION` | Teams that *receive* escalations | Resolve escalations raised against their team |
 
 Roles are additive — a user can hold multiple roles simultaneously.

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -731,11 +731,19 @@ team:
   leadership:
     name: Support Leadership
     group-ref: slack:<SLACK_GROUP_ID>       # members get ROLE_LEADERSHIP
+
+platform-integration:
+  enabled: true                             # must be true or the app fails to start
+  teams-scraping:
+    static:
+      enabled: true                         # no teams needed — acts as a no-op placeholder
 ```
 
 Add or remove people from those Slack groups and their role takes effect at their next login.
 
 > **Prerequisite:** the Slack bot token must have the `usergroups:read` scope. If the scope is missing, group membership resolution fails silently and no support/leadership roles are assigned.
+
+> **Note:** Slack group membership is resolved directly via the Slack API and does not depend on `platform-integration`. However, `platform-integration.enabled: true` is required or the app will fail to start. If you are not using any cloud identity source, the `teams-scraping.static` block with no teams listed is sufficient.
 
 ### Assigning roles via LDAP groups (Dex)
 

--- a/docs/user-guides/README.md
+++ b/docs/user-guides/README.md
@@ -9,6 +9,16 @@ Role-based guides for new team members. Start with the base user guide, then rea
 | [Leadership](./role-leadership.md) | `ROLE_LEADERSHIP` | Support leads who review metrics and trends |
 | [Escalation team](./role-escalation.md) | `ROLE_ESCALATION` | Teams that receive escalations from the support team |
 
-Roles are additive — you can hold more than one. For example, a support lead who is also on the support team would hold both `ROLE_SUPPORT_ENGINEER` and `ROLE_LEADERSHIP`.
+Roles are additive — you can hold more than one. Membership is based on Slack group membership and takes effect at next login.
+
+| Capability | User | Support Engineer | Leadership | Escalation |
+|------------|:----:|:----------------:|:----------:|:----------:|
+| View tickets, escalations, tenant requests | ✅ | ✅ | ✅ | ✅ |
+| View knowledge gaps summary | ✅ | ✅ | ✅ | ✅ |
+| Edit tickets (status, tags, impact, assignee) | ❌ | ✅ | ❌ | ❌ |
+| Close/escalate tickets | ❌ | ✅ | ❌ | ❌ |
+| View metrics (Stats, SLA, Health) | ❌ | ✅ | ✅ | ❌ |
+| Run and import knowledge gap analysis | ❌ | ✅ | ❌ | ❌ |
+| "Escalated to My Team" widget | ❌ | ❌ | ❌ | ✅ |
 
 For how roles are configured and assigned, see the [configuration docs](../../api/service/docs/configuration.md#roles).


### PR DESCRIPTION
## Summary

Adds a `## Roles` section to `api/service/docs/configuration.md` to document how authentication and role assignment works in the Support Bot UI — this was previously undocumented.

- Documents the four roles (`ROLE_USER`, `ROLE_SUPPORT_ENGINEER`, `ROLE_LEADERSHIP`, `ROLE_ESCALATION`) and their capabilities
- Explains the recommended approach: assigning roles via Slack user groups using `team.support.group-ref` and `team.leadership.group-ref` — membership changes take effect at next login with no redeployment
- Documents the alternative LDAP/Dex path via `platform-integration.jwt-groups` for organisations using Dex with an LDAP backend
- Clarifies `ROLE_ESCALATION`: escalation team members are notified via Slack tagging and can also view and resolve escalations in the UI; notes the current design limitation where escalation teams require `platform-integration` for member resolution rather than the simpler `group-ref` pattern available to support/leadership teams

## Test plan

- [x] Documentation renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)