### PR TITLE
[codex] Align Vertex gRPC and WireMock Jetty 12 dependencies

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -9,7 +9,6 @@ val safeDependencyVersions =
         "com.microsoft.kiota:microsoft-kiota-abstractions" to "1.9.1",
         "com.squareup.okhttp3:okhttp" to "4.12.0",
         "com.squareup.okio:okio" to "3.16.4",
-        "io.grpc:grpc-netty-shaded" to "1.75.0",
         "io.netty:netty-codec" to "4.1.133.Final",
         "io.netty:netty-codec-dns" to "4.1.133.Final",
         "io.netty:netty-codec-http" to "4.1.133.Final",

--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -127,6 +127,7 @@ dependencies {
 
     implementation("com.google.cloud:spring-cloud-gcp-starter:5.10.0")
     implementation("com.google.apis:google-api-services-cloudidentity:v1-rev20241208-2.0.0")
+    implementation("com.google.cloud:google-cloud-vertexai:1.52.0")
 
     implementation("com.microsoft.graph:microsoft-graph:6.36.0")
     implementation("com.azure.spring:spring-cloud-azure-starter:5.22.0")

--- a/api/testkit/build.gradle.kts
+++ b/api/testkit/build.gradle.kts
@@ -46,9 +46,7 @@ dependencies {
     api("org.assertj:assertj-core:3.27.7")
 
     // WireMock
-    api("org.wiremock:wiremock:3.13.+")
-    // Override Jetty to address security findings reported for wiremock's transitive dependency
-    implementation("org.eclipse.jetty:jetty-server:11.0.+")
+    api("org.wiremock:wiremock-jetty12:3.13.+")
 
     // Jackson
     api("com.fasterxml.jackson.core:jackson-databind:2.18.6")


### PR DESCRIPTION
## Summary

- remove the standalone `grpc-netty-shaded` override so the gRPC stack is not split across incompatible versions
- explicitly upgrade `google-cloud-vertexai` to `1.52.0`, which aligns Vertex transitive gRPC dependencies at `1.76.3`
- switch testkit from `org.wiremock:wiremock` plus a Jetty 11 override to `org.wiremock:wiremock-jetty12`

## Root Cause

Production failed during Vertex Gemini TLS negotiation because `grpc-netty-shaded:1.75.0` was forced while the rest of the Vertex/gRPC dependency graph was older. The shaded Netty transport referenced `GrpcAttributes.ATTR_AUTHORITY_VERIFIER`, which was absent from the older `grpc-core` on the runtime classpath.
