### PR TITLE
PT-518: Handle config enum (tag/impact/team) updates gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # p2p makefile
 .p2p.mk
 
+# Superpowers brainstorming/spec/plan artifacts (kept local, not committed)
+docs/superpowers/
+
 # LDAP bootstrap user entries (generated from 20-users.ldif.template + LDAP_BOOTSTRAP_USER_PASSWORD)
 ldap/bootstrap/20-users.ldif
 api/k8s/ldap/chart/files/bootstrap/20-users.ldif

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
@@ -1,0 +1,59 @@
+package com.coreeng.supportbot.enums;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.coreeng.supportbot.config.EnumerationValue;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fails fast at startup on internally-inconsistent enum config — duplicate or blank codes (PT-518).
+ *
+ * <p>These are always operator errors in the config artifact (not pre-existing data orphans), so
+ * failing the boot is safe: under a rolling update the previous pod keeps serving until the config
+ * is fixed. Runs after {@code RegistryInitialisation} (@Order(100)).
+ */
+@Component
+@Order(101)
+@RequiredArgsConstructor
+@Slf4j
+public class EnumConfigValidator implements ApplicationRunner {
+
+    private final EnumProps enumProps;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<String> problems = new ArrayList<>();
+        problems.addAll(findProblems("enums.escalation-teams", enumProps.escalationTeams()));
+        problems.addAll(findProblems("enums.tags", enumProps.tags()));
+        problems.addAll(findProblems("enums.impacts", enumProps.impacts()));
+
+        if (!problems.isEmpty()) {
+            throw new IllegalStateException("Invalid enum configuration: " + String.join("; ", problems)
+                    + ". Codes are immutable primary keys; fix the duplicate/blank codes in config.");
+        }
+        log.atInfo().log("Enum config validation passed");
+    }
+
+    private static List<String> findProblems(String path, ImmutableList<? extends EnumerationValue> values) {
+        List<String> problems = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (EnumerationValue value : values) {
+            String code = value.code();
+            if (code == null || code.isBlank()) {
+                problems.add(path + " has an entry with a blank code");
+            } else if (!seen.add(code)) {
+                problems.add(path + " has duplicate code '" + code + "'");
+            }
+        }
+        return problems;
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
@@ -35,7 +35,8 @@ public class EnumsService implements EscalationTeamsRegistry, TagsRegistry, Impa
 
     @Override
     public ImmutableList<TicketImpact> listAllImpacts() {
-        return impactsRepository.listAll();
+        // Active only — mirrors listAllTags(); retired impacts stay resolvable via findImpactByCode (PT-518).
+        return impactsRepository.listAllActive();
     }
 
     @Nullable @Override

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
@@ -39,6 +39,11 @@ public class EnumsService implements EscalationTeamsRegistry, TagsRegistry, Impa
         return impactsRepository.listAllActive();
     }
 
+    @Override
+    public ImmutableList<TicketImpact> listAllImpactsIncludingRetired() {
+        return impactsRepository.listAll();
+    }
+
     @Nullable @Override
     public TicketImpact findImpactByCode(String code) {
         return impactsRepository.findImpactByCode(code);
@@ -63,6 +68,11 @@ public class EnumsService implements EscalationTeamsRegistry, TagsRegistry, Impa
             }
             throw new RuntimeException("Cache retrieval failed for key: " + TAGS_CACHE_KEY, e);
         }
+    }
+
+    @Override
+    public ImmutableList<Tag> listAllTagsIncludingRetired() {
+        return tagsRepository.listAll();
     }
 
     @Override

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EscalationTeamHistoryRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EscalationTeamHistoryRepository.java
@@ -1,0 +1,57 @@
+package com.coreeng.supportbot.enums;
+
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION_TEAM;
+import static org.jooq.impl.DSL.excluded;
+import static org.jooq.impl.DSL.row;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Persistent code+label history for escalation teams (PT-518). Active teams (with group-ref /
+ * Slack mention) come from config via {@link EnumsService}; this store exists only so that a
+ * renamed/removed escalation team code still resolves to a label on existing tickets/escalations.
+ */
+@Repository
+@RequiredArgsConstructor
+public class EscalationTeamHistoryRepository {
+    private final DSLContext dsl;
+
+    /** Returns the label for {@code code} including soft-deleted (retired) rows, or null if unknown. */
+    @Nullable public String findLabelByCode(String code) {
+        return dsl.select(ESCALATION_TEAM.LABEL)
+                .from(ESCALATION_TEAM)
+                .where(ESCALATION_TEAM.CODE.eq(code))
+                .fetchOne(r -> r.get(ESCALATION_TEAM.LABEL));
+    }
+
+    public int insertOrActivate(ImmutableList<EscalationTeam> teams) {
+        if (teams.isEmpty()) {
+            return 0;
+        }
+        return dsl.insertInto(ESCALATION_TEAM, ESCALATION_TEAM.CODE, ESCALATION_TEAM.LABEL)
+                .valuesOfRows(teams.stream().map(t -> row(t.code(), t.label())).toList())
+                .onConflict(ESCALATION_TEAM.CODE)
+                .doUpdate()
+                .set(ESCALATION_TEAM.LABEL, excluded(ESCALATION_TEAM.LABEL))
+                .setNull(ESCALATION_TEAM.DELETED_AT)
+                .execute();
+    }
+
+    /** Soft-deletes every team whose code is not in {@code codes}. When {@code codes} is empty, soft-deletes all. */
+    public int deleteAllExcept(ImmutableList<String> codes) {
+        if (codes.isEmpty()) {
+            return dsl.update(ESCALATION_TEAM)
+                    .set(ESCALATION_TEAM.DELETED_AT, Instant.now())
+                    .execute();
+        }
+        return dsl.update(ESCALATION_TEAM)
+                .set(ESCALATION_TEAM.DELETED_AT, Instant.now())
+                .where(ESCALATION_TEAM.CODE.notIn(codes))
+                .execute();
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/ImpactsRegistry.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/ImpactsRegistry.java
@@ -6,5 +6,8 @@ import org.jspecify.annotations.Nullable;
 public interface ImpactsRegistry {
     ImmutableList<TicketImpact> listAllImpacts();
 
+    /** All impacts including soft-deleted (retired) — for display/badging, not for pickers (PT-518). */
+    ImmutableList<TicketImpact> listAllImpactsIncludingRetired();
+
     @Nullable TicketImpact findImpactByCode(String code);
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
@@ -1,0 +1,97 @@
+package com.coreeng.supportbot.enums;
+
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION;
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION_TO_TAG;
+import static com.coreeng.supportbot.dbschema.Tables.IMPACT;
+import static com.coreeng.supportbot.dbschema.Tables.TAG;
+import static com.coreeng.supportbot.dbschema.Tables.TICKET;
+import static com.coreeng.supportbot.dbschema.Tables.TICKET_TO_TAG;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.google.common.collect.ImmutableList;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Detects stored references to retired/removed enum codes and surfaces them loudly: an ERROR log
+ * plus a Micrometer gauge {@code support_bot.orphaned_references} tagged by type (PT-518).
+ *
+ * <p>Non-fatal by design — such references are expected after a legitimate retire/rename and are
+ * rendered gracefully at runtime (M1); we only want operators to notice them, never to block a
+ * restart (pre-existing orphans must not brick prod). The whole scan is guarded so a query problem
+ * can never prevent startup. Runs after {@code RegistryInitialisation} so soft-deletes are applied.
+ */
+@Component
+@Order(102)
+@RequiredArgsConstructor
+@Slf4j
+public class OrphanReferenceScanner implements ApplicationRunner {
+
+    private final DSLContext dsl;
+    private final EnumProps enumProps;
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            long retiredImpactRefs = dsl.fetchCount(
+                    TICKET,
+                    TICKET.IMPACT_CODE.in(
+                            dsl.select(IMPACT.CODE).from(IMPACT).where(IMPACT.DELETED_AT.isNotNull())));
+            long retiredTagRefs = (long) dsl.fetchCount(
+                            TICKET_TO_TAG,
+                            TICKET_TO_TAG.TAG_CODE.in(
+                                    dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())))
+                    + dsl.fetchCount(
+                            ESCALATION_TO_TAG,
+                            ESCALATION_TO_TAG.TAG_CODE.in(
+                                    dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())));
+            long orphanedEscalationTeamRefs = dsl.fetchCount(ESCALATION, orphanedEscalationTeamCondition());
+
+            register("impact", retiredImpactRefs);
+            register("tag", retiredTagRefs);
+            register("escalation_team", orphanedEscalationTeamRefs);
+
+            long total = retiredImpactRefs + retiredTagRefs + orphanedEscalationTeamRefs;
+            if (total > 0) {
+                log.atError()
+                        .addKeyValue("retiredImpactRefs", retiredImpactRefs)
+                        .addKeyValue("retiredTagRefs", retiredTagRefs)
+                        .addKeyValue("orphanedEscalationTeamRefs", orphanedEscalationTeamRefs)
+                        .log("Found stored references to retired/removed enum codes; they render with their "
+                                + "last-known label. Rename a code back in config to re-link, or ignore if intentional.");
+            } else {
+                log.atInfo().log("No orphaned enum references found");
+            }
+        } catch (RuntimeException e) {
+            // A diagnostic scan must never block startup.
+            log.atWarn().setCause(e).log("Orphaned-reference scan failed; skipping (non-fatal)");
+        }
+    }
+
+    private Condition orphanedEscalationTeamCondition() {
+        ImmutableList<String> activeCodes =
+                enumProps.escalationTeams().stream().map(EscalationTeam::code).collect(toImmutableList());
+        if (activeCodes.isEmpty()) {
+            return ESCALATION.TEAM.isNotNull();
+        }
+        return ESCALATION.TEAM.isNotNull().and(ESCALATION.TEAM.notIn(activeCodes));
+    }
+
+    private void register(String type, long count) {
+        Gauge.builder("support_bot.orphaned_references", () -> count)
+                .description("Stored references to retired/removed enum codes")
+                .tag("type", type)
+                .strongReference(true)
+                .register(meterRegistry);
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/RegistryInitialisation.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/RegistryInitialisation.java
@@ -3,6 +3,7 @@ package com.coreeng.supportbot.enums;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.coreeng.supportbot.config.EnumProps;
+import com.google.common.collect.ImmutableList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -17,6 +18,7 @@ public class RegistryInitialisation implements ApplicationRunner {
     private final EnumProps enumProps;
     private final TagsRepository tagsRepository;
     private final ImpactsRepository impactsRepository;
+    private final EscalationTeamHistoryRepository escalationTeamHistoryRepository;
 
     @Transactional
     @Override
@@ -27,5 +29,12 @@ public class RegistryInitialisation implements ApplicationRunner {
         impactsRepository.deleteAllExcept(
                 enumProps.impacts().stream().map(TicketImpact::code).collect(toImmutableList()));
         impactsRepository.insertOrActivate(enumProps.impacts());
+
+        // Reconcile escalation team history (code+label) from config so renamed/removed
+        // escalation team codes still resolve to a label on existing records (PT-518).
+        ImmutableList<EscalationTeam> escalationTeams = ImmutableList.copyOf(enumProps.escalationTeams());
+        escalationTeamHistoryRepository.deleteAllExcept(
+                escalationTeams.stream().map(EscalationTeam::code).collect(toImmutableList()));
+        escalationTeamHistoryRepository.insertOrActivate(escalationTeams);
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/TagsRegistry.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/TagsRegistry.java
@@ -6,5 +6,8 @@ import com.google.common.collect.ImmutableList;
 public interface TagsRegistry {
     ImmutableList<Tag> listAllTags();
 
+    /** All tags including soft-deleted (retired) — for display/badging, not for pickers (PT-518). */
+    ImmutableList<Tag> listAllTagsIncludingRetired();
+
     ImmutableList<Tag> listTagsByCodes(ImmutableCollection<String> codes);
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/rest/RegistryController.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/rest/RegistryController.java
@@ -1,10 +1,14 @@
 package com.coreeng.supportbot.enums.rest;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.coreeng.supportbot.enums.ImpactsRegistry;
+import com.coreeng.supportbot.enums.Tag;
 import com.coreeng.supportbot.enums.TagsRegistry;
+import com.coreeng.supportbot.enums.TicketImpact;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,23 +23,30 @@ public class RegistryController {
     private final ImpactsRegistry impactsRegistry;
     private final TagsRegistry tagsRegistry;
 
+    // Returns active + retired entries each flagged with `active` (PT-518). The UI filters to active
+    // for pickers and shows a "Retired" badge next to inactive values on existing tickets.
     @GetMapping("/impact")
     public ResponseEntity<List<ImpactUI>> listImpacts() {
-        ImmutableList<ImpactUI> impacts = impactsRegistry.listAllImpacts().stream()
-                .map(i -> new ImpactUI(i.label(), i.code()))
+        ImmutableSet<String> activeCodes = impactsRegistry.listAllImpacts().stream()
+                .map(TicketImpact::code)
+                .collect(toImmutableSet());
+        ImmutableList<ImpactUI> impacts = impactsRegistry.listAllImpactsIncludingRetired().stream()
+                .map(i -> new ImpactUI(i.label(), i.code(), activeCodes.contains(i.code())))
                 .collect(toImmutableList());
         return ResponseEntity.ok(impacts);
     }
 
     @GetMapping("/tag")
     public ResponseEntity<List<TagUI>> listTags() {
-        ImmutableList<TagUI> tags = tagsRegistry.listAllTags().stream()
-                .map(t -> new TagUI(t.label(), t.code()))
+        ImmutableSet<String> activeCodes =
+                tagsRegistry.listAllTags().stream().map(Tag::code).collect(toImmutableSet());
+        ImmutableList<TagUI> tags = tagsRegistry.listAllTagsIncludingRetired().stream()
+                .map(t -> new TagUI(t.label(), t.code(), activeCodes.contains(t.code())))
                 .collect(toImmutableList());
         return ResponseEntity.ok(tags);
     }
 
-    public record ImpactUI(String label, String code) {}
+    public record ImpactUI(String label, String code, boolean active) {}
 
-    public record TagUI(String label, String code) {}
+    public record TagUI(String label, String code, boolean active) {}
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
@@ -43,7 +43,14 @@ public class EscalationProcessingService {
         log.atInfo().addArgument(escalation::id).log("Escalation created: {}");
 
         String teamCode = checkNotNull(escalation.team());
-        EscalationTeam team = checkNotNull(escalationTeamsRegistry.findEscalationTeamByCode(teamCode));
+        EscalationTeam team = escalationTeamsRegistry.findEscalationTeamByCode(teamCode);
+        if (team == null) {
+            log.atWarn()
+                    .addKeyValue("escalationId", escalation.id())
+                    .addKeyValue("teamCode", teamCode)
+                    .log("Escalation references an unresolved team; created without posting a team mention");
+            return escalation;
+        }
         ChatPostMessageResponse messagePostResponse = slackClient.postMessage(new SlackPostMessageRequest(
                 createdMessageMapper.renderMessage(new EscalationCreatedMessage(escalation.id(), team)),
                 slackTicketsProps.channelId(),

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeam.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeam.java
@@ -4,15 +4,26 @@ import com.coreeng.supportbot.teams.groups.GroupRef;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@RequiredArgsConstructor
 public class PlatformTeam {
     @EqualsAndHashCode.Include
     private final String name;
 
+    private final String code;
     private final Set<GroupRef> groupRefs;
     private final Set<PlatformUser> users;
+
+    public PlatformTeam(String name, String code, Set<GroupRef> groupRefs, Set<PlatformUser> users) {
+        this.name = name;
+        this.code = code;
+        this.groupRefs = groupRefs;
+        this.users = users;
+    }
+
+    /** Convenience for scraped teams whose code is the same as the name (the default). */
+    public PlatformTeam(String name, Set<GroupRef> groupRefs, Set<PlatformUser> users) {
+        this(name, name, groupRefs, users);
+    }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetcher.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetcher.java
@@ -7,9 +7,14 @@ import java.util.List;
 public interface PlatformTeamsFetcher {
     List<TeamAndGroupTuple> fetchTeams();
 
-    record TeamAndGroupTuple(String name, GroupRef groupRef) {
+    record TeamAndGroupTuple(String name, String code, GroupRef groupRef) {
+        /** Scraped teams have no separate code; the name doubles as the immutable identity. */
+        public TeamAndGroupTuple(String name, GroupRef groupRef) {
+            this(name, name, groupRef);
+        }
+
         public TeamAndGroupTuple(String name, String groupRef) {
-            this(name, GroupRef.parse(groupRef));
+            this(name, name, GroupRef.parse(groupRef));
         }
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
@@ -41,7 +41,7 @@ public class PlatformTeamsService {
     private final PlatformTeamsFetchProps fetchProps;
 
     private final Map<String, PlatformUser> usersByEmail = new HashMap<>();
-    private final Map<String, PlatformTeam> teamByName = new HashMap<>();
+    private final Map<String, PlatformTeam> teamByCode = new HashMap<>();
     private final Map<GroupRef, List<PlatformUser>> groupRefToUsers = new HashMap<>();
 
     @PostConstruct
@@ -52,8 +52,8 @@ public class PlatformTeamsService {
 
         // Build team objects and collect unique group refs
         for (var t : teams) {
-            PlatformTeam team = teamByName.computeIfAbsent(
-                    t.name(), k -> new PlatformTeam(t.name(), new HashSet<>(), new HashSet<>()));
+            PlatformTeam team = teamByCode.computeIfAbsent(
+                    t.code(), k -> new PlatformTeam(t.name(), t.code(), new HashSet<>(), new HashSet<>()));
             team.groupRefs().add(t.groupRef());
         }
 
@@ -83,7 +83,7 @@ public class PlatformTeamsService {
         }
 
         groupRefToUsers.putAll(fetchedGroupUsers);
-        for (PlatformTeam team : teamByName.values()) {
+        for (PlatformTeam team : teamByCode.values()) {
             for (GroupRef groupRef : team.groupRefs()) {
                 List<PlatformUser> users = groupRefToUsers.getOrDefault(groupRef, List.of());
                 team.users().addAll(users);
@@ -94,7 +94,7 @@ public class PlatformTeamsService {
         }
 
         log.atInfo()
-                .addArgument(teamByName::size)
+                .addArgument(teamByCode::size)
                 .addArgument(groupRefToUsers::size)
                 .addArgument(usersByEmail::size)
                 .addArgument(() -> Duration.between(start, Instant.now()))
@@ -168,12 +168,12 @@ public class PlatformTeamsService {
     }
 
     private void validateEscalationTeamsMapping(List<PlatformTeamsFetcher.TeamAndGroupTuple> teams) {
-        ImmutableSet<String> teamNames =
-                teams.stream().map(PlatformTeamsFetcher.TeamAndGroupTuple::name).collect(toImmutableSet());
-        ImmutableSet<String> escalationTeamNames = escalationTeamsRegistry.listAllEscalationTeams().stream()
+        ImmutableSet<String> teamCodes =
+                teams.stream().map(PlatformTeamsFetcher.TeamAndGroupTuple::code).collect(toImmutableSet());
+        ImmutableSet<String> escalationTeamCodes = escalationTeamsRegistry.listAllEscalationTeams().stream()
                 .map(EscalationTeam::code)
                 .collect(toImmutableSet());
-        var setsDiff = Sets.difference(escalationTeamNames, teamNames);
+        var setsDiff = Sets.difference(escalationTeamCodes, teamCodes);
         if (!setsDiff.isEmpty()) {
             if (fetchProps.ignoreUnknownTeams()) {
                 log.info("""
@@ -187,7 +187,7 @@ public class PlatformTeamsService {
     }
 
     public ImmutableList<PlatformTeam> listTeams() {
-        return ImmutableList.copyOf(teamByName.values());
+        return ImmutableList.copyOf(teamByCode.values());
     }
 
     public ImmutableList<PlatformTeam> listTeamsByUserEmail(String email) {
@@ -198,8 +198,8 @@ public class PlatformTeamsService {
         return ImmutableList.copyOf(user.teams());
     }
 
-    @Nullable public PlatformTeam findTeamByName(String name) {
-        return teamByName.get(name);
+    @Nullable public PlatformTeam findTeamByCode(String code) {
+        return teamByCode.get(code);
     }
 
     @Nullable public PlatformUser findUserByEmail(String email) {

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcher.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcher.java
@@ -1,5 +1,6 @@
 package com.coreeng.supportbot.teams;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +13,24 @@ public class StaticPlatformTeamsFetcher implements PlatformTeamsFetcher {
 
     @Override
     public List<TeamAndGroupTuple> fetchTeams() {
-        return props.teams().stream()
-                .map(team -> new TeamAndGroupTuple(team.name(), team.groupRef()))
+        List<String> teamsUsingNameAsCode = new ArrayList<>();
+        List<TeamAndGroupTuple> teams = props.teams().stream()
+                .map(team -> {
+                    String explicitCode = team.code();
+                    String code = (explicitCode != null && !explicitCode.isBlank()) ? explicitCode : team.name();
+                    if (explicitCode == null || explicitCode.isBlank()) {
+                        teamsUsingNameAsCode.add(team.name());
+                    }
+                    return new TeamAndGroupTuple(team.name(), code, team.groupRef());
+                })
                 .toList();
+        if (!teamsUsingNameAsCode.isEmpty()) {
+            log.atWarn()
+                    .addKeyValue("teams", teamsUsingNameAsCode)
+                    .log("Static teams without an explicit 'code' use their 'name' as the immutable identity; "
+                            + "renaming such a team's 'name' orphans existing references. Add a stable 'code' to "
+                            + "decouple the displayed name from identity (PT-518).");
+        }
+        return teams;
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsProps.java
@@ -2,9 +2,15 @@ package com.coreeng.supportbot.teams;
 
 import com.coreeng.supportbot.teams.groups.GroupRef;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("platform-integration.teams-scraping.static")
 public record StaticPlatformTeamsProps(boolean enabled, List<TeamConfig> teams) {
-    public record TeamConfig(String name, GroupRef groupRef) {}
+    /**
+     * {@code code} is the immutable identity (defaults to {@code name} when omitted). {@code name}
+     * is the display value — set an explicit {@code code} to change the display without orphaning
+     * references (PT-518).
+     */
+    public record TeamConfig(String name, @Nullable String code, GroupRef groupRef) {}
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamDisplay.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamDisplay.java
@@ -1,0 +1,6 @@
+package com.coreeng.supportbot.teams;
+
+import com.google.common.collect.ImmutableList;
+
+/** Display-safe team resolution: always has a label; {@code active=false} means retired/unknown. */
+public record TeamDisplay(String code, String label, ImmutableList<TeamType> types, boolean active) {}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
@@ -3,6 +3,7 @@ package com.coreeng.supportbot.teams;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamHistoryRepository;
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
 import com.google.common.collect.ImmutableList;
 import java.util.stream.Stream;
@@ -17,6 +18,7 @@ public class TeamService {
     private final PlatformTeamsService platformTeamsService;
     private final EscalationTeamsRegistry escalationTeamsRegistry;
     private final SupportTeamService supportTeamService;
+    private final EscalationTeamHistoryRepository escalationTeamHistoryRepository;
 
     public ImmutableList<Team> listTeamsByUserEmail(String email) {
         ImmutableList<PlatformTeam> platformTeams = platformTeamsService.listTeamsByUserEmail(email);
@@ -82,6 +84,22 @@ public class TeamService {
         }
 
         return null;
+    }
+
+    /**
+     * Resolves a stored team code to a display-safe value that is never null (PT-518).
+     * Active config team -> active; else retired label from history -> inactive; else raw code -> inactive.
+     */
+    public TeamDisplay resolveForDisplay(String code) {
+        Team team = findTeamByCode(code);
+        if (team != null) {
+            return new TeamDisplay(team.code(), team.label(), team.types(), true);
+        }
+        String retiredLabel = escalationTeamHistoryRepository.findLabelByCode(code);
+        if (retiredLabel != null) {
+            return new TeamDisplay(code, retiredLabel, ImmutableList.of(), false);
+        }
+        return new TeamDisplay(code, code, ImmutableList.of(), false);
     }
 
     private ImmutableList<Team> mapPlatformTeams(ImmutableList<PlatformTeam> platformTeams) {

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
@@ -49,7 +49,7 @@ public class TeamService {
             case ESCALATION ->
                 escalationTeamsRegistry.listAllEscalationTeams().stream()
                         .map(t -> {
-                            PlatformTeam platformTeam = platformTeamsService.findTeamByName(t.code());
+                            PlatformTeam platformTeam = platformTeamsService.findTeamByCode(t.code());
                             if (platformTeam != null) {
                                 return new Team(
                                         t.label(), t.code(), ImmutableList.of(TeamType.TENANT, TeamType.ESCALATION));
@@ -73,7 +73,7 @@ public class TeamService {
             return leadershipTeam;
         }
 
-        PlatformTeam platformTeam = platformTeamsService.findTeamByName(code);
+        PlatformTeam platformTeam = platformTeamsService.findTeamByCode(code);
         if (platformTeam != null) {
             return mapPlatformTeam(platformTeam);
         }
@@ -107,13 +107,14 @@ public class TeamService {
     }
 
     @NonNull private Team mapPlatformTeam(PlatformTeam t) {
-        EscalationTeam escalationTeam = escalationTeamsRegistry.findEscalationTeamByCode(t.name());
+        EscalationTeam escalationTeam = escalationTeamsRegistry.findEscalationTeamByCode(t.code());
         if (escalationTeam != null) {
             return new Team(
                     escalationTeam.label(),
                     escalationTeam.code(),
                     ImmutableList.of(TeamType.TENANT, TeamType.ESCALATION));
         }
-        return new Team(t.name(), t.name(), ImmutableList.of(TeamType.TENANT));
+        // Display uses name; identity uses code (defaults to name for scraped teams) — PT-518.
+        return new Team(t.name(), t.code(), ImmutableList.of(TeamType.TENANT));
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUI.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUI.java
@@ -3,4 +3,9 @@ package com.coreeng.supportbot.teams.rest;
 import com.coreeng.supportbot.teams.TeamType;
 import com.google.common.collect.ImmutableList;
 
-public record TeamUI(String label, String code, ImmutableList<TeamType> types) {}
+public record TeamUI(String label, String code, ImmutableList<TeamType> types, boolean active) {
+    /** Active team (the common case); retired teams use the 4-arg form with active=false (PT-518). */
+    public TeamUI(String label, String code, ImmutableList<TeamType> types) {
+        this(label, code, types, true);
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
@@ -85,12 +85,9 @@ public class TicketSummaryService {
                 escalations,
                 currentTags,
                 allImpacts,
-                ticket.impact() != null
-                        ? allImpacts.stream()
-                                .filter(i -> ticket.impact().contains(i.code()))
-                                .findAny()
-                                .orElse(null)
-                        : null,
+                // Resolve the ticket's current impact directly (incl. soft-deleted) so a retired
+                // impact still renders on existing tickets even though the picker is active-only (PT-518).
+                ticket.impact() != null ? impactsRegistry.findImpactByCode(ticket.impact()) : null,
                 currentAssignee,
                 availableAssignees);
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
@@ -11,6 +11,7 @@ import com.coreeng.supportbot.slack.client.SlackClient;
 import com.coreeng.supportbot.slack.client.SlackGetMessageByTsRequest;
 import com.coreeng.supportbot.teams.SupportTeamService;
 import com.coreeng.supportbot.teams.Team;
+import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamMemberFetcher;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.rest.TeamUI;
@@ -103,11 +104,10 @@ public class TicketUIMapper {
                 .build();
     }
 
-    // TODO: If team is deleted after ticket has been saved to to db, this returns null. We should potentially look at
-    // saving team info to database so deleted teams can still be displayed instead of returning null
     @Nullable private TeamUI mapKnownTeamToUI(String code) {
-        Team team = teamService.findTeamByCode(code);
-        return team != null ? teamUIMapper.mapToUI(team) : null;
+        TeamDisplay team = teamService.resolveForDisplay(code);
+        // Retired/unknown teams still render their label instead of disappearing (PT-518).
+        return teamUIMapper.mapToUI(new Team(team.label(), team.code(), team.types()));
     }
 
     @Nullable private String resolveQueryPermalink(DetailedTicket ticket) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
@@ -106,8 +106,11 @@ public class TicketUIMapper {
 
     @Nullable private TeamUI mapKnownTeamToUI(String code) {
         TeamDisplay team = teamService.resolveForDisplay(code);
-        // Retired/unknown teams still render their label instead of disappearing (PT-518).
-        return teamUIMapper.mapToUI(new Team(team.label(), team.code(), team.types()));
+        // Retired/unknown teams still render their label, flagged active=false so the UI can badge them (PT-518).
+        if (team.active()) {
+            return teamUIMapper.mapToUI(new Team(team.label(), team.code(), team.types()));
+        }
+        return new TeamUI(team.label(), team.code(), team.types(), false);
     }
 
     @Nullable private String resolveQueryPermalink(DetailedTicket ticket) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUpdateService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUpdateService.java
@@ -62,7 +62,7 @@ public class TicketUpdateService {
             return ValidationResult.invalid("authorsTeam is required");
         }
         boolean isNotATenant = TicketTeam.NOT_A_TENANT_CODE.equals(request.authorsTeam());
-        PlatformTeam team = platformTeamsService.findTeamByName(request.authorsTeam());
+        PlatformTeam team = platformTeamsService.findTeamByCode(request.authorsTeam());
         if (!isNotATenant && team == null) {
             return ValidationResult.invalid("authorsTeam must be a valid team code");
         }

--- a/api/service/src/main/resources/db/migration/V31__escalation_team.sql
+++ b/api/service/src/main/resources/db/migration/V31__escalation_team.sql
@@ -1,0 +1,9 @@
+-- Escalation team history: code+label registry so renamed/removed escalation
+-- team codes still resolve to a label on existing tickets/escalations (PT-518).
+-- Active teams' group-ref / Slack mention still come from config; only code+label persisted.
+create table if not exists escalation_team
+(
+    code       text primary key,
+    label      text not null,
+    deleted_at timestamptz
+);

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/EnumConfigValidatorTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/EnumConfigValidatorTest.java
@@ -1,0 +1,58 @@
+package com.coreeng.supportbot.enums;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.coreeng.supportbot.teams.groups.GroupRef;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class EnumConfigValidatorTest {
+
+    @Mock
+    private EnumProps enumProps;
+
+    @InjectMocks
+    private EnumConfigValidator validator;
+
+    @Test
+    void run_passes_whenCodesAreUniqueAndNonBlank() {
+        when(enumProps.escalationTeams())
+                .thenReturn(ImmutableList.of(new EscalationTeam("Platform", "platform", new GroupRef.Slack("SP"))));
+        when(enumProps.tags()).thenReturn(ImmutableList.of(new Tag("Networking", "networking")));
+        when(enumProps.impacts()).thenReturn(ImmutableList.of(new TicketImpact("Blocking", "blocking")));
+
+        assertThatCode(() -> validator.run(new DefaultApplicationArguments())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void run_throws_onDuplicateTagCode() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(enumProps.tags())
+                .thenReturn(ImmutableList.of(new Tag("First", "dup"), new Tag("Second", "dup")));
+        when(enumProps.impacts()).thenReturn(ImmutableList.of());
+
+        assertThatThrownBy(() -> validator.run(new DefaultApplicationArguments()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("duplicate code 'dup'");
+    }
+
+    @Test
+    void run_throws_onBlankImpactCode() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(enumProps.tags()).thenReturn(ImmutableList.of());
+        when(enumProps.impacts()).thenReturn(ImmutableList.of(new TicketImpact("No Code", "")));
+
+        assertThatThrownBy(() -> validator.run(new DefaultApplicationArguments()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("blank code");
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/EnumsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/EnumsServiceTest.java
@@ -65,6 +65,18 @@ class EnumsServiceTest {
     }
 
     @Test
+    void listAllImpacts_delegatesToListAllActive_excludingSoftDeleted() {
+        ImmutableList<TicketImpact> activeImpacts =
+                ImmutableList.of(new TicketImpact("Production Blocking", "production-blocking"));
+        when(impactsRepository.listAllActive()).thenReturn(activeImpacts);
+
+        ImmutableList<TicketImpact> result = service.listAllImpacts();
+
+        assertThat(result).isEqualTo(activeImpacts);
+        verify(impactsRepository).listAllActive();
+    }
+
+    @Test
     void listTagsByCodes_delegatesToListByCodes() {
         ImmutableList<String> codes = ImmutableList.of("networking", "deleted-tag");
         ImmutableList<Tag> tags =

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/EnumsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/EnumsServiceTest.java
@@ -77,6 +77,25 @@ class EnumsServiceTest {
     }
 
     @Test
+    void listAllImpactsIncludingRetired_delegatesToListAll() {
+        ImmutableList<TicketImpact> all =
+                ImmutableList.of(new TicketImpact("Active", "active"), new TicketImpact("Retired", "retired"));
+        when(impactsRepository.listAll()).thenReturn(all);
+
+        assertThat(service.listAllImpactsIncludingRetired()).isEqualTo(all);
+        verify(impactsRepository).listAll();
+    }
+
+    @Test
+    void listAllTagsIncludingRetired_delegatesToListAll() {
+        ImmutableList<Tag> all = ImmutableList.of(new Tag("Active", "active"), new Tag("Retired", "retired"));
+        when(tagsRepository.listAll()).thenReturn(all);
+
+        assertThat(service.listAllTagsIncludingRetired()).isEqualTo(all);
+        verify(tagsRepository).listAll();
+    }
+
+    @Test
     void listTagsByCodes_delegatesToListByCodes() {
         ImmutableList<String> codes = ImmutableList.of("networking", "deleted-tag");
         ImmutableList<Tag> tags =

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/RegistryInitialisationTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/RegistryInitialisationTest.java
@@ -1,0 +1,46 @@
+package com.coreeng.supportbot.enums;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.coreeng.supportbot.teams.groups.GroupRef;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryInitialisationTest {
+
+    @Mock
+    private EnumProps enumProps;
+
+    @Mock
+    private TagsRepository tagsRepository;
+
+    @Mock
+    private ImpactsRepository impactsRepository;
+
+    @Mock
+    private EscalationTeamHistoryRepository escalationTeamHistoryRepository;
+
+    @InjectMocks
+    private RegistryInitialisation registryInitialisation;
+
+    @Test
+    void run_reconcilesEscalationTeams_insertsActiveAndSoftDeletesRemoved() {
+        EscalationTeam platform = new EscalationTeam("Platform Team", "platform", new GroupRef.Slack("Splatform"));
+        when(enumProps.tags()).thenReturn(ImmutableList.of());
+        when(enumProps.impacts()).thenReturn(ImmutableList.of());
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of(platform));
+
+        registryInitialisation.run(new DefaultApplicationArguments());
+
+        verify(escalationTeamHistoryRepository).insertOrActivate(ImmutableList.of(platform));
+        verify(escalationTeamHistoryRepository).deleteAllExcept(ImmutableList.of("platform"));
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/rest/RegistryControllerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/rest/RegistryControllerTest.java
@@ -1,0 +1,57 @@
+package com.coreeng.supportbot.enums.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.enums.ImpactsRegistry;
+import com.coreeng.supportbot.enums.Tag;
+import com.coreeng.supportbot.enums.TagsRegistry;
+import com.coreeng.supportbot.enums.TicketImpact;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryControllerTest {
+
+    @Mock
+    private ImpactsRegistry impactsRegistry;
+
+    @Mock
+    private TagsRegistry tagsRegistry;
+
+    @InjectMocks
+    private RegistryController controller;
+
+    @Test
+    void listImpacts_flagsRetiredAsInactive() {
+        when(impactsRegistry.listAllImpacts()).thenReturn(ImmutableList.of(new TicketImpact("Active", "active")));
+        when(impactsRegistry.listAllImpactsIncludingRetired())
+                .thenReturn(ImmutableList.of(
+                        new TicketImpact("Active", "active"), new TicketImpact("Retired", "retired")));
+
+        var body = controller.listImpacts().getBody();
+
+        assertThat(body)
+                .containsExactly(
+                        new RegistryController.ImpactUI("Active", "active", true),
+                        new RegistryController.ImpactUI("Retired", "retired", false));
+    }
+
+    @Test
+    void listTags_flagsRetiredAsInactive() {
+        when(tagsRegistry.listAllTags()).thenReturn(ImmutableList.of(new Tag("Active", "active")));
+        when(tagsRegistry.listAllTagsIncludingRetired())
+                .thenReturn(ImmutableList.of(new Tag("Active", "active"), new Tag("Retired", "retired")));
+
+        var body = controller.listTags().getBody();
+
+        assertThat(body)
+                .containsExactly(
+                        new RegistryController.TagUI("Active", "active", true),
+                        new RegistryController.TagUI("Retired", "retired", false));
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/escalation/EscalationProcessingServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/escalation/EscalationProcessingServiceTest.java
@@ -116,4 +116,33 @@ class EscalationProcessingServiceTest {
         assertThat(escalation.team()).isEqualTo(expectedEscalation.team());
         assertThat(escalation.tags()).isEqualTo(expectedEscalation.tags());
     }
+
+    @Test
+    public void shouldNotPostMessageWhenEscalationTeamUnresolved() {
+        // given: PT-518 — the escalation references a team code that no longer resolves in config
+        CreateEscalationRequest escalationRequest = CreateEscalationRequest.builder()
+                .ticket(Ticket.builder()
+                        .id(new TicketId(1))
+                        .queryTs(MessageTs.of("1234567890.123456"))
+                        .channelId("test-channel")
+                        .build())
+                .team("removed-team")
+                .tags(ImmutableList.of())
+                .build();
+        Escalation created = Escalation.builder()
+                .id(new EscalationId(1))
+                .ticketId(new TicketId(1))
+                .status(EscalationStatus.opened)
+                .team("removed-team")
+                .build();
+        when(escalationRepository.createIfNotExists(any(Escalation.class))).thenReturn(created);
+        when(escalationTeamsRegistry.findEscalationTeamByCode("removed-team")).thenReturn(null);
+
+        // when
+        Escalation escalation = requireNonNull(processingService.createEscalation(escalationRequest));
+
+        // then: no NPE, escalation still returned, and no Slack post for the unresolved team
+        assertThat(escalation.id()).isEqualTo(new EscalationId(1));
+        verifyNoInteractions(slackClient);
+    }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
@@ -76,7 +76,7 @@ class PlatformTeamsServiceConcurrencyTest {
         for (int i = 1; i <= groups; i++) {
             String teamName = "team-" + i;
             String groupKey = "G" + i;
-            var team = service.findTeamByName(teamName);
+            var team = service.findTeamByCode(teamName);
             assertNotNull(team);
             assertTrue(team.groupRefs().contains(GroupRef.parse(groupKey)));
             assertEquals(1, team.users().size());

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
@@ -46,7 +46,7 @@ class PlatformTeamsServiceTest {
         service.init();
 
         assertEquals(1, service.listTeams().size());
-        var team = service.findTeamByName("wow");
+        var team = service.findTeamByCode("wow");
         assertNotNull(team);
         assertTrue(team.groupRefs().contains(ref("wow-group")));
         assertEquals(1, team.users().size());
@@ -82,8 +82,8 @@ class PlatformTeamsServiceTest {
 
         assertEquals(1, usersFetcher.getCallCount("shared"));
 
-        var teamA = service.findTeamByName("A");
-        var teamB = service.findTeamByName("B");
+        var teamA = service.findTeamByCode("A");
+        var teamB = service.findTeamByCode("B");
         assertNotNull(teamA);
         assertNotNull(teamB);
         assertEquals(2, teamA.users().size());
@@ -111,7 +111,7 @@ class PlatformTeamsServiceTest {
 
         service.init();
 
-        var t1 = service.findTeamByName("T1");
+        var t1 = service.findTeamByCode("T1");
         assertNotNull(t1);
         assertEquals(2, t1.users().size());
         assertEquals(1, service.listTeamsByUserEmail("a@test.com").size());
@@ -155,7 +155,7 @@ class PlatformTeamsServiceTest {
 
         // Verify that the service initialized correctly with the known team
         assertEquals(1, service.listTeams().size());
-        var team = service.findTeamByName("wow");
+        var team = service.findTeamByCode("wow");
         assertNotNull(team);
         assertEquals("wow", team.name());
         assertEquals(1, team.users().size());
@@ -210,7 +210,7 @@ class PlatformTeamsServiceTest {
         service.init();
 
         assertEquals(1, usersFetcher.getCallCount("G"));
-        var t = service.findTeamByName("T");
+        var t = service.findTeamByCode("T");
         assertNotNull(t);
         assertEquals(1, t.groupRefs().size());
         assertTrue(t.groupRefs().contains(ref("G")));
@@ -246,12 +246,12 @@ class PlatformTeamsServiceTest {
         assertEquals(2, service.listTeams().size());
 
         // TeamA with working group should have its users
-        var teamA = service.findTeamByName("TeamA");
+        var teamA = service.findTeamByCode("TeamA");
         assertNotNull(teamA);
         assertEquals(2, teamA.users().size());
 
         // TeamB with failing group should have zero users
-        var teamB = service.findTeamByName("TeamB");
+        var teamB = service.findTeamByCode("TeamB");
         assertNotNull(teamB);
         assertEquals(0, teamB.users().size());
 
@@ -284,11 +284,11 @@ class PlatformTeamsServiceTest {
         // Teams should exist but with no users
         assertEquals(2, service.listTeams().size());
 
-        var teamA = service.findTeamByName("TeamA");
+        var teamA = service.findTeamByCode("TeamA");
         assertNotNull(teamA);
         assertEquals(0, teamA.users().size());
 
-        var teamB = service.findTeamByName("TeamB");
+        var teamB = service.findTeamByCode("TeamB");
         assertNotNull(teamB);
         assertEquals(0, teamB.users().size());
 

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcherTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcherTest.java
@@ -1,0 +1,38 @@
+package com.coreeng.supportbot.teams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.coreeng.supportbot.teams.PlatformTeamsFetcher.TeamAndGroupTuple;
+import com.coreeng.supportbot.teams.groups.GroupRef;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StaticPlatformTeamsFetcherTest {
+
+    @Test
+    void explicitCode_decouplesDisplayNameFromIdentity() {
+        StaticPlatformTeamsProps props = new StaticPlatformTeamsProps(
+                true,
+                List.of(new StaticPlatformTeamsProps.TeamConfig("PE Core", "pe-core", new GroupRef.Slack("S1"))));
+        StaticPlatformTeamsFetcher fetcher = new StaticPlatformTeamsFetcher(props);
+
+        List<TeamAndGroupTuple> result = fetcher.fetchTeams();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("PE Core");
+        assertThat(result.getFirst().code()).isEqualTo("pe-core");
+    }
+
+    @Test
+    void missingCode_defaultsCodeToName() {
+        StaticPlatformTeamsProps props = new StaticPlatformTeamsProps(
+                true, List.of(new StaticPlatformTeamsProps.TeamConfig("platform", null, new GroupRef.Slack("S2"))));
+        StaticPlatformTeamsFetcher fetcher = new StaticPlatformTeamsFetcher(props);
+
+        List<TeamAndGroupTuple> result = fetcher.fetchTeams();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("platform");
+        assertThat(result.getFirst().code()).isEqualTo("platform");
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
@@ -49,7 +49,7 @@ class TeamServiceTest {
         PlatformTeam platformOnlyTeam1 = new PlatformTeam("platform-only-1", Set.of(), Set.of());
         PlatformTeam platformOnlyTeam2 = new PlatformTeam("platform-only-2", Set.of(), Set.of());
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformOnlyTeam1, platformOnlyTeam2));
-        when(platformTeamsService.findTeamByName(anyString())).thenReturn(null);
+        when(platformTeamsService.findTeamByCode(anyString())).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Escalation Team 1", "esc1", "slack:SLACK1"),
@@ -81,9 +81,9 @@ class TeamServiceTest {
         PlatformTeam platformOnlyTeam = new PlatformTeam("platform-only-noise", Set.of(), Set.of());
         when(platformTeamsService.listTeams())
                 .thenReturn(ImmutableList.of(platformAndEscalationTeam, platformOnlyTeam));
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(platformAndEscalationTeam);
-        when(platformTeamsService.findTeamByName("esc2")).thenReturn(null);
-        when(platformTeamsService.findTeamByName("platform-only-noise")).thenReturn(platformOnlyTeam);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(platformAndEscalationTeam);
+        when(platformTeamsService.findTeamByCode("esc2")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("platform-only-noise")).thenReturn(platformOnlyTeam);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Escalation Team 1", "esc1", "slack:SLACK1"),
@@ -194,9 +194,9 @@ class TeamServiceTest {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         PlatformTeam platformTeam = new PlatformTeam("platform1", Set.of(), Set.of());
-        when(platformTeamsService.findTeamByName("platform1")).thenReturn(platformTeam);
-        when(platformTeamsService.findTeamByName("escalation-noise-1")).thenReturn(null);
-        when(platformTeamsService.findTeamByName("escalation-noise-2")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("platform1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByCode("escalation-noise-1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("escalation-noise-2")).thenReturn(null);
 
         // Add noise: escalation teams with different codes
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
@@ -222,8 +222,8 @@ class TeamServiceTest {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
-        when(platformTeamsService.findTeamByName("team1")).thenReturn(platformTeam);
-        when(platformTeamsService.findTeamByName("other-team")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("team1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByCode("other-team")).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Team 1", "team1", "slack:SLACK1"),
@@ -247,11 +247,11 @@ class TeamServiceTest {
     void findTeamByCode_returnsEscalationOnlyTeam() {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
-        when(platformTeamsService.findTeamByName("esc2")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc2")).thenReturn(null);
 
         PlatformTeam platformOnlyNoise = new PlatformTeam("platform-noise", Set.of(), Set.of());
-        when(platformTeamsService.findTeamByName("platform-noise")).thenReturn(platformOnlyNoise);
+        when(platformTeamsService.findTeamByCode("platform-noise")).thenReturn(platformOnlyNoise);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Escalation Team 1", "esc1", "slack:SLACK1"),
@@ -275,7 +275,7 @@ class TeamServiceTest {
     void findTeamByCode_returnsNullWhenTeamNotFound() {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("unknown")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("unknown")).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
@@ -460,7 +460,7 @@ class TeamServiceTest {
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformTeam));
-        when(platformTeamsService.findTeamByName("team1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByCode("team1")).thenReturn(platformTeam);
 
         EscalationTeamsRegistry escalationTeamsRegistry =
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Team 1", "team1", "slack:SLACK1")));
@@ -505,7 +505,7 @@ class TeamServiceTest {
         // given - escalation team that is NOT a platform team
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of());
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry =
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation Only", "esc1", "slack:SLACK1")));
@@ -538,7 +538,7 @@ class TeamServiceTest {
     @Test
     void resolveForDisplay_activeTeam_returnsActiveWithTypes() {
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(null);
         EscalationTeamsRegistry escalationTeamsRegistry =
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation One", "esc1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
@@ -558,7 +558,7 @@ class TeamServiceTest {
     @Test
     void resolveForDisplay_retiredTeam_returnsHistoryLabelInactive() {
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("old")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("old")).thenReturn(null);
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
         EscalationTeamHistoryRepository history = mock(EscalationTeamHistoryRepository.class);
@@ -577,7 +577,7 @@ class TeamServiceTest {
     @Test
     void resolveForDisplay_unknownTeam_fallsBackToRawCodeInactive() {
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("ghost")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("ghost")).thenReturn(null);
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
         EscalationTeamHistoryRepository history = mock(EscalationTeamHistoryRepository.class);

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamHistoryRepository;
 import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
 import com.coreeng.supportbot.teams.fakes.FakeEscalationTeamsRegistry;
 import com.google.common.collect.ImmutableList;
@@ -26,7 +27,8 @@ class TeamServiceTest {
         PlatformTeam platformTeam2 = new PlatformTeam("team2", Set.of(), Set.of());
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformTeam1, platformTeam2));
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.TENANT);
@@ -54,7 +56,8 @@ class TeamServiceTest {
                 new EscalationTeam("Escalation Team 2", "esc2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.ESCALATION);
@@ -87,7 +90,8 @@ class TeamServiceTest {
                 new EscalationTeam("Escalation Team 2", "esc2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.ESCALATION);
@@ -115,7 +119,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.SUPPORT);
@@ -134,7 +139,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.LEADERSHIP);
@@ -153,7 +159,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("support");
@@ -171,7 +178,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         Team result = teamService.findTeamByCode("leadership");
 
@@ -196,7 +204,8 @@ class TeamServiceTest {
                 new EscalationTeam("Escalation Noise 2", "escalation-noise-2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("platform1");
@@ -221,7 +230,8 @@ class TeamServiceTest {
                 new EscalationTeam("Other Team", "other-team", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("team1");
@@ -248,7 +258,8 @@ class TeamServiceTest {
                 new EscalationTeam("Escalation Team 2", "esc2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("esc1");
@@ -269,7 +280,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("unknown");
@@ -290,7 +302,8 @@ class TeamServiceTest {
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Both Team", "both1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeams();
@@ -357,7 +370,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("user@test.com");
@@ -379,7 +393,8 @@ class TeamServiceTest {
         SupportTeamService supportTeamService = mockSupportTeamService();
         when(supportTeamService.isMemberByUserEmail("support@test.com")).thenReturn(true);
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("support@test.com");
@@ -402,7 +417,8 @@ class TeamServiceTest {
         when(supportTeamService.isLeadershipMemberByUserEmail("leader@test.com"))
                 .thenReturn(true);
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("leader@test.com");
@@ -425,7 +441,8 @@ class TeamServiceTest {
         when(supportTeamService.isMemberByUserEmail("both@test.com")).thenReturn(true);
         when(supportTeamService.isLeadershipMemberByUserEmail("both@test.com")).thenReturn(true);
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("both@test.com");
@@ -449,7 +466,8 @@ class TeamServiceTest {
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Team 1", "team1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when - query the same team in different ways
         Team fromFindByCode = teamService.findTeamByCode("team1");
@@ -493,7 +511,8 @@ class TeamServiceTest {
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation Only", "esc1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(EscalationTeamHistoryRepository.class));
 
         // when - query the same team in different ways
         Team fromFindByCode = teamService.findTeamByCode("esc1");
@@ -514,6 +533,63 @@ class TeamServiceTest {
         // Should NOT appear in tenant list
         ImmutableList<Team> tenantTeams = teamService.listTeamsByType(TeamType.TENANT);
         assertTrue(tenantTeams.stream().noneMatch(t -> "esc1".equals(t.code())));
+    }
+
+    @Test
+    void resolveForDisplay_activeTeam_returnsActiveWithTypes() {
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
+        EscalationTeamsRegistry escalationTeamsRegistry =
+                new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation One", "esc1", "slack:SLACK1")));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        EscalationTeamHistoryRepository history = mock(EscalationTeamHistoryRepository.class);
+        TeamService teamService =
+                new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService, history);
+
+        TeamDisplay result = teamService.resolveForDisplay("esc1");
+
+        assertEquals("esc1", result.code());
+        assertEquals("Escalation One", result.label());
+        assertEquals(ImmutableList.of(TeamType.ESCALATION), result.types());
+        assertTrue(result.active());
+        verifyNoInteractions(history);
+    }
+
+    @Test
+    void resolveForDisplay_retiredTeam_returnsHistoryLabelInactive() {
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByName("old")).thenReturn(null);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        EscalationTeamHistoryRepository history = mock(EscalationTeamHistoryRepository.class);
+        when(history.findLabelByCode("old")).thenReturn("Old Team");
+        TeamService teamService =
+                new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService, history);
+
+        TeamDisplay result = teamService.resolveForDisplay("old");
+
+        assertEquals("Old Team", result.label());
+        assertEquals("old", result.code());
+        assertFalse(result.active());
+        assertTrue(result.types().isEmpty());
+    }
+
+    @Test
+    void resolveForDisplay_unknownTeam_fallsBackToRawCodeInactive() {
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByName("ghost")).thenReturn(null);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        EscalationTeamHistoryRepository history = mock(EscalationTeamHistoryRepository.class);
+        when(history.findLabelByCode("ghost")).thenReturn(null);
+        TeamService teamService =
+                new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService, history);
+
+        TeamDisplay result = teamService.resolveForDisplay("ghost");
+
+        assertEquals("ghost", result.code());
+        assertEquals("ghost", result.label());
+        assertFalse(result.active());
     }
 
     private SupportTeamService mockSupportTeamService() {

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
@@ -480,6 +480,8 @@ class TicketSummaryServiceTest {
                 .thenReturn(ImmutableList.of(
                         new TicketImpact("Production Blocking", "production-blocking"),
                         new TicketImpact("Minor Issue", "minor-issue")));
+        when(impactsRegistry.findImpactByCode("production-blocking"))
+                .thenReturn(new TicketImpact("Production Blocking", "production-blocking"));
 
         // when
         TicketSummaryView result = service.summaryView(ticketId);

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
@@ -3,6 +3,7 @@ package com.coreeng.supportbot.ticket.rest;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -148,17 +149,15 @@ public class TicketUIMapperTest {
 
         DetailedTicket detailedTicket = new DetailedTicket(ticket, ImmutableList.of());
 
-        Team retired = new Team("Deleted Team", "deleted-team", ImmutableList.of());
-        TeamUI retiredUI = new TeamUI("Deleted Team", "deleted-team", ImmutableList.of());
         when(teamService.resolveForDisplay("deleted-team"))
                 .thenReturn(new TeamDisplay("deleted-team", "Deleted Team", ImmutableList.of(), false));
-        when(teamUIMapper.mapToUI(retired)).thenReturn(retiredUI);
 
-        // then: renders the retired label instead of disappearing
+        // then: renders the retired label (active=false so the UI can badge it) instead of disappearing
         TicketUI result = assertDoesNotThrow(() -> ticketUIMapper.mapToUI(detailedTicket));
         TeamUI team = requireNonNull(result.team());
         assertEquals("Deleted Team", team.label());
         assertEquals("deleted-team", team.code());
+        assertFalse(team.active());
     }
 
     @Test

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
@@ -19,6 +19,7 @@ import com.coreeng.supportbot.slack.SlackId;
 import com.coreeng.supportbot.slack.client.SlackClient;
 import com.coreeng.supportbot.teams.SupportTeamService;
 import com.coreeng.supportbot.teams.Team;
+import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamMemberFetcher;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.TeamType;
@@ -130,8 +131,8 @@ public class TicketUIMapperTest {
     }
 
     @Test
-    void mapToUIReturnsNullWhenKnownTeamNotFound() {
-        // given
+    void mapToUIRendersRetiredTeamLabelWhenNotInConfig() {
+        // given: PT-518 — a team code that is no longer in config should still render its label
         Ticket ticket = Ticket.builder()
                 .id(new TicketId(1))
                 .channelId("C123")
@@ -147,12 +148,17 @@ public class TicketUIMapperTest {
 
         DetailedTicket detailedTicket = new DetailedTicket(ticket, ImmutableList.of());
 
-        // when
-        when(teamService.findTeamByCode("deleted-team")).thenReturn(null);
+        Team retired = new Team("Deleted Team", "deleted-team", ImmutableList.of());
+        TeamUI retiredUI = new TeamUI("Deleted Team", "deleted-team", ImmutableList.of());
+        when(teamService.resolveForDisplay("deleted-team"))
+                .thenReturn(new TeamDisplay("deleted-team", "Deleted Team", ImmutableList.of(), false));
+        when(teamUIMapper.mapToUI(retired)).thenReturn(retiredUI);
 
-        // then
+        // then: renders the retired label instead of disappearing
         TicketUI result = assertDoesNotThrow(() -> ticketUIMapper.mapToUI(detailedTicket));
-        assertNull(result.team());
+        TeamUI team = requireNonNull(result.team());
+        assertEquals("Deleted Team", team.label());
+        assertEquals("deleted-team", team.code());
     }
 
     @Test
@@ -176,7 +182,8 @@ public class TicketUIMapperTest {
         Team team = new Team("wow", "wow", ImmutableList.of(TeamType.TENANT));
         TeamUI teamUI = new TeamUI("wow", "wow", ImmutableList.of(TeamType.TENANT));
 
-        when(teamService.findTeamByCode("wow")).thenReturn(team);
+        when(teamService.resolveForDisplay("wow"))
+                .thenReturn(new TeamDisplay("wow", "wow", ImmutableList.of(TeamType.TENANT), true));
         when(teamUIMapper.mapToUI(team)).thenReturn(teamUI);
 
         // when

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUpdateServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUpdateServiceTest.java
@@ -61,7 +61,7 @@ class TicketUpdateServiceTest {
         DetailedTicket mockDetailedTicket = mock(DetailedTicket.class);
         TicketUI mockTicketUI = mock(TicketUI.class);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
         when(impactsRegistry.findImpactByCode("production-blocking")).thenReturn(validImpact);
         when(ticketProcessingService.submit(any(TicketSubmission.class))).thenReturn(new TicketSubmitResult.Success());
         when(queryService.findDetailedById(ticketId)).thenReturn(mockDetailedTicket);
@@ -137,14 +137,14 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request = new TicketUpdateRequest(
                 TicketStatus.closed, "invalid-team", ImmutableList.of("bug"), "production-blocking", null);
 
-        when(platformTeamsService.findTeamByName("invalid-team")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("invalid-team")).thenReturn(null);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("authorsTeam must be a valid team code");
 
-        verify(platformTeamsService).findTeamByName("invalid-team");
+        verify(platformTeamsService).findTeamByCode("invalid-team");
     }
 
     @Test
@@ -153,7 +153,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request =
                 new TicketUpdateRequest(TicketStatus.closed, "core-support", null, "production-blocking", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -167,7 +167,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request = new TicketUpdateRequest(
                 TicketStatus.closed, "core-support", ImmutableList.of(), "production-blocking", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -181,7 +181,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request =
                 new TicketUpdateRequest(TicketStatus.closed, "core-support", ImmutableList.of("bug"), null, null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -195,7 +195,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request =
                 new TicketUpdateRequest(TicketStatus.closed, "core-support", ImmutableList.of("bug"), "  ", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -209,7 +209,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request = new TicketUpdateRequest(
                 TicketStatus.closed, "core-support", ImmutableList.of("bug"), "invalid-impact", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
         when(impactsRegistry.findImpactByCode("invalid-impact")).thenReturn(null);
 
         // when/then
@@ -233,7 +233,7 @@ class TicketUpdateServiceTest {
         DetailedTicket mockDetailedTicket = mock(DetailedTicket.class);
         TicketUI mockTicketUI = mock(TicketUI.class);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
         when(impactsRegistry.findImpactByCode("production-blocking")).thenReturn(validImpact);
         when(ticketProcessingService.submit(any(TicketSubmission.class))).thenReturn(new TicketSubmitResult.Success());
         when(queryService.findDetailedById(ticketId)).thenReturn(mockDetailedTicket);
@@ -260,7 +260,7 @@ class TicketUpdateServiceTest {
             DetailedTicket mockDetailedTicket = mock(DetailedTicket.class);
             TicketUI mockTicketUI = mock(TicketUI.class);
 
-            when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+            when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
             when(impactsRegistry.findImpactByCode("production-blocking")).thenReturn(validImpact);
             when(ticketProcessingService.submit(any(TicketSubmission.class)))
                     .thenReturn(new TicketSubmitResult.Success());

--- a/docs/enum-codes.md
+++ b/docs/enum-codes.md
@@ -1,0 +1,20 @@
+# Enum codes: tags, impacts, teams
+
+Tags, impacts and (escalation) teams are identified by an immutable `code` that acts as a
+primary key. `label` is the display value and may be changed freely.
+
+- **Do** change `label` to alter what users see.
+- **Do not** change a `code` once in use — stored tickets/escalations reference it.
+- **To remove** a value, delete it from config: it is soft-deleted, hidden from pickers, and
+  still rendered (as "Retired") on existing records.
+- **Renaming** a `code` = delete + add: the old code becomes orphaned. The bot now degrades
+  gracefully (no crash) but historical references show the retired label, not the new one.
+
+## Static teams
+
+`platform-integration.teams-scraping.static.teams[]` accept an optional `code` (and `label`).
+When omitted, `code` defaults to `name`, so the `name` doubles as the identity — renaming it
+orphans references. Set an explicit `code` to keep identity stable while changing the display
+`name`/`label`. The bot logs a startup warning for static teams without an explicit `code`.
+
+Keep examples and codes generic — this repo is public.

--- a/ui/src/app/api/tickets/_lib/map-ticket.ts
+++ b/ui/src/app/api/tickets/_lib/map-ticket.ts
@@ -2,6 +2,7 @@ interface BackendTeam {
   label?: string;
   code?: string;
   types?: string[];
+  active?: boolean;
 }
 
 export function mapTicket(ticket: Record<string, unknown>) {
@@ -12,12 +13,12 @@ export function mapTicket(ticket: Record<string, unknown>) {
     ...ticket,
     summary: (ticket.summary as string) ?? null,
     id: String(ticket.id),
-    team: team ? { name: team.code || team.label || "" } : null,
+    team: team ? { name: team.code || team.label || "", active: team.active } : null,
     escalations:
       escalations?.map((esc) => ({
         ...esc,
         id: String(esc.id),
-        team: esc.team ? { name: esc.team.code || esc.team.label || "" } : null,
+        team: esc.team ? { name: esc.team.code || esc.team.label || "", active: esc.team.active } : null,
       })) ?? [],
   };
 }

--- a/ui/src/components/escalations/EscalatedToMyTeamTable.tsx
+++ b/ui/src/components/escalations/EscalatedToMyTeamTable.tsx
@@ -256,10 +256,12 @@ export default function EscalatedToMyTeamTable() {
             setImpactFilter(v ?? "all");
             setPageIndex(0);
           }}
-          options={(registryData?.impacts ?? []).map((impact: { code: string; label: string }) => ({
-            label: impact.label,
-            value: impact.code,
-          }))}
+          options={(registryData?.impacts ?? [])
+            .filter((impact) => impact.active !== false)
+            .map((impact: { code: string; label: string }) => ({
+              label: impact.label,
+              value: impact.code,
+            }))}
         />
         <SingleSelectFilter
           title="Tag"
@@ -268,10 +270,12 @@ export default function EscalatedToMyTeamTable() {
             setTagFilter(v ?? "");
             setPageIndex(0);
           }}
-          options={(registryData?.tags ?? []).map((tag: { code: string; label: string }) => ({
-            label: tag.label,
-            value: tag.code,
-          }))}
+          options={(registryData?.tags ?? [])
+            .filter((tag) => tag.active !== false)
+            .map((tag: { code: string; label: string }) => ({
+              label: tag.label,
+              value: tag.code,
+            }))}
         />
       </div>
 

--- a/ui/src/components/tickets/EditTicketModal.tsx
+++ b/ui/src/components/tickets/EditTicketModal.tsx
@@ -435,10 +435,12 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                     placeholder="Select tags..."
                     searchPlaceholder="Search tags..."
                     error={!!validationErrors.tags}
-                    options={(registryData?.tags ?? []).map((t: TicketTag) => ({
-                      label: t.label,
-                      value: t.code,
-                    }))}
+                    options={(registryData?.tags ?? [])
+                      .filter((t: TicketTag) => t.active !== false)
+                      .map((t: TicketTag) => ({
+                        label: t.label,
+                        value: t.code,
+                      }))}
                     selected={selectedTags}
                     onChange={(next) => {
                       setSelectedTags(next);
@@ -488,11 +490,13 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                       <SelectValue placeholder="Select impact..." />
                     </SelectTrigger>
                     <SelectContent>
-                      {registryData?.impacts.map((imp: TicketImpact) => (
-                        <SelectItem key={imp.code} value={imp.code}>
-                          {imp.label}
-                        </SelectItem>
-                      ))}
+                      {registryData?.impacts
+                        .filter((imp: TicketImpact) => imp.active !== false)
+                        .map((imp: TicketImpact) => (
+                          <SelectItem key={imp.code} value={imp.code}>
+                            {imp.label}
+                          </SelectItem>
+                        ))}
                     </SelectContent>
                   </Select>
                   {validationErrors.impact && <p className="text-destructive text-sm">{validationErrors.impact}</p>}

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -385,19 +385,23 @@ export default function TicketsPage() {
           title="Impact"
           value={impactFilter || undefined}
           onChange={(v) => setParams({ impact: v ?? "" })}
-          options={(registryData?.impacts ?? []).map((impact: TicketImpact) => ({
-            label: impact.label,
-            value: impact.code,
-          }))}
+          options={(registryData?.impacts ?? [])
+            .filter((impact: TicketImpact) => impact.active !== false)
+            .map((impact: TicketImpact) => ({
+              label: impact.label,
+              value: impact.code,
+            }))}
         />
         <SingleSelectFilter
           title="Tag"
           value={tagFilter || undefined}
           onChange={(v) => setParams({ tag: v ?? "" })}
-          options={(registryData?.tags ?? []).map((tag: TicketTag) => ({
-            label: tag.label,
-            value: tag.code,
-          }))}
+          options={(registryData?.tags ?? [])
+            .filter((tag: TicketTag) => tag.active !== false)
+            .map((tag: TicketTag) => ({
+              label: tag.label,
+              value: tag.code,
+            }))}
         />
         <SingleSelectFilter
           title="Escalated"
@@ -532,18 +536,36 @@ export default function TicketsPage() {
                       </TableCell>
                       <TableCell>{t.team?.name || "-"}</TableCell>
                       <TableCell>
-                        {registryData?.impacts.find((i: TicketImpact) => i.code === t.impact)?.label || t.impact || "-"}
+                        {(() => {
+                          if (!t.impact) return "-";
+                          const impact = registryData?.impacts.find((i: TicketImpact) => i.code === t.impact);
+                          return (
+                            <span className="inline-flex items-center gap-1">
+                              {impact?.label || t.impact}
+                              {impact?.active === false && (
+                                <Badge variant="secondary" className="text-[10px]">
+                                  Retired
+                                </Badge>
+                              )}
+                            </span>
+                          );
+                        })()}
                       </TableCell>
                       <TableCell>
                         {(t.tags?.length ?? 0) > 0
-                          ? t.tags
-                              ?.map(getTagLabel)
-                              .filter(Boolean)
-                              .map((tag, idx) => (
-                                <Badge key={`${t.id}-tag-${idx}`} variant="outline" className="mb-1 block w-fit last:mb-0">
-                                  {tag}
+                          ? t.tags?.map((code, idx) => {
+                              const retired = registryData?.tags.find((x: TicketTag) => x.code === code)?.active === false;
+                              return (
+                                <Badge
+                                  key={`${t.id}-tag-${idx}`}
+                                  variant="outline"
+                                  className="mb-1 flex w-fit items-center gap-1 last:mb-0"
+                                >
+                                  {getTagLabel(code)}
+                                  {retired && <span className="text-muted-foreground text-[10px]">(retired)</span>}
                                 </Badge>
-                              ))
+                              );
+                            })
                           : "-"}
                       </TableCell>
                       {isAssignmentEnabled && <TableCell>{t.assignedTo || "-"}</TableCell>}

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -534,7 +534,20 @@ export default function TicketsPage() {
                           {t.summary?.trim() ? t.summary : "—"}
                         </div>
                       </TableCell>
-                      <TableCell>{t.team?.name || "-"}</TableCell>
+                      <TableCell>
+                        {t.team ? (
+                          <span className="inline-flex items-center gap-1">
+                            {t.team.name || "-"}
+                            {t.team.active === false && (
+                              <Badge variant="secondary" className="text-[10px]">
+                                Retired
+                              </Badge>
+                            )}
+                          </span>
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
                       <TableCell>
                         {(() => {
                           if (!t.impact) return "-";

--- a/ui/src/lib/hooks/index.ts
+++ b/ui/src/lib/hooks/index.ts
@@ -304,8 +304,8 @@ export const useRatings = (from?: string, to?: string) => {
 };
 
 export interface Registry {
-  impacts: { label: string; code: string }[];
-  tags: { label: string; code: string }[];
+  impacts: { label: string; code: string; active?: boolean }[];
+  tags: { label: string; code: string; active?: boolean }[];
 }
 
 export function useRegistry() {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -31,7 +31,7 @@ export interface Escalation {
   hasThread: boolean;
   openedAt: string;
   resolvedAt: string | null;
-  team: { name: string } | null;
+  team: { name: string; active?: boolean } | null;
   escalatingTeam: string;
   tags: string[];
   impact: string | null;
@@ -56,7 +56,7 @@ export interface ParsedTicketLog extends TicketLog {
 export type TicketWithLogs = {
   id: string;
   status: string;
-  team?: { name: string } | null;
+  team?: { name: string; active?: boolean } | null;
   query?: {
     link?: string;
     text?: string;
@@ -73,6 +73,7 @@ export type TicketWithLogs = {
 
 export type TicketTeam = {
   name: string;
+  active?: boolean;
 };
 
 export interface EscalationTeam extends TicketTeam {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -82,11 +82,13 @@ export interface EscalationTeam extends TicketTeam {
 export type TicketImpact = {
   code: string;
   label: string;
+  active?: boolean;
 };
 
 export type TicketTag = {
   code: string;
   label: string;
+  active?: boolean;
 };
 
 export interface PaginatedTickets {


### PR DESCRIPTION
## What & why

Tags, impacts and (escalation) teams are keyed by an immutable `code`; `label`/`name` are display values. Persisted tickets/escalations store these codes, so renaming a code or deleting a config entry orphaned existing data — the bot threw a `NullPointerException` on "View Summary" and orphaned values silently disappeared from the UI. This PR makes config enum updates safe and adds a clear "Retired" UX.

Relates to #273.

## Changes (one commit per milestone)

**M1 — graceful resolution + escalation-team persistence**
- New `escalation_team` history table (V31), reconciled at startup, mirroring the tags/impacts pattern.
- `TeamService.resolveForDisplay`: active config team → retired history label → raw code (never null); `TicketUIMapper` renders retired teams instead of returning null (resolves a standing TODO).
- Removed a second `checkNotNull` NPE in `EscalationProcessingService`.

**M2 (Bug A) — impacts mirror tags**
- `listAllImpacts()` returns active only; a ticket's current impact still resolves (including soft-deleted) so history renders.

**M3 — fail loud**
- Startup validator fails fast on duplicate/blank config codes (always an operator error; safe under a rolling update).
- Non-fatal orphan scan: logs + a Micrometer gauge `support_bot.orphaned_references{type}`, fully guarded so it can never block startup.

**M4 — static-team code/name decoupling (incident root cause)**
- Static teams gain an optional `code` (immutable identity, defaults to `name`); `name` becomes the display value. Escalation↔platform join and ticket/author-team resolution match on `code`. Membership-based access scoping is unaffected by the re-keying.

**M5 — "Retired" indicator**
- `/registry` flags tags/impacts with `active`; every picker filters to active so retired values can't be re-selected; the tickets table shows a "Retired" badge next to retired tags, impacts and teams.

## Backward compatibility

No breaking config change: `code` defaults to `name`, the V31 migration is additive (no new FK), and the UI `active` flag is optional. Existing configs behave identically; explicit codes are opt-in.

## Testing

- **Backend:** full compile + every touched unit test + Checkstyle/ErrorProne green. DB-level behaviour of the new repository and the orphan scan is exercised by the functional harness per repo convention.
- **UI:** typecheck + Jest (636 tests) + prettier all green.

## Deferred / follow-up

- **Bug B** — orphan-aware "Unknown" team/tag *filter bucket*. It interacts with access scoping and is best done as its own change with the functional harness; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
