### PR TITLE
fix(ticket): keep Full Summary working when an escalation team is unresolved

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
@@ -7,6 +7,7 @@ import static com.slack.api.model.block.composition.BlockCompositions.markdownTe
 import static java.util.Comparator.comparing;
 
 import com.coreeng.supportbot.config.TicketAssignmentProps;
+import com.coreeng.supportbot.enums.EscalationTeam;
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
 import com.coreeng.supportbot.enums.ImpactsRegistry;
 import com.coreeng.supportbot.enums.Tag;
@@ -98,10 +99,18 @@ public class TicketSummaryService {
         TicketId ticketId = checkNotNull(ticket.id());
         return escalationQueryService.listByTicketId(ticketId).stream()
                 .sorted(comparing(Escalation::openedAt))
-                .map(e -> TicketSummaryView.EscalationView.of(
-                        e,
-                        checkNotNull(escalationTeamsRegistry.findEscalationTeamByCode(checkNotNull(e.team())))
-                                .slackMentionId()))
+                .map(e -> {
+                    EscalationTeam team =
+                            e.team() != null ? escalationTeamsRegistry.findEscalationTeamByCode(e.team()) : null;
+                    if (team == null) {
+                        log.atWarn()
+                                .addKeyValue("ticketId", ticketId)
+                                .addKeyValue("escalationId", e.id())
+                                .addKeyValue("teamCode", e.team())
+                                .log("Escalation references an unresolved team; rendering summary without a mention");
+                    }
+                    return TicketSummaryView.EscalationView.of(e, team != null ? team.slackMentionId() : null);
+                })
                 .collect(toImmutableList());
     }
 

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryView.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryView.java
@@ -58,9 +58,14 @@ public record TicketSummaryView(
             @Nullable SlackId senderId,
             @Nullable String permalink) {}
 
-    public record EscalationView(EscalationId id, String teamSlackGroupId, EscalationStatus status) {
-        public static EscalationView of(Escalation escalation, String teamSlackGroupId) {
-            return new EscalationView(checkNotNull(escalation.id()), teamSlackGroupId, escalation.status());
+    public record EscalationView(
+            EscalationId id,
+            @Nullable String teamSlackGroupId,
+            @Nullable String teamCode,
+            EscalationStatus status) {
+        public static EscalationView of(Escalation escalation, @Nullable String teamSlackGroupId) {
+            return new EscalationView(
+                    checkNotNull(escalation.id()), teamSlackGroupId, escalation.team(), escalation.status());
         }
     }
 

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryViewMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryViewMapper.java
@@ -174,10 +174,13 @@ public class TicketSummaryViewMapper {
     }
 
     private ImmutableList<LayoutBlock> renderEscalation(TicketSummaryView.EscalationView escalation) {
+        String teamText = escalation.teamSlackGroupId() != null
+                ? "Team: <!subteam^" + escalation.teamSlackGroupId() + ">"
+                : "Team: " + (escalation.teamCode() != null ? escalation.teamCode() : "unknown") + " (not configured)";
         return ImmutableList.of(
                 section(s -> s.fields(ImmutableList.of(
                         plainText(t -> t.text("Status: " + escalation.status().label())),
-                        markdownText(t -> t.text("Team: <!subteam^" + escalation.teamSlackGroupId() + ">"))))),
+                        markdownText(t -> t.text(teamText))))),
                 divider());
     }
 

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
@@ -20,6 +20,7 @@ import com.coreeng.supportbot.enums.TicketImpact;
 import com.coreeng.supportbot.escalation.Escalation;
 import com.coreeng.supportbot.escalation.EscalationId;
 import com.coreeng.supportbot.escalation.EscalationQueryService;
+import com.coreeng.supportbot.escalation.EscalationStatus;
 import com.coreeng.supportbot.slack.MessageTs;
 import com.coreeng.supportbot.slack.SlackException;
 import com.coreeng.supportbot.slack.SlackId;
@@ -251,6 +252,63 @@ class TicketSummaryServiceTest {
         // Should be sorted by openedAt
         assertThat(result.escalations().get(0).teamSlackGroupId()).isEqualTo("platform-support");
         assertThat(result.escalations().get(1).teamSlackGroupId()).isEqualTo("security-group");
+    }
+
+    @Test
+    void escalationWithUnresolvableTeam_doesNotCrashSummary() {
+        // Regression: an escalation whose team code no longer resolves in the registry must not
+        // blow up the whole Full Summary view (the "View Summary" spinner in Slack).
+        TicketAssignmentProps assignmentProps =
+                new TicketAssignmentProps(false, new TicketAssignmentProps.Encryption(false, null));
+        service = new TicketSummaryService(
+                repository,
+                slackClient,
+                escalationQueryService,
+                tagsRegistry,
+                impactsRegistry,
+                escalationTeamsRegistry,
+                supportTeamService,
+                assignmentProps);
+
+        Escalation resolvable = Escalation.builder()
+                .id(new EscalationId(1L))
+                .ticketId(ticketId)
+                .channelId(channelId)
+                .threadTs(MessageTs.of("1111111111.111111"))
+                .team("platform-team")
+                .status(EscalationStatus.opened)
+                .openedAt(Instant.parse("2024-01-01T10:00:00Z"))
+                .build();
+        Escalation orphaned = Escalation.builder()
+                .id(new EscalationId(2L))
+                .ticketId(ticketId)
+                .channelId(channelId)
+                .threadTs(MessageTs.of("2222222222.222222"))
+                .team("removed-team")
+                .status(EscalationStatus.opened)
+                .openedAt(Instant.parse("2024-01-01T11:00:00Z"))
+                .build();
+
+        when(repository.findTicketById(ticketId)).thenReturn(ticket);
+        when(slackClient.getMessageByTs(any(SlackGetMessageByTsRequest.class))).thenReturn(slackMessage);
+        when(slackClient.getPermalink(any(SlackGetMessageByTsRequest.class))).thenReturn("https://slack.com/permalink");
+        when(escalationQueryService.listByTicketId(ticketId)).thenReturn(ImmutableList.of(resolvable, orphaned));
+        when(impactsRegistry.listAllImpacts()).thenReturn(ImmutableList.of());
+        when(escalationTeamsRegistry.findEscalationTeamByCode("platform-team"))
+                .thenReturn(
+                        new EscalationTeam("Platform Team", "platform-team", new GroupRef.Slack("platform-support")));
+        when(escalationTeamsRegistry.findEscalationTeamByCode("removed-team")).thenReturn(null);
+
+        TicketSummaryView result = service.summaryView(ticketId);
+
+        assertThat(result.escalations()).hasSize(2);
+        assertThat(result.escalations().get(0).teamSlackGroupId()).isEqualTo("platform-support");
+        assertThat(result.escalations().get(1).teamSlackGroupId()).isNull();
+        assertThat(result.escalations().get(1).teamCode()).isEqualTo("removed-team");
+
+        // The mapper must render a fallback for the unresolved team instead of throwing.
+        View view = view(v -> summaryViewMapper.render(result, v).type("modal"));
+        assertThat(view).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## Problem

Clicking **View Summary** on a ticket in Slack just spun forever and never opened the modal. Production logs showed a `NullPointerException` thrown on every click:

```
ERROR c.c.supportbot.config.SlackAppInit : Error while handling blockAction(ids: [ticket-summary-view] …)
java.lang.NullPointerException
  at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:904)
  at …TicketSummaryService.lambda$getEscalationViews$0(TicketSummaryService.java:103)
  at …TicketSummaryService.summaryView(TicketSummaryService.java:64)
  at …TicketActionsHandler.openSummaryView(TicketActionsHandler.java:72)
```

`getEscalationViews` wrapped both `Escalation.team()` and `escalationTeamsRegistry.findEscalationTeamByCode(...)` (both `@Nullable`) in Guava `checkNotNull`. When a ticket has an escalation whose team code no longer resolves in the registry (e.g. a team removed/renamed after the PT-351 GroupRef refactor), the whole summary build throws. Because the exception happens **before** `slackClient.viewsOpen(...)`, Slack never gets the modal and the button spins indefinitely.

Observed on one ticket, failing on every click for over a week.

## Fix

Resolve the escalation team null-safely instead of asserting non-null:

- If the team code is `null` or absent from the registry, log a `warn` (with `ticketId` / `escalationId` / `teamCode`) and render the escalation **without** a Slack mention.
- `EscalationView.teamSlackGroupId` is now `@Nullable`; the view carries the raw `teamCode` so the mapper can show a fallback label (`Team: <code> (not configured)`) rather than a broken `<!subteam^…>` mention.

A single unresolvable escalation can no longer take down the entire summary view. The new `warn` log surfaces the exact orphaned team code, so the underlying config can be fixed as a follow-up.

## Testing

- New regression test `TicketSummaryServiceTest.escalationWithUnresolvableTeam_doesNotCrashSummary` — one resolvable + one orphaned escalation; asserts the summary builds and the mapper renders without throwing.
- `./gradlew :service:build` green (spotless, checkstyle, full test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
