### PR TITLE
Handle config enum (tag/impact/team) updates gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # p2p makefile
 .p2p.mk
 
+# Superpowers brainstorming/spec/plan artifacts (kept local, not committed)
+docs/superpowers/
+
 # LDAP bootstrap user entries (generated from 20-users.ldif.template + LDAP_BOOTSTRAP_USER_PASSWORD)
 ldap/bootstrap/20-users.ldif
 api/k8s/ldap/chart/files/bootstrap/20-users.ldif

--- a/api/integration-tests/src/test/java/com/coreeng/supportbot/teams/rest/TeamUI.java
+++ b/api/integration-tests/src/test/java/com/coreeng/supportbot/teams/rest/TeamUI.java
@@ -6,4 +6,5 @@ import java.util.List;
 public record TeamUI(
         @JsonProperty("label") String label,
         @JsonProperty("code") String code,
-        @JsonProperty("types") List<String> types) {}
+        @JsonProperty("types") List<String> types,
+        @JsonProperty("active") boolean active) {}

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -84,9 +84,11 @@ ticket:
       key: ${TICKET_ASSIGNMENT_ENCRYPTION_KEY:} # Encryption key (AES-256-GCM). Required when encryption.enabled=true; assignment skipped if missing.
 
 enums:
+  # Codes are immutable primary keys: unique and non-blank within each list (and across the static
+  # platform teams). The app validates this at startup and fails fast on a duplicate/blank code.
   escalation-teams: # Teams available for query escalation
     - label: wow # Label showed on the UI
-      code: wow # Team ID. Must be unique. Have to match platform team name unless platform-integration.fetch.ignore-unknown-teams is set to true
+      code: wow # Team ID. Must be unique. Have to match a platform team code unless platform-integration.fetch.ignore-unknown-teams is set to true
       slack-group-id: S08948NBMED # Slack group ID that will be tagged on escalations
   tags: # Ticket tags
     - label: Ingresses # Label showed on the UI

--- a/api/service/docs/configuration.md
+++ b/api/service/docs/configuration.md
@@ -133,6 +133,12 @@ platform-integration: # Whether to enable platform integration to automatically 
   azure:
     enabled: false
   teams-scraping: # team-name <-> cloud group id scrapper configuration
+    static: # Explicitly-listed teams (no cloud scraping); each team's members come from its group-ref
+      enabled: true
+      teams:
+        - name: My Team # display value shown in the UI
+          code: my-team # optional immutable identity used for mapping (ticket/escalation refs + escalation<->platform join); defaults to name
+          group-ref: my-group # group whose members belong to the team
     core-platform: # Scraper specific to CECG's Core Platform
       enabled: true
     k8s-generic: # A generic scraper that might be used in any K8S environment

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
@@ -1,0 +1,52 @@
+package com.coreeng.supportbot.enums;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.coreeng.supportbot.config.EnumerationValue;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(101)
+@RequiredArgsConstructor
+@Slf4j
+public class EnumConfigValidator implements ApplicationRunner {
+
+    private final EnumProps enumProps;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<String> problems = new ArrayList<>();
+        problems.addAll(findProblems("enums.escalation-teams", enumProps.escalationTeams()));
+        problems.addAll(findProblems("enums.tags", enumProps.tags()));
+        problems.addAll(findProblems("enums.impacts", enumProps.impacts()));
+
+        if (!problems.isEmpty()) {
+            throw new IllegalStateException("Invalid enum configuration: " + String.join("; ", problems)
+                    + ". Codes are immutable primary keys; fix the duplicate/blank codes in config.");
+        }
+        log.atInfo().log("Enum config validation passed");
+    }
+
+    private static List<String> findProblems(String path, ImmutableList<? extends EnumerationValue> values) {
+        List<String> problems = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (EnumerationValue value : values) {
+            String code = value.code();
+            if (code == null || code.isBlank()) {
+                problems.add(path + " has an entry with a blank code");
+            } else if (!seen.add(code)) {
+                problems.add(path + " has duplicate code '" + code + "'");
+            }
+        }
+        return problems;
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
@@ -27,11 +27,11 @@ public class EnumConfigValidator implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         List<String> problems = new ArrayList<>();
-        problems.addAll(findProblems("enums.escalation-teams", enumProps.escalationTeams()));
-        problems.addAll(findProblems("enums.tags", enumProps.tags()));
-        problems.addAll(findProblems("enums.impacts", enumProps.impacts()));
+        problems.addAll(validateCodes("enums.escalation-teams", enumProps.escalationTeams()));
+        problems.addAll(validateCodes("enums.tags", enumProps.tags()));
+        problems.addAll(validateCodes("enums.impacts", enumProps.impacts()));
         if (staticTeamsProps.enabled()) {
-            problems.addAll(findStaticTeamProblems(staticTeamsProps.teams()));
+            problems.addAll(validateStaticTeamCodes(staticTeamsProps.teams()));
         }
 
         if (!problems.isEmpty()) {
@@ -41,7 +41,7 @@ public class EnumConfigValidator implements ApplicationRunner {
         log.atInfo().log("Enum config validation passed");
     }
 
-    private static List<String> findProblems(String path, ImmutableList<? extends EnumerationValue> values) {
+    private static List<String> validateCodes(String path, ImmutableList<? extends EnumerationValue> values) {
         List<String> problems = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         for (EnumerationValue value : values) {
@@ -55,7 +55,7 @@ public class EnumConfigValidator implements ApplicationRunner {
         return problems;
     }
 
-    private static List<String> findStaticTeamProblems(List<StaticPlatformTeamsProps.TeamConfig> teams) {
+    private static List<String> validateStaticTeamCodes(List<StaticPlatformTeamsProps.TeamConfig> teams) {
         List<String> problems = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         for (StaticPlatformTeamsProps.TeamConfig team : teams) {

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumConfigValidator.java
@@ -2,6 +2,7 @@ package com.coreeng.supportbot.enums;
 
 import com.coreeng.supportbot.config.EnumProps;
 import com.coreeng.supportbot.config.EnumerationValue;
+import com.coreeng.supportbot.teams.StaticPlatformTeamsProps;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -15,12 +16,13 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
-@Order(101)
+@Order(99)
 @RequiredArgsConstructor
 @Slf4j
 public class EnumConfigValidator implements ApplicationRunner {
 
     private final EnumProps enumProps;
+    private final StaticPlatformTeamsProps staticTeamsProps;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -28,6 +30,9 @@ public class EnumConfigValidator implements ApplicationRunner {
         problems.addAll(findProblems("enums.escalation-teams", enumProps.escalationTeams()));
         problems.addAll(findProblems("enums.tags", enumProps.tags()));
         problems.addAll(findProblems("enums.impacts", enumProps.impacts()));
+        if (staticTeamsProps.enabled()) {
+            problems.addAll(findStaticTeamProblems(staticTeamsProps.teams()));
+        }
 
         if (!problems.isEmpty()) {
             throw new IllegalStateException("Invalid enum configuration: " + String.join("; ", problems)
@@ -45,6 +50,21 @@ public class EnumConfigValidator implements ApplicationRunner {
                 problems.add(path + " has an entry with a blank code");
             } else if (!seen.add(code)) {
                 problems.add(path + " has duplicate code '" + code + "'");
+            }
+        }
+        return problems;
+    }
+
+    private static List<String> findStaticTeamProblems(List<StaticPlatformTeamsProps.TeamConfig> teams) {
+        List<String> problems = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (StaticPlatformTeamsProps.TeamConfig team : teams) {
+            String explicit = team.code();
+            String code = explicit != null && !explicit.isBlank() ? explicit : team.name();
+            if (code.isBlank()) {
+                problems.add("platform-integration.teams-scraping.static.teams has an entry with a blank code/name");
+            } else if (!seen.add(code)) {
+                problems.add("platform-integration.teams-scraping.static.teams has duplicate code '" + code + "'");
             }
         }
         return problems;

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/EnumsService.java
@@ -35,6 +35,11 @@ public class EnumsService implements EscalationTeamsRegistry, TagsRegistry, Impa
 
     @Override
     public ImmutableList<TicketImpact> listAllImpacts() {
+        return impactsRepository.listAllActive();
+    }
+
+    @Override
+    public ImmutableList<TicketImpact> listAllImpactsIncludingRetired() {
         return impactsRepository.listAll();
     }
 
@@ -62,6 +67,11 @@ public class EnumsService implements EscalationTeamsRegistry, TagsRegistry, Impa
             }
             throw new RuntimeException("Cache retrieval failed for key: " + TAGS_CACHE_KEY, e);
         }
+    }
+
+    @Override
+    public ImmutableList<Tag> listAllTagsIncludingRetired() {
+        return tagsRepository.listAll();
     }
 
     @Override

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/ImpactsRegistry.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/ImpactsRegistry.java
@@ -6,5 +6,7 @@ import org.jspecify.annotations.Nullable;
 public interface ImpactsRegistry {
     ImmutableList<TicketImpact> listAllImpacts();
 
+    ImmutableList<TicketImpact> listAllImpactsIncludingRetired();
+
     @Nullable TicketImpact findImpactByCode(String code);
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceRepository.java
@@ -1,0 +1,49 @@
+package com.coreeng.supportbot.enums;
+
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION;
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION_TO_TAG;
+import static com.coreeng.supportbot.dbschema.Tables.IMPACT;
+import static com.coreeng.supportbot.dbschema.Tables.TAG;
+import static com.coreeng.supportbot.dbschema.Tables.TICKET;
+import static com.coreeng.supportbot.dbschema.Tables.TICKET_TO_TAG;
+
+import com.google.common.collect.ImmutableList;
+import lombok.RequiredArgsConstructor;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+/** Counts stored references to soft-deleted/removed enum codes. */
+@Repository
+@RequiredArgsConstructor
+public class OrphanReferenceRepository {
+
+    private final DSLContext dsl;
+
+    public long countRetiredImpactReferences() {
+        return dsl.fetchCount(
+                TICKET,
+                TICKET.IMPACT_CODE.in(dsl.select(IMPACT.CODE).from(IMPACT).where(IMPACT.DELETED_AT.isNotNull())));
+    }
+
+    public long countRetiredTagReferences() {
+        return (long) dsl.fetchCount(
+                        TICKET_TO_TAG,
+                        TICKET_TO_TAG.TAG_CODE.in(dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())))
+                + dsl.fetchCount(
+                        ESCALATION_TO_TAG,
+                        ESCALATION_TO_TAG.TAG_CODE.in(
+                                dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())));
+    }
+
+    public long countOrphanedEscalationTeamReferences(ImmutableList<String> activeEscalationCodes) {
+        return dsl.fetchCount(ESCALATION, orphanedEscalationTeamCondition(activeEscalationCodes));
+    }
+
+    private static Condition orphanedEscalationTeamCondition(ImmutableList<String> activeCodes) {
+        if (activeCodes.isEmpty()) {
+            return ESCALATION.TEAM.isNotNull();
+        }
+        return ESCALATION.TEAM.isNotNull().and(ESCALATION.TEAM.notIn(activeCodes));
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
@@ -1,11 +1,5 @@
 package com.coreeng.supportbot.enums;
 
-import static com.coreeng.supportbot.dbschema.Tables.ESCALATION;
-import static com.coreeng.supportbot.dbschema.Tables.ESCALATION_TO_TAG;
-import static com.coreeng.supportbot.dbschema.Tables.IMPACT;
-import static com.coreeng.supportbot.dbschema.Tables.TAG;
-import static com.coreeng.supportbot.dbschema.Tables.TICKET;
-import static com.coreeng.supportbot.dbschema.Tables.TICKET_TO_TAG;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.coreeng.supportbot.config.EnumProps;
@@ -17,8 +11,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.Condition;
-import org.jooq.DSLContext;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.annotation.Order;
@@ -30,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class OrphanReferenceScanner implements ApplicationRunner {
 
-    private final DSLContext dsl;
+    private final OrphanReferenceRepository repository;
     private final EnumProps enumProps;
     private final MeterRegistry meterRegistry;
     private final Map<String, AtomicLong> orphanGauges = new ConcurrentHashMap<>();
@@ -38,18 +30,13 @@ public class OrphanReferenceScanner implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         try {
-            long retiredImpactRefs = dsl.fetchCount(
-                    TICKET,
-                    TICKET.IMPACT_CODE.in(dsl.select(IMPACT.CODE).from(IMPACT).where(IMPACT.DELETED_AT.isNotNull())));
-            long retiredTagRefs = (long) dsl.fetchCount(
-                            TICKET_TO_TAG,
-                            TICKET_TO_TAG.TAG_CODE.in(
-                                    dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())))
-                    + dsl.fetchCount(
-                            ESCALATION_TO_TAG,
-                            ESCALATION_TO_TAG.TAG_CODE.in(
-                                    dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())));
-            long orphanedEscalationTeamRefs = dsl.fetchCount(ESCALATION, orphanedEscalationTeamCondition());
+            ImmutableList<String> activeEscalationCodes = enumProps.escalationTeams().stream()
+                    .map(EscalationTeam::code)
+                    .collect(toImmutableList());
+
+            long retiredImpactRefs = repository.countRetiredImpactReferences();
+            long retiredTagRefs = repository.countRetiredTagReferences();
+            long orphanedEscalationTeamRefs = repository.countOrphanedEscalationTeamReferences(activeEscalationCodes);
 
             register("impact", retiredImpactRefs);
             register("tag", retiredTagRefs);
@@ -70,15 +57,6 @@ public class OrphanReferenceScanner implements ApplicationRunner {
         } catch (RuntimeException e) {
             log.atWarn().setCause(e).log("Orphaned-reference scan failed; skipping (non-fatal)");
         }
-    }
-
-    private Condition orphanedEscalationTeamCondition() {
-        ImmutableList<String> activeCodes =
-                enumProps.escalationTeams().stream().map(EscalationTeam::code).collect(toImmutableList());
-        if (activeCodes.isEmpty()) {
-            return ESCALATION.TEAM.isNotNull();
-        }
-        return ESCALATION.TEAM.isNotNull().and(ESCALATION.TEAM.notIn(activeCodes));
     }
 
     private void register(String type, long count) {

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
@@ -12,6 +12,9 @@ import com.coreeng.supportbot.config.EnumProps;
 import com.google.common.collect.ImmutableList;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
@@ -30,6 +33,7 @@ public class OrphanReferenceScanner implements ApplicationRunner {
     private final DSLContext dsl;
     private final EnumProps enumProps;
     private final MeterRegistry meterRegistry;
+    private final Map<String, AtomicLong> orphanGauges = new ConcurrentHashMap<>();
 
     @Override
     public void run(ApplicationArguments args) {
@@ -78,10 +82,16 @@ public class OrphanReferenceScanner implements ApplicationRunner {
     }
 
     private void register(String type, long count) {
-        Gauge.builder("support_bot.orphaned_references", () -> count)
-                .description("Stored references to retired/removed enum codes")
-                .tag("type", type)
-                .strongReference(true)
-                .register(meterRegistry);
+        orphanGauges
+                .computeIfAbsent(type, key -> {
+                    AtomicLong holder = new AtomicLong();
+                    Gauge.builder("support_bot.orphaned_references", holder, AtomicLong::get)
+                            .description("Stored references to retired/removed enum codes")
+                            .tag("type", key)
+                            .strongReference(true)
+                            .register(meterRegistry);
+                    return holder;
+                })
+                .set(count);
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/OrphanReferenceScanner.java
@@ -1,0 +1,87 @@
+package com.coreeng.supportbot.enums;
+
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION;
+import static com.coreeng.supportbot.dbschema.Tables.ESCALATION_TO_TAG;
+import static com.coreeng.supportbot.dbschema.Tables.IMPACT;
+import static com.coreeng.supportbot.dbschema.Tables.TAG;
+import static com.coreeng.supportbot.dbschema.Tables.TICKET;
+import static com.coreeng.supportbot.dbschema.Tables.TICKET_TO_TAG;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.google.common.collect.ImmutableList;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(102)
+@RequiredArgsConstructor
+@Slf4j
+public class OrphanReferenceScanner implements ApplicationRunner {
+
+    private final DSLContext dsl;
+    private final EnumProps enumProps;
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            long retiredImpactRefs = dsl.fetchCount(
+                    TICKET,
+                    TICKET.IMPACT_CODE.in(dsl.select(IMPACT.CODE).from(IMPACT).where(IMPACT.DELETED_AT.isNotNull())));
+            long retiredTagRefs = (long) dsl.fetchCount(
+                            TICKET_TO_TAG,
+                            TICKET_TO_TAG.TAG_CODE.in(
+                                    dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())))
+                    + dsl.fetchCount(
+                            ESCALATION_TO_TAG,
+                            ESCALATION_TO_TAG.TAG_CODE.in(
+                                    dsl.select(TAG.CODE).from(TAG).where(TAG.DELETED_AT.isNotNull())));
+            long orphanedEscalationTeamRefs = dsl.fetchCount(ESCALATION, orphanedEscalationTeamCondition());
+
+            register("impact", retiredImpactRefs);
+            register("tag", retiredTagRefs);
+            register("escalation_team", orphanedEscalationTeamRefs);
+
+            long total = retiredImpactRefs + retiredTagRefs + orphanedEscalationTeamRefs;
+            if (total > 0) {
+                log.atError()
+                        .addKeyValue("retiredImpactRefs", retiredImpactRefs)
+                        .addKeyValue("retiredTagRefs", retiredTagRefs)
+                        .addKeyValue("orphanedEscalationTeamRefs", orphanedEscalationTeamRefs)
+                        .log(
+                                "Found stored references to retired/removed enum codes; they render with their "
+                                        + "last-known label. Rename a code back in config to re-link, or ignore if intentional.");
+            } else {
+                log.atInfo().log("No orphaned enum references found");
+            }
+        } catch (RuntimeException e) {
+            log.atWarn().setCause(e).log("Orphaned-reference scan failed; skipping (non-fatal)");
+        }
+    }
+
+    private Condition orphanedEscalationTeamCondition() {
+        ImmutableList<String> activeCodes =
+                enumProps.escalationTeams().stream().map(EscalationTeam::code).collect(toImmutableList());
+        if (activeCodes.isEmpty()) {
+            return ESCALATION.TEAM.isNotNull();
+        }
+        return ESCALATION.TEAM.isNotNull().and(ESCALATION.TEAM.notIn(activeCodes));
+    }
+
+    private void register(String type, long count) {
+        Gauge.builder("support_bot.orphaned_references", () -> count)
+                .description("Stored references to retired/removed enum codes")
+                .tag("type", type)
+                .strongReference(true)
+                .register(meterRegistry);
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/TagsRegistry.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/TagsRegistry.java
@@ -6,5 +6,7 @@ import com.google.common.collect.ImmutableList;
 public interface TagsRegistry {
     ImmutableList<Tag> listAllTags();
 
+    ImmutableList<Tag> listAllTagsIncludingRetired();
+
     ImmutableList<Tag> listTagsByCodes(ImmutableCollection<String> codes);
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/enums/rest/RegistryController.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/enums/rest/RegistryController.java
@@ -1,10 +1,14 @@
 package com.coreeng.supportbot.enums.rest;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.coreeng.supportbot.enums.ImpactsRegistry;
+import com.coreeng.supportbot.enums.Tag;
 import com.coreeng.supportbot.enums.TagsRegistry;
+import com.coreeng.supportbot.enums.TicketImpact;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,21 +25,26 @@ public class RegistryController {
 
     @GetMapping("/impact")
     public ResponseEntity<List<ImpactUI>> listImpacts() {
-        ImmutableList<ImpactUI> impacts = impactsRegistry.listAllImpacts().stream()
-                .map(i -> new ImpactUI(i.label(), i.code()))
+        ImmutableSet<String> activeCodes = impactsRegistry.listAllImpacts().stream()
+                .map(TicketImpact::code)
+                .collect(toImmutableSet());
+        ImmutableList<ImpactUI> impacts = impactsRegistry.listAllImpactsIncludingRetired().stream()
+                .map(i -> new ImpactUI(i.label(), i.code(), activeCodes.contains(i.code())))
                 .collect(toImmutableList());
         return ResponseEntity.ok(impacts);
     }
 
     @GetMapping("/tag")
     public ResponseEntity<List<TagUI>> listTags() {
-        ImmutableList<TagUI> tags = tagsRegistry.listAllTags().stream()
-                .map(t -> new TagUI(t.label(), t.code()))
+        ImmutableSet<String> activeCodes =
+                tagsRegistry.listAllTags().stream().map(Tag::code).collect(toImmutableSet());
+        ImmutableList<TagUI> tags = tagsRegistry.listAllTagsIncludingRetired().stream()
+                .map(t -> new TagUI(t.label(), t.code(), activeCodes.contains(t.code())))
                 .collect(toImmutableList());
         return ResponseEntity.ok(tags);
     }
 
-    public record ImpactUI(String label, String code) {}
+    public record ImpactUI(String label, String code, boolean active) {}
 
-    public record TagUI(String label, String code) {}
+    public record TagUI(String label, String code, boolean active) {}
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/EscalationProcessingService.java
@@ -43,7 +43,14 @@ public class EscalationProcessingService {
         log.atInfo().addArgument(escalation::id).log("Escalation created: {}");
 
         String teamCode = checkNotNull(escalation.team());
-        EscalationTeam team = checkNotNull(escalationTeamsRegistry.findEscalationTeamByCode(teamCode));
+        EscalationTeam team = escalationTeamsRegistry.findEscalationTeamByCode(teamCode);
+        if (team == null) {
+            log.atWarn()
+                    .addKeyValue("escalationId", escalation.id())
+                    .addKeyValue("teamCode", teamCode)
+                    .log("Escalation references an unresolved team; created without posting a team mention");
+            return escalation;
+        }
         ChatPostMessageResponse messagePostResponse = slackClient.postMessage(new SlackPostMessageRequest(
                 createdMessageMapper.renderMessage(new EscalationCreatedMessage(escalation.id(), team)),
                 slackTicketsProps.channelId(),

--- a/api/service/src/main/java/com/coreeng/supportbot/escalation/rest/EscalationUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/escalation/rest/EscalationUIMapper.java
@@ -3,7 +3,6 @@ package com.coreeng.supportbot.escalation.rest;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.coreeng.supportbot.escalation.Escalation;
-import com.coreeng.supportbot.teams.Team;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.rest.TeamUIMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +15,16 @@ public class EscalationUIMapper {
     private final TeamUIMapper teamUIMapper;
 
     public EscalationUI mapToUI(Escalation escalation) {
-        Team team = escalation.team() != null ? teamService.findTeamByCode(escalation.team()) : null;
         return EscalationUI.builder()
                 .id(checkNotNull(escalation.id()))
                 .ticketId(escalation.ticketId())
                 .hasThread(escalation.threadTs() != null)
                 .openedAt(escalation.openedAt())
                 .resolvedAt(escalation.resolvedAt())
-                .team(team != null ? teamUIMapper.mapToUI(team) : null)
+                .team(
+                        escalation.team() != null
+                                ? teamUIMapper.mapToUI(teamService.resolveForDisplay(escalation.team()))
+                                : null)
                 .tags(escalation.tags())
                 .build();
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeam.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeam.java
@@ -4,15 +4,25 @@ import com.coreeng.supportbot.teams.groups.GroupRef;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@RequiredArgsConstructor
 public class PlatformTeam {
     @EqualsAndHashCode.Include
     private final String name;
 
+    private final String code;
     private final Set<GroupRef> groupRefs;
     private final Set<PlatformUser> users;
+
+    public PlatformTeam(String name, String code, Set<GroupRef> groupRefs, Set<PlatformUser> users) {
+        this.name = name;
+        this.code = code;
+        this.groupRefs = groupRefs;
+        this.users = users;
+    }
+
+    public PlatformTeam(String name, Set<GroupRef> groupRefs, Set<PlatformUser> users) {
+        this(name, name, groupRefs, users);
+    }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetcher.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsFetcher.java
@@ -7,9 +7,13 @@ import java.util.List;
 public interface PlatformTeamsFetcher {
     List<TeamAndGroupTuple> fetchTeams();
 
-    record TeamAndGroupTuple(String name, GroupRef groupRef) {
+    record TeamAndGroupTuple(String name, String code, GroupRef groupRef) {
+        public TeamAndGroupTuple(String name, GroupRef groupRef) {
+            this(name, name, groupRef);
+        }
+
         public TeamAndGroupTuple(String name, String groupRef) {
-            this(name, GroupRef.parse(groupRef));
+            this(name, name, GroupRef.parse(groupRef));
         }
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
@@ -181,7 +181,9 @@ public class PlatformTeamsService {
                     Ensure that it's expected that these teams are not found among platform teams.""", setsDiff);
             } else {
                 throw new IllegalStateException("Unknown escalation teams specified: "
-                        + setsDiff.stream().collect(joining(", ", "[", "]")));
+                        + setsDiff.stream().collect(joining(", ", "[", "]"))
+                        + ". An escalation team's code must match a platform team's code; if a platform team uses an "
+                        + "explicit code, set the same code on its escalation-teams entry.");
             }
         }
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/PlatformTeamsService.java
@@ -41,7 +41,7 @@ public class PlatformTeamsService {
     private final PlatformTeamsFetchProps fetchProps;
 
     private final Map<String, PlatformUser> usersByEmail = new HashMap<>();
-    private final Map<String, PlatformTeam> teamByName = new HashMap<>();
+    private final Map<String, PlatformTeam> teamByCode = new HashMap<>();
     private final Map<GroupRef, List<PlatformUser>> groupRefToUsers = new HashMap<>();
 
     @PostConstruct
@@ -52,8 +52,8 @@ public class PlatformTeamsService {
 
         // Build team objects and collect unique group refs
         for (var t : teams) {
-            PlatformTeam team = teamByName.computeIfAbsent(
-                    t.name(), k -> new PlatformTeam(t.name(), new HashSet<>(), new HashSet<>()));
+            PlatformTeam team = teamByCode.computeIfAbsent(
+                    t.code(), k -> new PlatformTeam(t.name(), t.code(), new HashSet<>(), new HashSet<>()));
             team.groupRefs().add(t.groupRef());
         }
 
@@ -83,7 +83,7 @@ public class PlatformTeamsService {
         }
 
         groupRefToUsers.putAll(fetchedGroupUsers);
-        for (PlatformTeam team : teamByName.values()) {
+        for (PlatformTeam team : teamByCode.values()) {
             for (GroupRef groupRef : team.groupRefs()) {
                 List<PlatformUser> users = groupRefToUsers.getOrDefault(groupRef, List.of());
                 team.users().addAll(users);
@@ -94,7 +94,7 @@ public class PlatformTeamsService {
         }
 
         log.atInfo()
-                .addArgument(teamByName::size)
+                .addArgument(teamByCode::size)
                 .addArgument(groupRefToUsers::size)
                 .addArgument(usersByEmail::size)
                 .addArgument(() -> Duration.between(start, Instant.now()))
@@ -168,12 +168,12 @@ public class PlatformTeamsService {
     }
 
     private void validateEscalationTeamsMapping(List<PlatformTeamsFetcher.TeamAndGroupTuple> teams) {
-        ImmutableSet<String> teamNames =
-                teams.stream().map(PlatformTeamsFetcher.TeamAndGroupTuple::name).collect(toImmutableSet());
-        ImmutableSet<String> escalationTeamNames = escalationTeamsRegistry.listAllEscalationTeams().stream()
+        ImmutableSet<String> teamCodes =
+                teams.stream().map(PlatformTeamsFetcher.TeamAndGroupTuple::code).collect(toImmutableSet());
+        ImmutableSet<String> escalationTeamCodes = escalationTeamsRegistry.listAllEscalationTeams().stream()
                 .map(EscalationTeam::code)
                 .collect(toImmutableSet());
-        var setsDiff = Sets.difference(escalationTeamNames, teamNames);
+        var setsDiff = Sets.difference(escalationTeamCodes, teamCodes);
         if (!setsDiff.isEmpty()) {
             if (fetchProps.ignoreUnknownTeams()) {
                 log.info("""
@@ -187,7 +187,7 @@ public class PlatformTeamsService {
     }
 
     public ImmutableList<PlatformTeam> listTeams() {
-        return ImmutableList.copyOf(teamByName.values());
+        return ImmutableList.copyOf(teamByCode.values());
     }
 
     public ImmutableList<PlatformTeam> listTeamsByUserEmail(String email) {
@@ -198,8 +198,8 @@ public class PlatformTeamsService {
         return ImmutableList.copyOf(user.teams());
     }
 
-    @Nullable public PlatformTeam findTeamByName(String name) {
-        return teamByName.get(name);
+    @Nullable public PlatformTeam findTeamByCode(String code) {
+        return teamByCode.get(code);
     }
 
     @Nullable public PlatformUser findUserByEmail(String email) {

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcher.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcher.java
@@ -1,5 +1,6 @@
 package com.coreeng.supportbot.teams;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +13,24 @@ public class StaticPlatformTeamsFetcher implements PlatformTeamsFetcher {
 
     @Override
     public List<TeamAndGroupTuple> fetchTeams() {
-        return props.teams().stream()
-                .map(team -> new TeamAndGroupTuple(team.name(), team.groupRef()))
+        List<String> teamsUsingNameAsCode = new ArrayList<>();
+        List<TeamAndGroupTuple> teams = props.teams().stream()
+                .map(team -> {
+                    String explicitCode = team.code();
+                    String code = (explicitCode != null && !explicitCode.isBlank()) ? explicitCode : team.name();
+                    if (explicitCode == null || explicitCode.isBlank()) {
+                        teamsUsingNameAsCode.add(team.name());
+                    }
+                    return new TeamAndGroupTuple(team.name(), code, team.groupRef());
+                })
                 .toList();
+        if (!teamsUsingNameAsCode.isEmpty()) {
+            log.atWarn()
+                    .addKeyValue("teams", teamsUsingNameAsCode)
+                    .log("Static teams without an explicit 'code' use their 'name' as the immutable identity; "
+                            + "renaming such a team's 'name' orphans existing references. Add a stable 'code' to "
+                            + "decouple the displayed name from identity.");
+        }
+        return teams;
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/StaticPlatformTeamsProps.java
@@ -2,9 +2,10 @@ package com.coreeng.supportbot.teams;
 
 import com.coreeng.supportbot.teams.groups.GroupRef;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("platform-integration.teams-scraping.static")
 public record StaticPlatformTeamsProps(boolean enabled, List<TeamConfig> teams) {
-    public record TeamConfig(String name, GroupRef groupRef) {}
+    public record TeamConfig(String name, @Nullable String code, GroupRef groupRef) {}
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamDisplay.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamDisplay.java
@@ -1,0 +1,5 @@
+package com.coreeng.supportbot.teams;
+
+import com.google.common.collect.ImmutableList;
+
+public record TeamDisplay(String code, String label, ImmutableList<TeamType> types, boolean active) {}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamHistoryReconciler.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamHistoryReconciler.java
@@ -1,0 +1,43 @@
+package com.coreeng.supportbot.teams;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import com.google.common.collect.ImmutableList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(150)
+@RequiredArgsConstructor
+public class TeamHistoryReconciler implements ApplicationRunner {
+    private final PlatformTeamsService platformTeamsService;
+    private final EscalationTeamsRegistry escalationTeamsRegistry;
+    private final SupportTeamService supportTeamService;
+    private final TeamHistoryRepository teamHistoryRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, Team> byCode = new LinkedHashMap<>();
+        for (PlatformTeam t : platformTeamsService.listTeams()) {
+            byCode.put(t.code(), new Team(t.name(), t.code(), ImmutableList.of(TeamType.TENANT)));
+        }
+        for (EscalationTeam t : escalationTeamsRegistry.listAllEscalationTeams()) {
+            byCode.put(t.code(), new Team(t.label(), t.code(), ImmutableList.of(TeamType.ESCALATION)));
+        }
+        Team support = supportTeamService.getTeam();
+        byCode.put(support.code(), support);
+        Team leadership = supportTeamService.getLeadershipTeam();
+        byCode.put(leadership.code(), leadership);
+
+        ImmutableList<Team> teams = ImmutableList.copyOf(byCode.values());
+        teamHistoryRepository.deleteAllExcept(teams.stream().map(Team::code).collect(toImmutableList()));
+        teamHistoryRepository.insertOrActivate(teams);
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamHistoryRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamHistoryRepository.java
@@ -1,0 +1,45 @@
+package com.coreeng.supportbot.teams;
+
+import static com.coreeng.supportbot.dbschema.Tables.TEAM;
+import static org.jooq.impl.DSL.excluded;
+import static org.jooq.impl.DSL.row;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamHistoryRepository {
+    private final DSLContext dsl;
+
+    @Nullable public String findLabelByCode(String code) {
+        return dsl.select(TEAM.LABEL).from(TEAM).where(TEAM.CODE.eq(code)).fetchOne(r -> r.get(TEAM.LABEL));
+    }
+
+    public int insertOrActivate(ImmutableList<Team> teams) {
+        if (teams.isEmpty()) {
+            return 0;
+        }
+        return dsl.insertInto(TEAM, TEAM.CODE, TEAM.LABEL)
+                .valuesOfRows(teams.stream().map(t -> row(t.code(), t.label())).toList())
+                .onConflict(TEAM.CODE)
+                .doUpdate()
+                .set(TEAM.LABEL, excluded(TEAM.LABEL))
+                .setNull(TEAM.DELETED_AT)
+                .execute();
+    }
+
+    public int deleteAllExcept(ImmutableList<String> codes) {
+        if (codes.isEmpty()) {
+            return dsl.update(TEAM).set(TEAM.DELETED_AT, Instant.now()).execute();
+        }
+        return dsl.update(TEAM)
+                .set(TEAM.DELETED_AT, Instant.now())
+                .where(TEAM.CODE.notIn(codes))
+                .execute();
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamHistoryRepository.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamHistoryRepository.java
@@ -35,7 +35,7 @@ public class TeamHistoryRepository {
 
     public int deleteAllExcept(ImmutableList<String> codes) {
         if (codes.isEmpty()) {
-            return dsl.update(TEAM).set(TEAM.DELETED_AT, Instant.now()).execute();
+            return 0;
         }
         return dsl.update(TEAM)
                 .set(TEAM.DELETED_AT, Instant.now())

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/TeamService.java
@@ -17,6 +17,7 @@ public class TeamService {
     private final PlatformTeamsService platformTeamsService;
     private final EscalationTeamsRegistry escalationTeamsRegistry;
     private final SupportTeamService supportTeamService;
+    private final TeamHistoryRepository teamHistoryRepository;
 
     public ImmutableList<Team> listTeamsByUserEmail(String email) {
         ImmutableList<PlatformTeam> platformTeams = platformTeamsService.listTeamsByUserEmail(email);
@@ -47,7 +48,7 @@ public class TeamService {
             case ESCALATION ->
                 escalationTeamsRegistry.listAllEscalationTeams().stream()
                         .map(t -> {
-                            PlatformTeam platformTeam = platformTeamsService.findTeamByName(t.code());
+                            PlatformTeam platformTeam = platformTeamsService.findTeamByCode(t.code());
                             if (platformTeam != null) {
                                 return new Team(
                                         t.label(), t.code(), ImmutableList.of(TeamType.TENANT, TeamType.ESCALATION));
@@ -71,7 +72,7 @@ public class TeamService {
             return leadershipTeam;
         }
 
-        PlatformTeam platformTeam = platformTeamsService.findTeamByName(code);
+        PlatformTeam platformTeam = platformTeamsService.findTeamByCode(code);
         if (platformTeam != null) {
             return mapPlatformTeam(platformTeam);
         }
@@ -84,18 +85,30 @@ public class TeamService {
         return null;
     }
 
+    public TeamDisplay resolveForDisplay(String code) {
+        Team team = findTeamByCode(code);
+        if (team != null) {
+            return new TeamDisplay(team.code(), team.label(), team.types(), true);
+        }
+        String retiredLabel = teamHistoryRepository.findLabelByCode(code);
+        if (retiredLabel != null) {
+            return new TeamDisplay(code, retiredLabel, ImmutableList.of(), false);
+        }
+        return new TeamDisplay(code, code, ImmutableList.of(), false);
+    }
+
     private ImmutableList<Team> mapPlatformTeams(ImmutableList<PlatformTeam> platformTeams) {
         return platformTeams.stream().map(this::mapPlatformTeam).collect(toImmutableList());
     }
 
     @NonNull private Team mapPlatformTeam(PlatformTeam t) {
-        EscalationTeam escalationTeam = escalationTeamsRegistry.findEscalationTeamByCode(t.name());
+        EscalationTeam escalationTeam = escalationTeamsRegistry.findEscalationTeamByCode(t.code());
         if (escalationTeam != null) {
             return new Team(
                     escalationTeam.label(),
                     escalationTeam.code(),
                     ImmutableList.of(TeamType.TENANT, TeamType.ESCALATION));
         }
-        return new Team(t.name(), t.name(), ImmutableList.of(TeamType.TENANT));
+        return new Team(t.name(), t.code(), ImmutableList.of(TeamType.TENANT));
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUI.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUI.java
@@ -3,4 +3,8 @@ package com.coreeng.supportbot.teams.rest;
 import com.coreeng.supportbot.teams.TeamType;
 import com.google.common.collect.ImmutableList;
 
-public record TeamUI(String label, String code, ImmutableList<TeamType> types) {}
+public record TeamUI(String label, String code, ImmutableList<TeamType> types, boolean active) {
+    public TeamUI(String label, String code, ImmutableList<TeamType> types) {
+        this(label, code, types, true);
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/teams/rest/TeamUIMapper.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.coreeng.supportbot.teams.PlatformUser;
 import com.coreeng.supportbot.teams.Team;
+import com.coreeng.supportbot.teams.TeamDisplay;
 import com.google.common.collect.ImmutableList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,5 +19,12 @@ public class TeamUIMapper {
 
     public TeamUI mapToUI(Team team) {
         return new TeamUI(team.label(), team.code(), team.types());
+    }
+
+    public TeamUI mapToUI(TeamDisplay team) {
+        if (team.active()) {
+            return mapToUI(new Team(team.label(), team.code(), team.types()));
+        }
+        return new TeamUI(team.label(), team.code(), team.types(), false);
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
@@ -66,7 +66,9 @@ public class TicketSummaryService {
         // Resolve labels for tags on this ticket, including any soft-deleted from the database,
         // so historical tag data remains visible in the summary view.
         ImmutableList<Tag> currentTags = tagsRegistry.listTagsByCodes(ticket.tags());
-        ImmutableList<TicketImpact> allImpacts = impactsRegistry.listAllImpacts();
+        ImmutableList<TicketImpact> activeImpacts = impactsRegistry.listAllImpacts();
+        TicketImpact currentImpact = ticket.impact() != null ? impactsRegistry.findImpactByCode(ticket.impact()) : null;
+        ImmutableList<TicketImpact> impactOptions = impactOptionsWithCurrent(activeImpacts, currentImpact);
 
         // Assignee fields (only if assignment is enabled)
         String currentAssignee = assignmentProps.enabled() && ticket.assignedTo() != null
@@ -84,10 +86,22 @@ public class TicketSummaryService {
                 querySummary,
                 escalations,
                 currentTags,
-                allImpacts,
-                ticket.impact() != null ? impactsRegistry.findImpactByCode(ticket.impact()) : null,
+                impactOptions,
+                currentImpact,
                 currentAssignee,
                 availableAssignees);
+    }
+
+    private static ImmutableList<TicketImpact> impactOptionsWithCurrent(
+            ImmutableList<TicketImpact> active, @Nullable TicketImpact current) {
+        if (current == null) {
+            return active;
+        }
+        String currentCode = current.code();
+        if (active.stream().anyMatch(i -> currentCode.equals(i.code()))) {
+            return active;
+        }
+        return ImmutableList.<TicketImpact>builder().addAll(active).add(current).build();
     }
 
     private ImmutableList<TicketSummaryView.EscalationView> getEscalationViews(Ticket ticket) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
@@ -85,12 +85,7 @@ public class TicketSummaryService {
                 escalations,
                 currentTags,
                 allImpacts,
-                ticket.impact() != null
-                        ? allImpacts.stream()
-                                .filter(i -> ticket.impact().contains(i.code()))
-                                .findAny()
-                                .orElse(null)
-                        : null,
+                ticket.impact() != null ? impactsRegistry.findImpactByCode(ticket.impact()) : null,
                 currentAssignee,
                 availableAssignees);
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
@@ -10,8 +10,6 @@ import com.coreeng.supportbot.slack.SlackId;
 import com.coreeng.supportbot.slack.client.SlackClient;
 import com.coreeng.supportbot.slack.client.SlackGetMessageByTsRequest;
 import com.coreeng.supportbot.teams.SupportTeamService;
-import com.coreeng.supportbot.teams.Team;
-import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamMemberFetcher;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.rest.TeamUI;
@@ -104,12 +102,8 @@ public class TicketUIMapper {
                 .build();
     }
 
-    @Nullable private TeamUI mapKnownTeamToUI(String code) {
-        TeamDisplay team = teamService.resolveForDisplay(code);
-        if (team.active()) {
-            return teamUIMapper.mapToUI(new Team(team.label(), team.code(), team.types()));
-        }
-        return new TeamUI(team.label(), team.code(), team.types(), false);
+    private TeamUI mapKnownTeamToUI(String code) {
+        return teamUIMapper.mapToUI(teamService.resolveForDisplay(code));
     }
 
     @Nullable private String resolveQueryPermalink(DetailedTicket ticket) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUIMapper.java
@@ -11,6 +11,7 @@ import com.coreeng.supportbot.slack.client.SlackClient;
 import com.coreeng.supportbot.slack.client.SlackGetMessageByTsRequest;
 import com.coreeng.supportbot.teams.SupportTeamService;
 import com.coreeng.supportbot.teams.Team;
+import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamMemberFetcher;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.rest.TeamUI;
@@ -103,11 +104,12 @@ public class TicketUIMapper {
                 .build();
     }
 
-    // TODO: If team is deleted after ticket has been saved to to db, this returns null. We should potentially look at
-    // saving team info to database so deleted teams can still be displayed instead of returning null
     @Nullable private TeamUI mapKnownTeamToUI(String code) {
-        Team team = teamService.findTeamByCode(code);
-        return team != null ? teamUIMapper.mapToUI(team) : null;
+        TeamDisplay team = teamService.resolveForDisplay(code);
+        if (team.active()) {
+            return teamUIMapper.mapToUI(new Team(team.label(), team.code(), team.types()));
+        }
+        return new TeamUI(team.label(), team.code(), team.types(), false);
     }
 
     @Nullable private String resolveQueryPermalink(DetailedTicket ticket) {

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUpdateService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/rest/TicketUpdateService.java
@@ -62,7 +62,7 @@ public class TicketUpdateService {
             return ValidationResult.invalid("authorsTeam is required");
         }
         boolean isNotATenant = TicketTeam.NOT_A_TENANT_CODE.equals(request.authorsTeam());
-        PlatformTeam team = platformTeamsService.findTeamByName(request.authorsTeam());
+        PlatformTeam team = platformTeamsService.findTeamByCode(request.authorsTeam());
         if (!isNotATenant && team == null) {
             return ValidationResult.invalid("authorsTeam must be a valid team code");
         }

--- a/api/service/src/main/resources/db/migration/V31__team.sql
+++ b/api/service/src/main/resources/db/migration/V31__team.sql
@@ -1,0 +1,6 @@
+create table if not exists team
+(
+    code       text primary key,
+    label      text not null,
+    deleted_at timestamptz
+);

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/EnumConfigValidatorTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/EnumConfigValidatorTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.coreeng.supportbot.config.EnumProps;
+import com.coreeng.supportbot.teams.StaticPlatformTeamsProps;
 import com.coreeng.supportbot.teams.groups.GroupRef;
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,6 +21,9 @@ class EnumConfigValidatorTest {
 
     @Mock
     private EnumProps enumProps;
+
+    @Mock
+    private StaticPlatformTeamsProps staticTeamsProps;
 
     @InjectMocks
     private EnumConfigValidator validator;
@@ -53,5 +58,21 @@ class EnumConfigValidatorTest {
         assertThatThrownBy(() -> validator.run(new DefaultApplicationArguments()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("blank code");
+    }
+
+    @Test
+    void run_throws_onDuplicateStaticTeamCode() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(enumProps.tags()).thenReturn(ImmutableList.of());
+        when(enumProps.impacts()).thenReturn(ImmutableList.of());
+        when(staticTeamsProps.enabled()).thenReturn(true);
+        when(staticTeamsProps.teams())
+                .thenReturn(List.of(
+                        new StaticPlatformTeamsProps.TeamConfig("First", "dup", new GroupRef.Slack("S1")),
+                        new StaticPlatformTeamsProps.TeamConfig("Second", "dup", new GroupRef.Slack("S2"))));
+
+        assertThatThrownBy(() -> validator.run(new DefaultApplicationArguments()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("duplicate code 'dup'");
     }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/EnumConfigValidatorTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/EnumConfigValidatorTest.java
@@ -1,0 +1,57 @@
+package com.coreeng.supportbot.enums;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.coreeng.supportbot.teams.groups.GroupRef;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class EnumConfigValidatorTest {
+
+    @Mock
+    private EnumProps enumProps;
+
+    @InjectMocks
+    private EnumConfigValidator validator;
+
+    @Test
+    void run_passes_whenCodesAreUniqueAndNonBlank() {
+        when(enumProps.escalationTeams())
+                .thenReturn(ImmutableList.of(new EscalationTeam("Platform", "platform", new GroupRef.Slack("SP"))));
+        when(enumProps.tags()).thenReturn(ImmutableList.of(new Tag("Networking", "networking")));
+        when(enumProps.impacts()).thenReturn(ImmutableList.of(new TicketImpact("Blocking", "blocking")));
+
+        assertThatCode(() -> validator.run(new DefaultApplicationArguments())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void run_throws_onDuplicateTagCode() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(enumProps.tags()).thenReturn(ImmutableList.of(new Tag("First", "dup"), new Tag("Second", "dup")));
+        when(enumProps.impacts()).thenReturn(ImmutableList.of());
+
+        assertThatThrownBy(() -> validator.run(new DefaultApplicationArguments()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("duplicate code 'dup'");
+    }
+
+    @Test
+    void run_throws_onBlankImpactCode() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(enumProps.tags()).thenReturn(ImmutableList.of());
+        when(enumProps.impacts()).thenReturn(ImmutableList.of(new TicketImpact("No Code", "")));
+
+        assertThatThrownBy(() -> validator.run(new DefaultApplicationArguments()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("blank code");
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/EnumsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/EnumsServiceTest.java
@@ -65,6 +65,37 @@ class EnumsServiceTest {
     }
 
     @Test
+    void listAllImpacts_delegatesToListAllActive_excludingSoftDeleted() {
+        ImmutableList<TicketImpact> activeImpacts =
+                ImmutableList.of(new TicketImpact("Production Blocking", "production-blocking"));
+        when(impactsRepository.listAllActive()).thenReturn(activeImpacts);
+
+        ImmutableList<TicketImpact> result = service.listAllImpacts();
+
+        assertThat(result).isEqualTo(activeImpacts);
+        verify(impactsRepository).listAllActive();
+    }
+
+    @Test
+    void listAllImpactsIncludingRetired_delegatesToListAll() {
+        ImmutableList<TicketImpact> all =
+                ImmutableList.of(new TicketImpact("Active", "active"), new TicketImpact("Retired", "retired"));
+        when(impactsRepository.listAll()).thenReturn(all);
+
+        assertThat(service.listAllImpactsIncludingRetired()).isEqualTo(all);
+        verify(impactsRepository).listAll();
+    }
+
+    @Test
+    void listAllTagsIncludingRetired_delegatesToListAll() {
+        ImmutableList<Tag> all = ImmutableList.of(new Tag("Active", "active"), new Tag("Retired", "retired"));
+        when(tagsRepository.listAll()).thenReturn(all);
+
+        assertThat(service.listAllTagsIncludingRetired()).isEqualTo(all);
+        verify(tagsRepository).listAll();
+    }
+
+    @Test
     void listTagsByCodes_delegatesToListByCodes() {
         ImmutableList<String> codes = ImmutableList.of("networking", "deleted-tag");
         ImmutableList<Tag> tags =

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/OrphanReferenceScannerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/OrphanReferenceScannerTest.java
@@ -1,0 +1,59 @@
+package com.coreeng.supportbot.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.config.EnumProps;
+import com.google.common.collect.ImmutableList;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class OrphanReferenceScannerTest {
+
+    @Mock
+    private OrphanReferenceRepository repository;
+
+    @Mock
+    private EnumProps enumProps;
+
+    @Test
+    void run_registersGaugesFromRepositoryCounts() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(repository.countRetiredImpactReferences()).thenReturn(2L);
+        when(repository.countRetiredTagReferences()).thenReturn(3L);
+        when(repository.countOrphanedEscalationTeamReferences(ImmutableList.of()))
+                .thenReturn(4L);
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        OrphanReferenceScanner scanner = new OrphanReferenceScanner(repository, enumProps, meterRegistry);
+
+        scanner.run(new DefaultApplicationArguments());
+
+        assertThat(gauge(meterRegistry, "impact")).isEqualTo(2.0);
+        assertThat(gauge(meterRegistry, "tag")).isEqualTo(3.0);
+        assertThat(gauge(meterRegistry, "escalation_team")).isEqualTo(4.0);
+    }
+
+    @Test
+    void run_isNonFatalWhenRepositoryThrows() {
+        when(enumProps.escalationTeams()).thenReturn(ImmutableList.of());
+        when(repository.countRetiredImpactReferences()).thenThrow(new RuntimeException("db unavailable"));
+        OrphanReferenceScanner scanner = new OrphanReferenceScanner(repository, enumProps, new SimpleMeterRegistry());
+
+        // The scan must never block startup.
+        assertThatCode(() -> scanner.run(new DefaultApplicationArguments())).doesNotThrowAnyException();
+    }
+
+    private static double gauge(MeterRegistry registry, String type) {
+        return registry.get("support_bot.orphaned_references")
+                .tag("type", type)
+                .gauge()
+                .value();
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/enums/rest/RegistryControllerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/enums/rest/RegistryControllerTest.java
@@ -1,0 +1,57 @@
+package com.coreeng.supportbot.enums.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.enums.ImpactsRegistry;
+import com.coreeng.supportbot.enums.Tag;
+import com.coreeng.supportbot.enums.TagsRegistry;
+import com.coreeng.supportbot.enums.TicketImpact;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryControllerTest {
+
+    @Mock
+    private ImpactsRegistry impactsRegistry;
+
+    @Mock
+    private TagsRegistry tagsRegistry;
+
+    @InjectMocks
+    private RegistryController controller;
+
+    @Test
+    void listImpacts_flagsRetiredAsInactive() {
+        when(impactsRegistry.listAllImpacts()).thenReturn(ImmutableList.of(new TicketImpact("Active", "active")));
+        when(impactsRegistry.listAllImpactsIncludingRetired())
+                .thenReturn(
+                        ImmutableList.of(new TicketImpact("Active", "active"), new TicketImpact("Retired", "retired")));
+
+        var body = controller.listImpacts().getBody();
+
+        assertThat(body)
+                .containsExactly(
+                        new RegistryController.ImpactUI("Active", "active", true),
+                        new RegistryController.ImpactUI("Retired", "retired", false));
+    }
+
+    @Test
+    void listTags_flagsRetiredAsInactive() {
+        when(tagsRegistry.listAllTags()).thenReturn(ImmutableList.of(new Tag("Active", "active")));
+        when(tagsRegistry.listAllTagsIncludingRetired())
+                .thenReturn(ImmutableList.of(new Tag("Active", "active"), new Tag("Retired", "retired")));
+
+        var body = controller.listTags().getBody();
+
+        assertThat(body)
+                .containsExactly(
+                        new RegistryController.TagUI("Active", "active", true),
+                        new RegistryController.TagUI("Retired", "retired", false));
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/escalation/EscalationProcessingServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/escalation/EscalationProcessingServiceTest.java
@@ -116,4 +116,30 @@ class EscalationProcessingServiceTest {
         assertThat(escalation.team()).isEqualTo(expectedEscalation.team());
         assertThat(escalation.tags()).isEqualTo(expectedEscalation.tags());
     }
+
+    @Test
+    public void shouldNotPostMessageWhenEscalationTeamUnresolved() {
+        CreateEscalationRequest escalationRequest = CreateEscalationRequest.builder()
+                .ticket(Ticket.builder()
+                        .id(new TicketId(1))
+                        .queryTs(MessageTs.of("1234567890.123456"))
+                        .channelId("test-channel")
+                        .build())
+                .team("removed-team")
+                .tags(ImmutableList.of())
+                .build();
+        Escalation created = Escalation.builder()
+                .id(new EscalationId(1))
+                .ticketId(new TicketId(1))
+                .status(EscalationStatus.opened)
+                .team("removed-team")
+                .build();
+        when(escalationRepository.createIfNotExists(any(Escalation.class))).thenReturn(created);
+        when(escalationTeamsRegistry.findEscalationTeamByCode("removed-team")).thenReturn(null);
+
+        Escalation escalation = requireNonNull(processingService.createEscalation(escalationRequest));
+
+        assertThat(escalation.id()).isEqualTo(new EscalationId(1));
+        verifyNoInteractions(slackClient);
+    }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/escalation/rest/EscalationUIMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/escalation/rest/EscalationUIMapperTest.java
@@ -10,7 +10,7 @@ import com.coreeng.supportbot.escalation.Escalation;
 import com.coreeng.supportbot.escalation.EscalationId;
 import com.coreeng.supportbot.escalation.EscalationStatus;
 import com.coreeng.supportbot.slack.MessageTs;
-import com.coreeng.supportbot.teams.Team;
+import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.TeamType;
 import com.coreeng.supportbot.teams.rest.TeamUI;
@@ -69,9 +69,9 @@ class EscalationUIMapperTest {
     void mapToUIReturnsTeam() {
         // given
         Escalation escalation = escalation().team("platform").build();
-        Team team = new Team("platform", "Platform", ImmutableList.of(TeamType.TENANT));
-        TeamUI teamUI = new TeamUI("platform", "Platform", ImmutableList.of(TeamType.TENANT));
-        when(teamService.findTeamByCode("platform")).thenReturn(team);
+        TeamDisplay team = new TeamDisplay("platform", "Platform", ImmutableList.of(TeamType.TENANT), true);
+        TeamUI teamUI = new TeamUI("Platform", "platform", ImmutableList.of(TeamType.TENANT));
+        when(teamService.resolveForDisplay("platform")).thenReturn(team);
         when(teamUIMapper.mapToUI(team)).thenReturn(teamUI);
 
         // when
@@ -94,16 +94,19 @@ class EscalationUIMapperTest {
     }
 
     @Test
-    void mapToUIReturnsNullTeamWhenTeamNotFound() {
-        // given
+    void mapToUIReturnsRetiredTeamWithLastKnownLabel() {
+        // given: a team removed from config still resolves to its last-known label, flagged retired
         Escalation escalation = escalation().team("deleted-team").build();
-        when(teamService.findTeamByCode("deleted-team")).thenReturn(null);
+        TeamDisplay retired = new TeamDisplay("deleted-team", "Deleted Team", ImmutableList.of(), false);
+        TeamUI retiredUI = new TeamUI("Deleted Team", "deleted-team", ImmutableList.of(), false);
+        when(teamService.resolveForDisplay("deleted-team")).thenReturn(retired);
+        when(teamUIMapper.mapToUI(retired)).thenReturn(retiredUI);
 
         // when
         EscalationUI result = escalationUIMapper.mapToUI(escalation);
 
-        // then
-        assertNull(result.team());
+        // then: equals covers active=false; the team is rendered rather than dropped
+        assertEquals(retiredUI, result.team());
     }
 
     private Escalation.EscalationBuilder escalation() {

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceConcurrencyTest.java
@@ -76,7 +76,7 @@ class PlatformTeamsServiceConcurrencyTest {
         for (int i = 1; i <= groups; i++) {
             String teamName = "team-" + i;
             String groupKey = "G" + i;
-            var team = service.findTeamByName(teamName);
+            var team = service.findTeamByCode(teamName);
             assertNotNull(team);
             assertTrue(team.groupRefs().contains(GroupRef.parse(groupKey)));
             assertEquals(1, team.users().size());

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
@@ -132,7 +132,11 @@ class PlatformTeamsServiceTest {
                 new PlatformTeamsService(teamsFetcher, resolverOf(usersFetcher), registry, props);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class, service::init);
-        assertEquals("Unknown escalation teams specified: [unknown]", ex.getMessage());
+        assertEquals(
+                "Unknown escalation teams specified: [unknown]. An escalation team's code must match a "
+                        + "platform team's code; if a platform team uses an explicit code, set the same code "
+                        + "on its escalation-teams entry.",
+                ex.getMessage());
     }
 
     @Test

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/PlatformTeamsServiceTest.java
@@ -46,7 +46,7 @@ class PlatformTeamsServiceTest {
         service.init();
 
         assertEquals(1, service.listTeams().size());
-        var team = service.findTeamByName("wow");
+        var team = service.findTeamByCode("wow");
         assertNotNull(team);
         assertTrue(team.groupRefs().contains(ref("wow-group")));
         assertEquals(1, team.users().size());
@@ -82,8 +82,8 @@ class PlatformTeamsServiceTest {
 
         assertEquals(1, usersFetcher.getCallCount("shared"));
 
-        var teamA = service.findTeamByName("A");
-        var teamB = service.findTeamByName("B");
+        var teamA = service.findTeamByCode("A");
+        var teamB = service.findTeamByCode("B");
         assertNotNull(teamA);
         assertNotNull(teamB);
         assertEquals(2, teamA.users().size());
@@ -111,7 +111,7 @@ class PlatformTeamsServiceTest {
 
         service.init();
 
-        var t1 = service.findTeamByName("T1");
+        var t1 = service.findTeamByCode("T1");
         assertNotNull(t1);
         assertEquals(2, t1.users().size());
         assertEquals(1, service.listTeamsByUserEmail("a@test.com").size());
@@ -155,7 +155,7 @@ class PlatformTeamsServiceTest {
 
         // Verify that the service initialized correctly with the known team
         assertEquals(1, service.listTeams().size());
-        var team = service.findTeamByName("wow");
+        var team = service.findTeamByCode("wow");
         assertNotNull(team);
         assertEquals("wow", team.name());
         assertEquals(1, team.users().size());
@@ -210,7 +210,7 @@ class PlatformTeamsServiceTest {
         service.init();
 
         assertEquals(1, usersFetcher.getCallCount("G"));
-        var t = service.findTeamByName("T");
+        var t = service.findTeamByCode("T");
         assertNotNull(t);
         assertEquals(1, t.groupRefs().size());
         assertTrue(t.groupRefs().contains(ref("G")));
@@ -246,12 +246,12 @@ class PlatformTeamsServiceTest {
         assertEquals(2, service.listTeams().size());
 
         // TeamA with working group should have its users
-        var teamA = service.findTeamByName("TeamA");
+        var teamA = service.findTeamByCode("TeamA");
         assertNotNull(teamA);
         assertEquals(2, teamA.users().size());
 
         // TeamB with failing group should have zero users
-        var teamB = service.findTeamByName("TeamB");
+        var teamB = service.findTeamByCode("TeamB");
         assertNotNull(teamB);
         assertEquals(0, teamB.users().size());
 
@@ -284,11 +284,11 @@ class PlatformTeamsServiceTest {
         // Teams should exist but with no users
         assertEquals(2, service.listTeams().size());
 
-        var teamA = service.findTeamByName("TeamA");
+        var teamA = service.findTeamByCode("TeamA");
         assertNotNull(teamA);
         assertEquals(0, teamA.users().size());
 
-        var teamB = service.findTeamByName("TeamB");
+        var teamB = service.findTeamByCode("TeamB");
         assertNotNull(teamB);
         assertEquals(0, teamB.users().size());
 

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcherTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/StaticPlatformTeamsFetcherTest.java
@@ -1,0 +1,38 @@
+package com.coreeng.supportbot.teams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.coreeng.supportbot.teams.PlatformTeamsFetcher.TeamAndGroupTuple;
+import com.coreeng.supportbot.teams.groups.GroupRef;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StaticPlatformTeamsFetcherTest {
+
+    @Test
+    void explicitCode_decouplesDisplayNameFromIdentity() {
+        StaticPlatformTeamsProps props = new StaticPlatformTeamsProps(
+                true,
+                List.of(new StaticPlatformTeamsProps.TeamConfig("Display Name", "team-id", new GroupRef.Slack("S1"))));
+        StaticPlatformTeamsFetcher fetcher = new StaticPlatformTeamsFetcher(props);
+
+        List<TeamAndGroupTuple> result = fetcher.fetchTeams();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("Display Name");
+        assertThat(result.getFirst().code()).isEqualTo("team-id");
+    }
+
+    @Test
+    void missingCode_defaultsCodeToName() {
+        StaticPlatformTeamsProps props = new StaticPlatformTeamsProps(
+                true, List.of(new StaticPlatformTeamsProps.TeamConfig("platform", null, new GroupRef.Slack("S2"))));
+        StaticPlatformTeamsFetcher fetcher = new StaticPlatformTeamsFetcher(props);
+
+        List<TeamAndGroupTuple> result = fetcher.fetchTeams();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("platform");
+        assertThat(result.getFirst().code()).isEqualTo("platform");
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/TeamHistoryReconcilerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/TeamHistoryReconcilerTest.java
@@ -1,0 +1,54 @@
+package com.coreeng.supportbot.teams;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coreeng.supportbot.enums.EscalationTeam;
+import com.coreeng.supportbot.enums.EscalationTeamsRegistry;
+import com.coreeng.supportbot.teams.fakes.FakeEscalationTeamsRegistry;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class TeamHistoryReconcilerTest {
+
+    @Mock
+    private PlatformTeamsService platformTeamsService;
+
+    @Mock
+    private SupportTeamService supportTeamService;
+
+    @Mock
+    private TeamHistoryRepository teamHistoryRepository;
+
+    @Test
+    void run_persistsCodeAndLabelForEveryKnownTeamSource() {
+        EscalationTeamsRegistry escalationTeamsRegistry =
+                new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation One", "esc1", "slack:S1")));
+        when(platformTeamsService.listTeams())
+                .thenReturn(ImmutableList.of(new PlatformTeam("Platform One", "plat1", Set.of(), Set.of())));
+        when(supportTeamService.getTeam())
+                .thenReturn(new Team("Support", "support", ImmutableList.of(TeamType.SUPPORT)));
+        when(supportTeamService.getLeadershipTeam())
+                .thenReturn(new Team("Leadership", "leadership", ImmutableList.of(TeamType.LEADERSHIP)));
+
+        TeamHistoryReconciler reconciler = new TeamHistoryReconciler(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, teamHistoryRepository);
+
+        reconciler.run(new DefaultApplicationArguments());
+
+        verify(teamHistoryRepository).deleteAllExcept(ImmutableList.of("plat1", "esc1", "support", "leadership"));
+        verify(teamHistoryRepository)
+                .insertOrActivate(ImmutableList.of(
+                        new Team("Platform One", "plat1", ImmutableList.of(TeamType.TENANT)),
+                        new Team("Escalation One", "esc1", ImmutableList.of(TeamType.ESCALATION)),
+                        new Team("Support", "support", ImmutableList.of(TeamType.SUPPORT)),
+                        new Team("Leadership", "leadership", ImmutableList.of(TeamType.LEADERSHIP))));
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/TeamServiceTest.java
@@ -26,7 +26,8 @@ class TeamServiceTest {
         PlatformTeam platformTeam2 = new PlatformTeam("team2", Set.of(), Set.of());
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformTeam1, platformTeam2));
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.TENANT);
@@ -47,14 +48,15 @@ class TeamServiceTest {
         PlatformTeam platformOnlyTeam1 = new PlatformTeam("platform-only-1", Set.of(), Set.of());
         PlatformTeam platformOnlyTeam2 = new PlatformTeam("platform-only-2", Set.of(), Set.of());
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformOnlyTeam1, platformOnlyTeam2));
-        when(platformTeamsService.findTeamByName(anyString())).thenReturn(null);
+        when(platformTeamsService.findTeamByCode(anyString())).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Escalation Team 1", "esc1", "slack:SLACK1"),
                 new EscalationTeam("Escalation Team 2", "esc2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.ESCALATION);
@@ -78,16 +80,17 @@ class TeamServiceTest {
         PlatformTeam platformOnlyTeam = new PlatformTeam("platform-only-noise", Set.of(), Set.of());
         when(platformTeamsService.listTeams())
                 .thenReturn(ImmutableList.of(platformAndEscalationTeam, platformOnlyTeam));
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(platformAndEscalationTeam);
-        when(platformTeamsService.findTeamByName("esc2")).thenReturn(null);
-        when(platformTeamsService.findTeamByName("platform-only-noise")).thenReturn(platformOnlyTeam);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(platformAndEscalationTeam);
+        when(platformTeamsService.findTeamByCode("esc2")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("platform-only-noise")).thenReturn(platformOnlyTeam);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Escalation Team 1", "esc1", "slack:SLACK1"),
                 new EscalationTeam("Escalation Team 2", "esc2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.ESCALATION);
@@ -115,7 +118,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.SUPPORT);
@@ -134,7 +138,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByType(TeamType.LEADERSHIP);
@@ -153,7 +158,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("support");
@@ -171,7 +177,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         Team result = teamService.findTeamByCode("leadership");
 
@@ -186,9 +193,9 @@ class TeamServiceTest {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         PlatformTeam platformTeam = new PlatformTeam("platform1", Set.of(), Set.of());
-        when(platformTeamsService.findTeamByName("platform1")).thenReturn(platformTeam);
-        when(platformTeamsService.findTeamByName("escalation-noise-1")).thenReturn(null);
-        when(platformTeamsService.findTeamByName("escalation-noise-2")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("platform1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByCode("escalation-noise-1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("escalation-noise-2")).thenReturn(null);
 
         // Add noise: escalation teams with different codes
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
@@ -196,7 +203,8 @@ class TeamServiceTest {
                 new EscalationTeam("Escalation Noise 2", "escalation-noise-2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("platform1");
@@ -213,15 +221,16 @@ class TeamServiceTest {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
-        when(platformTeamsService.findTeamByName("team1")).thenReturn(platformTeam);
-        when(platformTeamsService.findTeamByName("other-team")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("team1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByCode("other-team")).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Team 1", "team1", "slack:SLACK1"),
                 new EscalationTeam("Other Team", "other-team", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("team1");
@@ -237,18 +246,19 @@ class TeamServiceTest {
     void findTeamByCode_returnsEscalationOnlyTeam() {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
-        when(platformTeamsService.findTeamByName("esc2")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc2")).thenReturn(null);
 
         PlatformTeam platformOnlyNoise = new PlatformTeam("platform-noise", Set.of(), Set.of());
-        when(platformTeamsService.findTeamByName("platform-noise")).thenReturn(platformOnlyNoise);
+        when(platformTeamsService.findTeamByCode("platform-noise")).thenReturn(platformOnlyNoise);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of(
                 new EscalationTeam("Escalation Team 1", "esc1", "slack:SLACK1"),
                 new EscalationTeam("Escalation Team 2", "esc2", "slack:SLACK2")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("esc1");
@@ -264,12 +274,13 @@ class TeamServiceTest {
     void findTeamByCode_returnsNullWhenTeamNotFound() {
         // given
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
-        when(platformTeamsService.findTeamByName("unknown")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("unknown")).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         Team result = teamService.findTeamByCode("unknown");
@@ -290,7 +301,8 @@ class TeamServiceTest {
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Both Team", "both1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeams();
@@ -357,7 +369,8 @@ class TeamServiceTest {
         EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("user@test.com");
@@ -379,7 +392,8 @@ class TeamServiceTest {
         SupportTeamService supportTeamService = mockSupportTeamService();
         when(supportTeamService.isMemberByUserEmail("support@test.com")).thenReturn(true);
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("support@test.com");
@@ -402,7 +416,8 @@ class TeamServiceTest {
         when(supportTeamService.isLeadershipMemberByUserEmail("leader@test.com"))
                 .thenReturn(true);
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("leader@test.com");
@@ -425,7 +440,8 @@ class TeamServiceTest {
         when(supportTeamService.isMemberByUserEmail("both@test.com")).thenReturn(true);
         when(supportTeamService.isLeadershipMemberByUserEmail("both@test.com")).thenReturn(true);
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when
         ImmutableList<Team> result = teamService.listTeamsByUserEmail("both@test.com");
@@ -443,13 +459,14 @@ class TeamServiceTest {
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         PlatformTeam platformTeam = new PlatformTeam("team1", Set.of(), Set.of());
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of(platformTeam));
-        when(platformTeamsService.findTeamByName("team1")).thenReturn(platformTeam);
+        when(platformTeamsService.findTeamByCode("team1")).thenReturn(platformTeam);
 
         EscalationTeamsRegistry escalationTeamsRegistry =
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Team 1", "team1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when - query the same team in different ways
         Team fromFindByCode = teamService.findTeamByCode("team1");
@@ -487,13 +504,14 @@ class TeamServiceTest {
         // given - escalation team that is NOT a platform team
         PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
         when(platformTeamsService.listTeams()).thenReturn(ImmutableList.of());
-        when(platformTeamsService.findTeamByName("esc1")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(null);
 
         EscalationTeamsRegistry escalationTeamsRegistry =
                 new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation Only", "esc1", "slack:SLACK1")));
         SupportTeamService supportTeamService = mockSupportTeamService();
 
-        TeamService teamService = new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService);
+        TeamService teamService = new TeamService(
+                platformTeamsService, escalationTeamsRegistry, supportTeamService, mock(TeamHistoryRepository.class));
 
         // when - query the same team in different ways
         Team fromFindByCode = teamService.findTeamByCode("esc1");
@@ -514,6 +532,63 @@ class TeamServiceTest {
         // Should NOT appear in tenant list
         ImmutableList<Team> tenantTeams = teamService.listTeamsByType(TeamType.TENANT);
         assertTrue(tenantTeams.stream().noneMatch(t -> "esc1".equals(t.code())));
+    }
+
+    @Test
+    void resolveForDisplay_activeTeam_returnsActiveWithTypes() {
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByCode("esc1")).thenReturn(null);
+        EscalationTeamsRegistry escalationTeamsRegistry =
+                new FakeEscalationTeamsRegistry(List.of(new EscalationTeam("Escalation One", "esc1", "slack:SLACK1")));
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        TeamHistoryRepository history = mock(TeamHistoryRepository.class);
+        TeamService teamService =
+                new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService, history);
+
+        TeamDisplay result = teamService.resolveForDisplay("esc1");
+
+        assertEquals("esc1", result.code());
+        assertEquals("Escalation One", result.label());
+        assertEquals(ImmutableList.of(TeamType.ESCALATION), result.types());
+        assertTrue(result.active());
+        verifyNoInteractions(history);
+    }
+
+    @Test
+    void resolveForDisplay_retiredTeam_returnsHistoryLabelInactive() {
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByCode("old")).thenReturn(null);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        TeamHistoryRepository history = mock(TeamHistoryRepository.class);
+        when(history.findLabelByCode("old")).thenReturn("Old Team");
+        TeamService teamService =
+                new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService, history);
+
+        TeamDisplay result = teamService.resolveForDisplay("old");
+
+        assertEquals("Old Team", result.label());
+        assertEquals("old", result.code());
+        assertFalse(result.active());
+        assertTrue(result.types().isEmpty());
+    }
+
+    @Test
+    void resolveForDisplay_unknownTeam_fallsBackToRawCodeInactive() {
+        PlatformTeamsService platformTeamsService = mock(PlatformTeamsService.class);
+        when(platformTeamsService.findTeamByCode("ghost")).thenReturn(null);
+        EscalationTeamsRegistry escalationTeamsRegistry = new FakeEscalationTeamsRegistry(List.of());
+        SupportTeamService supportTeamService = mockSupportTeamService();
+        TeamHistoryRepository history = mock(TeamHistoryRepository.class);
+        when(history.findLabelByCode("ghost")).thenReturn(null);
+        TeamService teamService =
+                new TeamService(platformTeamsService, escalationTeamsRegistry, supportTeamService, history);
+
+        TeamDisplay result = teamService.resolveForDisplay("ghost");
+
+        assertEquals("ghost", result.code());
+        assertEquals("ghost", result.label());
+        assertFalse(result.active());
     }
 
     private SupportTeamService mockSupportTeamService() {

--- a/api/service/src/test/java/com/coreeng/supportbot/teams/rest/TeamUIMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/teams/rest/TeamUIMapperTest.java
@@ -1,0 +1,31 @@
+package com.coreeng.supportbot.teams.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.coreeng.supportbot.teams.TeamDisplay;
+import com.coreeng.supportbot.teams.TeamType;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+class TeamUIMapperTest {
+
+    private final TeamUIMapper mapper = new TeamUIMapper();
+
+    @Test
+    void mapsActiveTeamDisplayAsActive() {
+        TeamUI ui = mapper.mapToUI(new TeamDisplay("pe", "PE Core", ImmutableList.of(TeamType.TENANT), true));
+
+        assertThat(ui.code()).isEqualTo("pe");
+        assertThat(ui.label()).isEqualTo("PE Core");
+        assertThat(ui.active()).isTrue();
+    }
+
+    @Test
+    void mapsRetiredTeamDisplayWithLastKnownLabelAndActiveFalse() {
+        TeamUI ui = mapper.mapToUI(new TeamDisplay("old-team", "Old Team", ImmutableList.of(), false));
+
+        assertThat(ui.code()).isEqualTo("old-team");
+        assertThat(ui.label()).isEqualTo("Old Team");
+        assertThat(ui.active()).isFalse();
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
@@ -480,6 +480,8 @@ class TicketSummaryServiceTest {
                 .thenReturn(ImmutableList.of(
                         new TicketImpact("Production Blocking", "production-blocking"),
                         new TicketImpact("Minor Issue", "minor-issue")));
+        when(impactsRegistry.findImpactByCode("production-blocking"))
+                .thenReturn(new TicketImpact("Production Blocking", "production-blocking"));
 
         // when
         TicketSummaryView result = service.summaryView(ticketId);

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/TicketSummaryServiceTest.java
@@ -523,6 +523,26 @@ class TicketSummaryServiceTest {
         assertThat(result.currentImpact()).isNull();
     }
 
+    @Test
+    void retiredCurrentImpact_isIncludedInImpactOptions() {
+        // Regression (#1): the impact picker is a required static select whose initialOption is the
+        // ticket's current impact. A retired impact must still appear among the options, otherwise
+        // Slack rejects the view and the modal won't open.
+        when(repository.findTicketById(ticketId)).thenReturn(ticket);
+        when(slackClient.getMessageByTs(any(SlackGetMessageByTsRequest.class))).thenReturn(slackMessage);
+        when(slackClient.getPermalink(any(SlackGetMessageByTsRequest.class))).thenReturn("https://slack.com/permalink");
+        when(escalationQueryService.listByTicketId(ticketId)).thenReturn(ImmutableList.of());
+        when(impactsRegistry.listAllImpacts())
+                .thenReturn(ImmutableList.of(new TicketImpact("Minor Issue", "minor-issue")));
+        when(impactsRegistry.findImpactByCode("production-blocking"))
+                .thenReturn(new TicketImpact("Production Blocking", "production-blocking"));
+
+        TicketSummaryView result = service.summaryView(ticketId);
+
+        assertThat(result.currentImpact()).isNotNull();
+        assertThat(result.impacts().stream().map(TicketImpact::code)).contains("production-blocking");
+    }
+
     private Ticket sampleTicket() {
         return Ticket.builder()
                 .id(new TicketId(1))

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
@@ -19,7 +19,6 @@ import com.coreeng.supportbot.slack.SlackException;
 import com.coreeng.supportbot.slack.SlackId;
 import com.coreeng.supportbot.slack.client.SlackClient;
 import com.coreeng.supportbot.teams.SupportTeamService;
-import com.coreeng.supportbot.teams.Team;
 import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamMemberFetcher;
 import com.coreeng.supportbot.teams.TeamService;
@@ -148,8 +147,10 @@ public class TicketUIMapperTest {
 
         DetailedTicket detailedTicket = new DetailedTicket(ticket, ImmutableList.of());
 
-        when(teamService.resolveForDisplay("deleted-team"))
-                .thenReturn(new TeamDisplay("deleted-team", "Deleted Team", ImmutableList.of(), false));
+        TeamDisplay retired = new TeamDisplay("deleted-team", "Deleted Team", ImmutableList.of(), false);
+        TeamUI retiredUI = new TeamUI("Deleted Team", "deleted-team", ImmutableList.of(), false);
+        when(teamService.resolveForDisplay("deleted-team")).thenReturn(retired);
+        when(teamUIMapper.mapToUI(retired)).thenReturn(retiredUI);
 
         TicketUI result = assertDoesNotThrow(() -> ticketUIMapper.mapToUI(detailedTicket));
         TeamUI team = requireNonNull(result.team());
@@ -176,12 +177,11 @@ public class TicketUIMapperTest {
 
         DetailedTicket detailedTicket = new DetailedTicket(ticket, ImmutableList.of());
 
-        Team team = new Team("wow", "wow", ImmutableList.of(TeamType.TENANT));
+        TeamDisplay teamDisplay = new TeamDisplay("wow", "wow", ImmutableList.of(TeamType.TENANT), true);
         TeamUI teamUI = new TeamUI("wow", "wow", ImmutableList.of(TeamType.TENANT));
 
-        when(teamService.resolveForDisplay("wow"))
-                .thenReturn(new TeamDisplay("wow", "wow", ImmutableList.of(TeamType.TENANT), true));
-        when(teamUIMapper.mapToUI(team)).thenReturn(teamUI);
+        when(teamService.resolveForDisplay("wow")).thenReturn(teamDisplay);
+        when(teamUIMapper.mapToUI(teamDisplay)).thenReturn(teamUI);
 
         // when
         TicketUI result = ticketUIMapper.mapToUI(detailedTicket);

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUIMapperTest.java
@@ -3,6 +3,7 @@ package com.coreeng.supportbot.ticket.rest;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,6 +20,7 @@ import com.coreeng.supportbot.slack.SlackId;
 import com.coreeng.supportbot.slack.client.SlackClient;
 import com.coreeng.supportbot.teams.SupportTeamService;
 import com.coreeng.supportbot.teams.Team;
+import com.coreeng.supportbot.teams.TeamDisplay;
 import com.coreeng.supportbot.teams.TeamMemberFetcher;
 import com.coreeng.supportbot.teams.TeamService;
 import com.coreeng.supportbot.teams.TeamType;
@@ -130,8 +132,7 @@ public class TicketUIMapperTest {
     }
 
     @Test
-    void mapToUIReturnsNullWhenKnownTeamNotFound() {
-        // given
+    void mapToUIRendersRetiredTeamLabelWhenNotInConfig() {
         Ticket ticket = Ticket.builder()
                 .id(new TicketId(1))
                 .channelId("C123")
@@ -147,12 +148,14 @@ public class TicketUIMapperTest {
 
         DetailedTicket detailedTicket = new DetailedTicket(ticket, ImmutableList.of());
 
-        // when
-        when(teamService.findTeamByCode("deleted-team")).thenReturn(null);
+        when(teamService.resolveForDisplay("deleted-team"))
+                .thenReturn(new TeamDisplay("deleted-team", "Deleted Team", ImmutableList.of(), false));
 
-        // then
         TicketUI result = assertDoesNotThrow(() -> ticketUIMapper.mapToUI(detailedTicket));
-        assertNull(result.team());
+        TeamUI team = requireNonNull(result.team());
+        assertEquals("Deleted Team", team.label());
+        assertEquals("deleted-team", team.code());
+        assertFalse(team.active());
     }
 
     @Test
@@ -176,7 +179,8 @@ public class TicketUIMapperTest {
         Team team = new Team("wow", "wow", ImmutableList.of(TeamType.TENANT));
         TeamUI teamUI = new TeamUI("wow", "wow", ImmutableList.of(TeamType.TENANT));
 
-        when(teamService.findTeamByCode("wow")).thenReturn(team);
+        when(teamService.resolveForDisplay("wow"))
+                .thenReturn(new TeamDisplay("wow", "wow", ImmutableList.of(TeamType.TENANT), true));
         when(teamUIMapper.mapToUI(team)).thenReturn(teamUI);
 
         // when

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUpdateServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/rest/TicketUpdateServiceTest.java
@@ -61,7 +61,7 @@ class TicketUpdateServiceTest {
         DetailedTicket mockDetailedTicket = mock(DetailedTicket.class);
         TicketUI mockTicketUI = mock(TicketUI.class);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
         when(impactsRegistry.findImpactByCode("production-blocking")).thenReturn(validImpact);
         when(ticketProcessingService.submit(any(TicketSubmission.class))).thenReturn(new TicketSubmitResult.Success());
         when(queryService.findDetailedById(ticketId)).thenReturn(mockDetailedTicket);
@@ -137,14 +137,14 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request = new TicketUpdateRequest(
                 TicketStatus.closed, "invalid-team", ImmutableList.of("bug"), "production-blocking", null);
 
-        when(platformTeamsService.findTeamByName("invalid-team")).thenReturn(null);
+        when(platformTeamsService.findTeamByCode("invalid-team")).thenReturn(null);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("authorsTeam must be a valid team code");
 
-        verify(platformTeamsService).findTeamByName("invalid-team");
+        verify(platformTeamsService).findTeamByCode("invalid-team");
     }
 
     @Test
@@ -153,7 +153,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request =
                 new TicketUpdateRequest(TicketStatus.closed, "core-support", null, "production-blocking", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -167,7 +167,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request = new TicketUpdateRequest(
                 TicketStatus.closed, "core-support", ImmutableList.of(), "production-blocking", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -181,7 +181,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request =
                 new TicketUpdateRequest(TicketStatus.closed, "core-support", ImmutableList.of("bug"), null, null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -195,7 +195,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request =
                 new TicketUpdateRequest(TicketStatus.closed, "core-support", ImmutableList.of("bug"), "  ", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
 
         // when/then
         assertThatThrownBy(() -> service.update(ticketId, request))
@@ -209,7 +209,7 @@ class TicketUpdateServiceTest {
         TicketUpdateRequest request = new TicketUpdateRequest(
                 TicketStatus.closed, "core-support", ImmutableList.of("bug"), "invalid-impact", null);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
         when(impactsRegistry.findImpactByCode("invalid-impact")).thenReturn(null);
 
         // when/then
@@ -233,7 +233,7 @@ class TicketUpdateServiceTest {
         DetailedTicket mockDetailedTicket = mock(DetailedTicket.class);
         TicketUI mockTicketUI = mock(TicketUI.class);
 
-        when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+        when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
         when(impactsRegistry.findImpactByCode("production-blocking")).thenReturn(validImpact);
         when(ticketProcessingService.submit(any(TicketSubmission.class))).thenReturn(new TicketSubmitResult.Success());
         when(queryService.findDetailedById(ticketId)).thenReturn(mockDetailedTicket);
@@ -260,7 +260,7 @@ class TicketUpdateServiceTest {
             DetailedTicket mockDetailedTicket = mock(DetailedTicket.class);
             TicketUI mockTicketUI = mock(TicketUI.class);
 
-            when(platformTeamsService.findTeamByName("core-support")).thenReturn(validTeam);
+            when(platformTeamsService.findTeamByCode("core-support")).thenReturn(validTeam);
             when(impactsRegistry.findImpactByCode("production-blocking")).thenReturn(validImpact);
             when(ticketProcessingService.submit(any(TicketSubmission.class)))
                     .thenReturn(new TicketSubmitResult.Success());

--- a/docs/enum-codes.md
+++ b/docs/enum-codes.md
@@ -1,0 +1,20 @@
+# Enum codes: tags, impacts, teams
+
+Tags, impacts and (escalation) teams are identified by an immutable `code` that acts as a
+primary key. `label` is the display value and may be changed freely.
+
+- **Do** change `label` to alter what users see.
+- **Do not** change a `code` once in use — stored tickets/escalations reference it.
+- **To remove** a value, delete it from config: it is soft-deleted, hidden from pickers, and
+  still rendered (as "Retired") on existing records.
+- **Renaming** a `code` = delete + add: the old code becomes orphaned. The bot now degrades
+  gracefully (no crash) but historical references show the retired label, not the new one.
+
+## Static teams
+
+`platform-integration.teams-scraping.static.teams[]` accept an optional `code` (and `label`).
+When omitted, `code` defaults to `name`, so the `name` doubles as the identity — renaming it
+orphans references. Set an explicit `code` to keep identity stable while changing the display
+`name`/`label`. The bot logs a startup warning for static teams without an explicit `code`.
+
+Keep examples and codes generic — this repo is public.

--- a/docs/enum-codes.md
+++ b/docs/enum-codes.md
@@ -17,4 +17,18 @@ When omitted, `code` defaults to `name`, so the `name` doubles as the identity �
 orphans references. Set an explicit `code` to keep identity stable while changing the display
 `name`/`label`. The bot logs a startup warning for static teams without an explicit `code`.
 
+## Startup validation
+
+Codes must be unique and non-blank within each list — `enums.tags`, `enums.impacts`,
+`enums.escalation-teams`, and the static `platform-integration.teams-scraping.static.teams`
+(by effective code, i.e. `code` or, when omitted, `name`). The app validates this at startup and
+**fails fast** with a clear message (`duplicate code 'X'` / blank code) before any data is written.
+
+## Observability
+
+A startup scan counts stored references to retired/removed codes and exposes them as the Micrometer
+gauge `support_bot.orphaned_references{type=impact|tag|escalation_team}` (and logs them at ERROR).
+It is fully guarded and non-fatal — it never blocks startup. See
+[runbooks/orphaned-enum-references.md](runbooks/orphaned-enum-references.md).
+
 Keep examples and codes generic — this repo is public.

--- a/docs/enum-codes.md
+++ b/docs/enum-codes.md
@@ -12,10 +12,12 @@ primary key. `label` is the display value and may be changed freely.
 
 ## Static teams
 
-`platform-integration.teams-scraping.static.teams[]` accept an optional `code` (and `label`).
-When omitted, `code` defaults to `name`, so the `name` doubles as the identity — renaming it
-orphans references. Set an explicit `code` to keep identity stable while changing the display
-`name`/`label`. The bot logs a startup warning for static teams without an explicit `code`.
+`platform-integration.teams-scraping.static.teams[]` take a `name` and an optional `code`. The
+`code` is the **identity** used for mapping (ticket/escalation references and the escalation↔platform
+join); the `name` is the **display** value. When `code` is omitted it defaults to `name`, so the
+`name` then doubles as the identity and renaming it orphans references. Set an explicit `code` to
+keep the identity stable while changing the displayed `name`. The bot logs a startup warning for
+static teams that have no explicit `code`.
 
 ## Startup validation
 

--- a/docs/runbooks/orphaned-enum-references.md
+++ b/docs/runbooks/orphaned-enum-references.md
@@ -1,0 +1,32 @@
+# Runbook: orphaned enum references
+
+After a tag, impact, or (escalation) team `code` is renamed or removed from config, existing
+tickets and escalations still reference the old code. The bot renders these gracefully — the
+last-known label, marked "Retired" — and does **not** crash, but the stale references are worth
+surfacing so operators can decide whether to re-link them.
+
+## Signal
+
+At startup the API scans the database for stored references to retired/removed codes and:
+
+- logs them at **ERROR** (`Found stored references to retired/removed enum codes …`), and
+- exposes a Micrometer gauge **`support_bot.orphaned_references{type=impact|tag|escalation_team}`**
+  (also scrapeable on `/actuator/prometheus`).
+
+The scan is fully guarded and **non-fatal** — it never blocks startup.
+
+## When the gauge is > 0
+
+1. **Expected?** Removing a value on purpose leaves its historical references orphaned; they keep
+   rendering as "Retired". No action needed if this is intentional.
+2. **Re-link them** by adding the original `code` back to config (the `label` may differ). The
+   values un-retire on the next startup reconcile and existing records resolve to the active value
+   again.
+3. The gauge reflects the count at the last startup and refreshes on each restart.
+
+## Notes
+
+- Codes are immutable primary keys — prefer changing a `label` over renaming a `code`
+  (see [../enum-codes.md](../enum-codes.md)).
+- Duplicate or blank codes are a separate, **fatal** condition: the app fails fast at startup with
+  a clear `duplicate code 'X'` / blank-code message.

--- a/ui/src/app/api/escalations/route.ts
+++ b/ui/src/app/api/escalations/route.ts
@@ -4,6 +4,7 @@ import { backendFetch, errorResponse, unauthorizedResponse } from "../_lib/backe
 interface BackendTeam {
   label?: string;
   code?: string;
+  active?: boolean;
 }
 
 export async function GET(request: NextRequest) {
@@ -33,7 +34,7 @@ export async function GET(request: NextRequest) {
       openedAt: e.openedAt,
       resolvedAt: e.resolvedAt,
       escalatingTeam: e.escalatingTeam,
-      team: team ? { name: team.code || team.label || "", label: team.label || team.code || "" } : null,
+      team: team ? { name: team.code || team.label || "", label: team.label || team.code || "", active: team.active } : null,
       tags: e.tags ?? [],
       impact: e.impact ?? null,
     };

--- a/ui/src/app/api/escalations/route.ts
+++ b/ui/src/app/api/escalations/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
       openedAt: e.openedAt,
       resolvedAt: e.resolvedAt,
       escalatingTeam: e.escalatingTeam,
-      team: team ? { name: team.code || team.label || "" } : null,
+      team: team ? { name: team.code || team.label || "", label: team.label || team.code || "" } : null,
       tags: e.tags ?? [],
       impact: e.impact ?? null,
     };

--- a/ui/src/app/api/teams/route.ts
+++ b/ui/src/app/api/teams/route.ts
@@ -10,6 +10,7 @@ interface BackendTeam {
 function mapTeam(team: BackendTeam) {
   return {
     name: team.code || team.label || "",
+    label: team.label || team.code || "",
     types: team.types,
   };
 }

--- a/ui/src/app/api/tickets/_lib/__tests__/map-ticket.test.ts
+++ b/ui/src/app/api/tickets/_lib/__tests__/map-ticket.test.ts
@@ -1,0 +1,37 @@
+import { mapTicket } from "../map-ticket";
+
+describe("mapTicket team mapping", () => {
+  it("carries both the identity (name = code) and the display label for the ticket team", () => {
+    const result = mapTicket({
+      id: 1,
+      team: { code: "pe", label: "PE Core", active: true },
+      escalations: [],
+    });
+
+    expect(result.team).toEqual({ name: "pe", label: "PE Core", active: true });
+  });
+
+  it("carries the label for escalation teams and preserves the retired flag", () => {
+    const result = mapTicket({
+      id: 2,
+      team: { code: "old-team", label: "Old Team", active: false },
+      escalations: [{ id: 7, team: { code: "esc", label: "Escalation One", active: true } }],
+    });
+
+    expect(result.team).toEqual({ name: "old-team", label: "Old Team", active: false });
+    expect(result.escalations[0].team).toEqual({ name: "esc", label: "Escalation One", active: true });
+  });
+
+  it("falls back across code and label when one is missing", () => {
+    const onlyCode = mapTicket({ id: 3, team: { code: "wow" }, escalations: [] });
+    expect(onlyCode.team).toEqual({ name: "wow", label: "wow", active: undefined });
+
+    const onlyLabel = mapTicket({ id: 4, team: { label: "Only Label" }, escalations: [] });
+    expect(onlyLabel.team).toEqual({ name: "Only Label", label: "Only Label", active: undefined });
+  });
+
+  it("returns a null team when the ticket has no team", () => {
+    const result = mapTicket({ id: 5, escalations: [] });
+    expect(result.team).toBeNull();
+  });
+});

--- a/ui/src/app/api/tickets/_lib/map-ticket.ts
+++ b/ui/src/app/api/tickets/_lib/map-ticket.ts
@@ -2,6 +2,7 @@ interface BackendTeam {
   label?: string;
   code?: string;
   types?: string[];
+  active?: boolean;
 }
 
 export function mapTicket(ticket: Record<string, unknown>) {
@@ -12,12 +13,12 @@ export function mapTicket(ticket: Record<string, unknown>) {
     ...ticket,
     summary: (ticket.summary as string) ?? null,
     id: String(ticket.id),
-    team: team ? { name: team.code || team.label || "" } : null,
+    team: team ? { name: team.code || team.label || "", active: team.active } : null,
     escalations:
       escalations?.map((esc) => ({
         ...esc,
         id: String(esc.id),
-        team: esc.team ? { name: esc.team.code || esc.team.label || "" } : null,
+        team: esc.team ? { name: esc.team.code || esc.team.label || "", active: esc.team.active } : null,
       })) ?? [],
   };
 }

--- a/ui/src/app/api/tickets/_lib/map-ticket.ts
+++ b/ui/src/app/api/tickets/_lib/map-ticket.ts
@@ -13,12 +13,14 @@ export function mapTicket(ticket: Record<string, unknown>) {
     ...ticket,
     summary: (ticket.summary as string) ?? null,
     id: String(ticket.id),
-    team: team ? { name: team.code || team.label || "", active: team.active } : null,
+    team: team ? { name: team.code || team.label || "", label: team.label || team.code || "", active: team.active } : null,
     escalations:
       escalations?.map((esc) => ({
         ...esc,
         id: String(esc.id),
-        team: esc.team ? { name: esc.team.code || esc.team.label || "", active: esc.team.active } : null,
+        team: esc.team
+          ? { name: esc.team.code || esc.team.label || "", label: esc.team.label || esc.team.code || "", active: esc.team.active }
+          : null,
       })) ?? [],
   };
 }

--- a/ui/src/components/TeamSelector.tsx
+++ b/ui/src/components/TeamSelector.tsx
@@ -35,31 +35,28 @@ export default function TeamSelector() {
     return null;
   };
 
-  const tenantTeamNames = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          teams
-            .filter((t) => !isRoleTeam(t) && !isEscalationTeam(t))
-            .map((t) => t.name)
-            .filter(Boolean)
-        )
-      ).sort(),
-    [teams]
-  );
+  const tenantTeams = useMemo(() => {
+    const byCode = new Map<string, string>();
+    teams
+      .filter((t) => !isRoleTeam(t) && !isEscalationTeam(t))
+      .forEach((t) => {
+        if (t.name) byCode.set(t.name, t.label || t.name);
+      });
+    return Array.from(byCode, ([name, label]) => ({ name, label })).sort((a, b) => a.label.localeCompare(b.label));
+  }, [teams]);
 
   const userEscalationTeams = useMemo(() => teams.filter((t) => isEscalationTeam(t) && !isRoleTeam(t)), [teams]);
 
   const userRoleTeams = useMemo(() => teams.filter((t) => isRoleTeam(t)), [teams]);
 
-  const firstAvailableSelection = tenantTeamNames[0] || userEscalationTeams[0]?.name || userRoleTeams[0]?.name || null;
+  const firstAvailableSelection = tenantTeams[0]?.name || userEscalationTeams[0]?.name || userRoleTeams[0]?.name || null;
 
   const validSelections = useMemo(() => {
-    const set = new Set(tenantTeamNames);
+    const set = new Set(tenantTeams.map((t) => t.name));
     userEscalationTeams.forEach((t) => set.add(t.name));
     userRoleTeams.forEach((t) => set.add(t.name));
     return set;
-  }, [tenantTeamNames, userEscalationTeams, userRoleTeams]);
+  }, [tenantTeams, userEscalationTeams, userRoleTeams]);
 
   useEffect(() => {
     const urlTeam = teamParams.team;
@@ -121,6 +118,7 @@ export default function TeamSelector() {
   }
 
   const displayValue = selectedTeam && validSelections.has(selectedTeam) ? selectedTeam : firstAvailableSelection || "";
+  const displayLabel = teams.find((t) => t.name === displayValue)?.label || displayValue;
 
   const fallbackTeam = selectedTeam && validSelections.has(selectedTeam) ? selectedTeam : firstAvailableSelection;
 
@@ -128,11 +126,11 @@ export default function TeamSelector() {
     setTeamParam({ team: name });
   };
 
-  const renderItem = (name: string, suffix?: string | null) => (
+  const renderItem = (name: string, label: string, suffix?: string | null) => (
     <DropdownMenuItem key={name} onSelect={() => handleSelect(name)} className="cursor-pointer">
       <Users className="mr-2 h-4 w-4" />
       <span className="flex-1 break-words">
-        {name}
+        {label}
         {suffix && <span className="text-muted-foreground ml-1">· {suffix}</span>}
       </span>
       {displayValue === name && <Check className="text-primary ml-2 h-4 w-4" />}
@@ -170,34 +168,36 @@ export default function TeamSelector() {
         <DropdownMenuTrigger asChild>
           <Button variant="outline" data-testid="team-selector-trigger" className="cursor-pointer">
             <Users className="h-4 w-4" />
-            <span className="text-sm">{displayValue || "Select team"}</span>
+            <span className="text-sm">{displayLabel || "Select team"}</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-max max-w-[min(32rem,calc(100vw-2rem))] min-w-[14rem]">
-          {tenantTeamNames.length > 0 && (
+          {tenantTeams.length > 0 && (
             <>
               <DropdownMenuLabel className="text-muted-foreground text-xs">Teams</DropdownMenuLabel>
-              {tenantTeamNames.map((name) => renderItem(name))}
+              {tenantTeams.map((t) => renderItem(t.name, t.label))}
             </>
           )}
           {userEscalationTeams.length > 0 && (
             <>
-              {tenantTeamNames.length > 0 && <DropdownMenuSeparator />}
+              {tenantTeams.length > 0 && <DropdownMenuSeparator />}
               <DropdownMenuLabel className="text-muted-foreground text-xs">Escalation Teams</DropdownMenuLabel>
-              {userEscalationTeams.map((t) => renderItem(t.name, "Escalation"))}
+              {userEscalationTeams.map((t) => renderItem(t.name, t.label || t.name, "Escalation"))}
             </>
           )}
           {userRoleTeams.length > 0 && (
             <>
-              {(tenantTeamNames.length > 0 || userEscalationTeams.length > 0) && <DropdownMenuSeparator />}
+              {(tenantTeams.length > 0 || userEscalationTeams.length > 0) && <DropdownMenuSeparator />}
               <DropdownMenuLabel className="text-muted-foreground text-xs">Access Roles</DropdownMenuLabel>
-              {userRoleTeams.map((t) => renderItem(t.name, tagForTypes(t.types)))}
+              {userRoleTeams.map((t) => renderItem(t.name, t.label || t.name, tagForTypes(t.types)))}
             </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>
       {selectedTeam && !(isLeadership || isSupportEngineer) && (
-        <span className="text-warning ml-2 text-xs italic">Viewing: {selectedTeam}</span>
+        <span className="text-warning ml-2 text-xs italic">
+          Viewing: {teams.find((t) => t.name === selectedTeam)?.label || selectedTeam}
+        </span>
       )}
     </>
   );

--- a/ui/src/components/__tests__/TeamSelector.test.tsx
+++ b/ui/src/components/__tests__/TeamSelector.test.tsx
@@ -289,4 +289,28 @@ describe("TeamSelector", () => {
     expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining("team=Tenant+A"));
     expect(mockReplace).not.toHaveBeenCalledWith(expect.stringContaining("OldTeam"));
   });
+
+  it("shows the team display label while selecting by its code", async () => {
+    const setSelectedTeam = jest.fn();
+    mockUseTeamFilter.mockReturnValue({ selectedTeam: "pe", setSelectedTeam });
+    mockUseAuth.mockReturnValue({
+      user: {
+        teams: [{ name: "pe", label: "PE Core", types: ["tenant"], groupRefs: [] }],
+      },
+      isLeadership: false,
+      isSupportEngineer: false,
+    });
+
+    renderSelector();
+
+    // Trigger shows the friendly label, not the code.
+    expect(screen.getByTestId("team-selector-trigger")).toHaveTextContent("PE Core");
+
+    const user = await openMenu();
+    expect(screen.getByRole("menuitem", { name: /PE Core/ })).toBeInTheDocument();
+
+    // Selecting it writes the immutable code into the URL.
+    await user.click(screen.getByRole("menuitem", { name: /PE Core/ }));
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining("team=pe"));
+  });
 });

--- a/ui/src/components/escalations/EscalatedToMyTeamTable.tsx
+++ b/ui/src/components/escalations/EscalatedToMyTeamTable.tsx
@@ -256,10 +256,12 @@ export default function EscalatedToMyTeamTable() {
             setImpactFilter(v ?? "all");
             setPageIndex(0);
           }}
-          options={(registryData?.impacts ?? []).map((impact: { code: string; label: string }) => ({
-            label: impact.label,
-            value: impact.code,
-          }))}
+          options={(registryData?.impacts ?? [])
+            .filter((impact) => impact.active !== false)
+            .map((impact: { code: string; label: string }) => ({
+              label: impact.label,
+              value: impact.code,
+            }))}
         />
         <SingleSelectFilter
           title="Tag"
@@ -268,10 +270,12 @@ export default function EscalatedToMyTeamTable() {
             setTagFilter(v ?? "");
             setPageIndex(0);
           }}
-          options={(registryData?.tags ?? []).map((tag: { code: string; label: string }) => ({
-            label: tag.label,
-            value: tag.code,
-          }))}
+          options={(registryData?.tags ?? [])
+            .filter((tag) => tag.active !== false)
+            .map((tag: { code: string; label: string }) => ({
+              label: tag.label,
+              value: tag.code,
+            }))}
         />
       </div>
 

--- a/ui/src/components/escalations/escalations.tsx
+++ b/ui/src/components/escalations/escalations.tsx
@@ -267,7 +267,7 @@ export default function EscalationsPage() {
       } else if (sortColumn === "escalatingTeam") {
         cmp = (a.escalatingTeam || "").localeCompare(b.escalatingTeam || "");
       } else if (sortColumn === "escalatedTo") {
-        cmp = (a.team?.name || "").localeCompare(b.team?.name || "");
+        cmp = (a.team?.label || a.team?.name || "").localeCompare(b.team?.label || b.team?.name || "");
       } else if (sortColumn === "openedAt") {
         cmp = (a.openedAt || "").localeCompare(b.openedAt || "");
       } else if (sortColumn === "resolvedAt") {
@@ -303,17 +303,18 @@ export default function EscalationsPage() {
       .map(([tag, count]) => ({ tag, count }));
   }, [filteredEscalations]);
 
+  const teamLabel = (code?: string | null): string => (tenantTeamsData ?? []).find((t) => t.name === code)?.label || code || "";
   const secondTableTitle =
     selectedTeam === ALL_TEAMS_FILTER
       ? "All Escalations"
       : selectedTeam
-        ? `Escalated for ${selectedTeam}`
+        ? `Escalated for ${teamLabel(selectedTeam)}`
         : isViewingAsEscalationTeam && teamFilterSelectedTeam
-          ? `Escalated for ${teamFilterSelectedTeam}`
+          ? `Escalated for ${teamLabel(teamFilterSelectedTeam)}`
           : "All Escalations";
-  const scopeLabel = effectiveTeams.length === 0 ? "All Teams" : effectiveTeams.join(", ");
-  const teamFilterLabel = selectedTeam === ALL_TEAMS_FILTER ? "All Teams" : selectedTeam || "Current Team Scope";
-  const topTagsTitleSuffix = selectedTeam ? (selectedTeam === ALL_TEAMS_FILTER ? "for All Teams" : `for ${selectedTeam}`) : "";
+  const scopeLabel = effectiveTeams.length === 0 ? "All Teams" : effectiveTeams.map(teamLabel).join(", ");
+  const teamFilterLabel = selectedTeam === ALL_TEAMS_FILTER ? "All Teams" : teamLabel(selectedTeam) || "Current Team Scope";
+  const topTagsTitleSuffix = selectedTeam ? (selectedTeam === ALL_TEAMS_FILTER ? "for All Teams" : `for ${teamLabel(selectedTeam)}`) : "";
   const showEscalatedForColumn = hasFullAccess || selectedTeam === ALL_TEAMS_FILTER;
 
   const ANY_DATE = "__any";
@@ -422,7 +423,7 @@ export default function EscalationsPage() {
               onChange={(v) => setParams({ selectedTeam: v ?? "", page: "0" })}
               options={[
                 ...(effectiveTeams.length > 0 ? [{ label: "All Teams", value: ALL_TEAMS_FILTER }] : []),
-                ...(tenantTeamsData ?? []).map((team) => ({ label: team.name, value: team.name })),
+                ...(tenantTeamsData ?? []).map((team) => ({ label: team.label || team.name, value: team.name })),
               ]}
             />
           )}
@@ -524,7 +525,7 @@ export default function EscalationsPage() {
                   <tr key={esc.id} className="hover:bg-accent transition-colors">
                     <td className="px-4 py-2 text-sm">{esc.ticketId}</td>
                     {showEscalatedForColumn && <td className="px-4 py-2 text-sm">{esc.escalatingTeam || "-"}</td>}
-                    <td className="px-4 py-2 text-sm">{esc.team?.name || "-"}</td>
+                    <td className="px-4 py-2 text-sm">{esc.team?.label || esc.team?.name || "-"}</td>
                     <td className="px-4 py-2">
                       <span
                         className={`rounded-full px-2 py-1 text-xs font-semibold ${esc.resolvedAt ? "bg-success/20 text-success" : "bg-warning/20 text-warning"}`}

--- a/ui/src/components/escalations/escalations.tsx
+++ b/ui/src/components/escalations/escalations.tsx
@@ -411,10 +411,12 @@ export default function EscalationsPage() {
             title="Impact"
             value={impactFilter !== "all" ? impactFilter : undefined}
             onChange={(v) => setParams({ impact: v ?? "all", page: "0" })}
-            options={(registryData?.impacts ?? []).map((impact: { code: string; label: string }) => ({
-              label: impact.label,
-              value: impact.code,
-            }))}
+            options={(registryData?.impacts ?? [])
+              .filter((impact: { code: string; label: string; active?: boolean }) => impact.active !== false)
+              .map((impact) => ({
+                label: impact.label,
+                value: impact.code,
+              }))}
           />
           {!hasNoTeamScope && (
             <SingleSelectFilter
@@ -431,10 +433,12 @@ export default function EscalationsPage() {
             title="Tag"
             value={tagFilter || undefined}
             onChange={(v) => setParams({ tag: v ?? "", page: "0" })}
-            options={(registryData?.tags ?? []).map((tag: { code: string; label: string }) => ({
-              label: tag.label,
-              value: tag.code,
-            }))}
+            options={(registryData?.tags ?? [])
+              .filter((tag: { code: string; label: string; active?: boolean }) => tag.active !== false)
+              .map((tag) => ({
+                label: tag.label,
+                value: tag.code,
+              }))}
           />
         </div>
 
@@ -524,7 +528,7 @@ export default function EscalationsPage() {
                 return (
                   <tr key={esc.id} className="hover:bg-accent transition-colors">
                     <td className="px-4 py-2 text-sm">{esc.ticketId}</td>
-                    {showEscalatedForColumn && <td className="px-4 py-2 text-sm">{esc.escalatingTeam || "-"}</td>}
+                    {showEscalatedForColumn && <td className="px-4 py-2 text-sm">{teamLabel(esc.escalatingTeam) || "-"}</td>}
                     <td className="px-4 py-2 text-sm">{esc.team?.label || esc.team?.name || "-"}</td>
                     <td className="px-4 py-2">
                       <span

--- a/ui/src/components/health/health.tsx
+++ b/ui/src/components/health/health.tsx
@@ -331,7 +331,7 @@ export default function HealthPage() {
   const ticketsByTeam = useMemo(() => {
     const counts: Record<string, number> = {};
     filteredTickets.forEach((t) => {
-      const teamName = t.team?.name || "Unassigned Team";
+      const teamName = t.team?.label || t.team?.name || "Unassigned Team";
       counts[teamName] = (counts[teamName] || 0) + 1;
     });
     return Object.entries(counts)
@@ -553,21 +553,21 @@ export default function HealthPage() {
 
   // --- Teams lists for filters (safe) ---
   const inquiringTeamsWithTickets = useMemo(() => {
-    const set = new Set<string>();
+    const byCode = new Map<string, string>();
     tickets?.content?.forEach((t) => {
-      if (t.team?.name) set.add(t.team.name);
+      if (t.team?.name) byCode.set(t.team.name, t.team.label || t.team.name);
     });
-    return Array.from(set);
+    return Array.from(byCode, ([value, label]) => ({ value, label }));
   }, [tickets]);
 
   const escalatedTeamsWithTickets = useMemo(() => {
-    const set = new Set<string>();
+    const byCode = new Map<string, string>();
     tickets?.content?.forEach((t) =>
       (t.escalations || []).forEach((e: Escalation) => {
-        if (e.team?.name) set.add(e.team.name);
+        if (e.team?.name) byCode.set(e.team.name, e.team.label || e.team.name);
       })
     );
-    return Array.from(set);
+    return Array.from(byCode, ([value, label]) => ({ value, label }));
   }, [tickets]);
 
   if (ticketsLoading || ratingsLoading) return <LoadingSkeleton />;
@@ -1478,7 +1478,7 @@ export default function HealthPage() {
                     setInquiringTeamFilter(v ?? "");
                     setCurrentPage(1);
                   }}
-                  options={inquiringTeamsWithTickets.map((team) => ({ label: team, value: team }))}
+                  options={inquiringTeamsWithTickets}
                 />
                 <SingleSelectFilter
                   title="Escalated To"
@@ -1487,7 +1487,7 @@ export default function HealthPage() {
                     setEscalatedTeamFilter(v ?? "");
                     setCurrentPage(1);
                   }}
-                  options={escalatedTeamsWithTickets.map((team) => ({ label: team, value: team }))}
+                  options={escalatedTeamsWithTickets}
                 />
                 <SingleSelectFilter
                   title="Status"
@@ -1565,7 +1565,7 @@ export default function HealthPage() {
                         const { opened } = getOpenedClosed(t);
                         return (
                           <TableRow key={t.id}>
-                            <TableCell>{t.team?.name || "-"}</TableCell>
+                            <TableCell>{t.team?.label || t.team?.name || "-"}</TableCell>
                             <TableCell>
                               {registryData?.impacts.find((i: TicketImpact) => i.code === t.impact)?.label || t.impact || "-"}
                             </TableCell>
@@ -1581,7 +1581,7 @@ export default function HealthPage() {
                             <TableCell>
                               {(t.escalations || []).length ? (
                                 (t.escalations || [])
-                                  .map((e: Escalation) => e.team?.name)
+                                  .map((e: Escalation) => e.team?.label || e.team?.name)
                                   .filter(Boolean)
                                   .join(", ")
                               ) : (

--- a/ui/src/components/tickets/EditTicketModal.tsx
+++ b/ui/src/components/tickets/EditTicketModal.tsx
@@ -492,10 +492,11 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                     </SelectTrigger>
                     <SelectContent>
                       {registryData?.impacts
-                        .filter((imp: TicketImpact) => imp.active !== false)
+                        .filter((imp: TicketImpact) => imp.active !== false || imp.code === impact)
                         .map((imp: TicketImpact) => (
                           <SelectItem key={imp.code} value={imp.code}>
                             {imp.label}
+                            {imp.active === false && " (retired)"}
                           </SelectItem>
                         ))}
                     </SelectContent>

--- a/ui/src/components/tickets/EditTicketModal.tsx
+++ b/ui/src/components/tickets/EditTicketModal.tsx
@@ -435,10 +435,12 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                     placeholder="Select tags..."
                     searchPlaceholder="Search tags..."
                     error={!!validationErrors.tags}
-                    options={(registryData?.tags ?? []).map((t: TicketTag) => ({
-                      label: t.label,
-                      value: t.code,
-                    }))}
+                    options={(registryData?.tags ?? [])
+                      .filter((t: TicketTag) => t.active !== false)
+                      .map((t: TicketTag) => ({
+                        label: t.label,
+                        value: t.code,
+                      }))}
                     selected={selectedTags}
                     onChange={(next) => {
                       setSelectedTags(next);
@@ -488,11 +490,13 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                       <SelectValue placeholder="Select impact..." />
                     </SelectTrigger>
                     <SelectContent>
-                      {registryData?.impacts.map((imp: TicketImpact) => (
-                        <SelectItem key={imp.code} value={imp.code}>
-                          {imp.label}
-                        </SelectItem>
-                      ))}
+                      {registryData?.impacts
+                        .filter((imp: TicketImpact) => imp.active !== false)
+                        .map((imp: TicketImpact) => (
+                          <SelectItem key={imp.code} value={imp.code}>
+                            {imp.label}
+                          </SelectItem>
+                        ))}
                     </SelectContent>
                   </Select>
                   {validationErrors.impact && <p className="text-destructive text-sm">{validationErrors.impact}</p>}

--- a/ui/src/components/tickets/EditTicketModal.tsx
+++ b/ui/src/components/tickets/EditTicketModal.tsx
@@ -264,7 +264,7 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                   <ul className="divide-y">
                     {displayTicket.escalations.map((esc, idx) => (
                       <li key={idx} className="text-foreground flex h-9 items-center px-3">
-                        Escalated to <span className="ml-1 font-medium">{esc.team?.name || "Unknown team"}</span>
+                        Escalated to <span className="ml-1 font-medium">{esc.team?.label || esc.team?.name || "Unknown team"}</span>
                       </li>
                     ))}
                   </ul>
@@ -367,6 +367,7 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                   const CLEAR_SENTINEL = "__clear__";
                   const suggested = isTeamSuggestionsError ? [] : (teamSuggestionsData?.suggestedTeams ?? []);
                   const others = isTeamSuggestionsError ? (teamsData?.map((t) => t.name) ?? []) : (teamSuggestionsData?.otherTeams ?? []);
+                  const teamLabel = (code: string) => teamsData?.find((t) => t.name === code)?.label || code;
                   return (
                     <div className="space-y-1">
                       <Select
@@ -388,7 +389,7 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                               <SelectLabel>Suggested teams</SelectLabel>
                               {suggested.map((name) => (
                                 <SelectItem key={`s-${name}`} value={name}>
-                                  {name}
+                                  {teamLabel(name)}
                                 </SelectItem>
                               ))}
                             </SelectGroup>
@@ -399,7 +400,7 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                               <SelectLabel>Others</SelectLabel>
                               {others.map((name) => (
                                 <SelectItem key={`o-${name}`} value={name}>
-                                  {name}
+                                  {teamLabel(name)}
                                 </SelectItem>
                               ))}
                             </SelectGroup>
@@ -419,7 +420,7 @@ export default function EditTicketModal({ ticketId, open, onOpenChange, onSucces
                   );
                 })()
               ) : (
-                <p className="text-foreground text-sm">{displayTicket.team?.name || "-"}</p>
+                <p className="text-foreground text-sm">{displayTicket.team?.label || displayTicket.team?.name || "-"}</p>
               )}
             </div>
 

--- a/ui/src/components/tickets/__tests__/tickets.test.tsx
+++ b/ui/src/components/tickets/__tests__/tickets.test.tsx
@@ -626,6 +626,26 @@ describe("Tickets Component", () => {
     });
   });
 
+  describe("Tag Display", () => {
+    it("renders tag labels from the registry, not the raw codes", () => {
+      const ticket = { ...createMockTicket("1", "opened", "Team A", "high"), tags: ["networking"] };
+      mockUseRegistry.mockReturnValue({
+        data: { impacts: mockRegistry.impacts, tags: [{ code: "networking", label: "Networking", active: true }] },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useRegistry>);
+      mockUseTickets.mockReturnValue({
+        data: getMockPaginatedTickets([ticket]),
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useTickets>);
+
+      render(<Tickets />, { wrapper: Wrapper });
+
+      expect(screen.getAllByText("Networking").length).toBeGreaterThan(0);
+    });
+  });
+
   describe("Ticket Modal Interaction", () => {
     it("opens modal when ticket row is clicked", () => {
       const mockTickets = getMockPaginatedTickets([createMockTicket("1", "opened", "Team A", "high")]);

--- a/ui/src/components/tickets/__tests__/tickets.test.tsx
+++ b/ui/src/components/tickets/__tests__/tickets.test.tsx
@@ -577,6 +577,21 @@ describe("Tickets Component", () => {
 
       expect(screen.getByRole("table")).toBeInTheDocument();
     });
+
+    it("displays the team's display name (label) rather than its code", () => {
+      const ticket = { ...createMockTicket("1", "opened", "pe", "high"), team: { name: "pe", label: "PE Core" } };
+
+      mockUseTickets.mockReturnValue({
+        data: getMockPaginatedTickets([ticket]),
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useTickets>);
+
+      render(<Tickets />, { wrapper: Wrapper });
+
+      // The friendly display name is shown; the immutable code is kept only for filtering/identity.
+      expect(screen.getAllByText("PE Core").length).toBeGreaterThan(0);
+    });
   });
 
   describe("Impact Display", () => {

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -385,19 +385,23 @@ export default function TicketsPage() {
           title="Impact"
           value={impactFilter || undefined}
           onChange={(v) => setParams({ impact: v ?? "" })}
-          options={(registryData?.impacts ?? []).map((impact: TicketImpact) => ({
-            label: impact.label,
-            value: impact.code,
-          }))}
+          options={(registryData?.impacts ?? [])
+            .filter((impact: TicketImpact) => impact.active !== false)
+            .map((impact: TicketImpact) => ({
+              label: impact.label,
+              value: impact.code,
+            }))}
         />
         <SingleSelectFilter
           title="Tag"
           value={tagFilter || undefined}
           onChange={(v) => setParams({ tag: v ?? "" })}
-          options={(registryData?.tags ?? []).map((tag: TicketTag) => ({
-            label: tag.label,
-            value: tag.code,
-          }))}
+          options={(registryData?.tags ?? [])
+            .filter((tag: TicketTag) => tag.active !== false)
+            .map((tag: TicketTag) => ({
+              label: tag.label,
+              value: tag.code,
+            }))}
         />
         <SingleSelectFilter
           title="Escalated"
@@ -530,20 +534,51 @@ export default function TicketsPage() {
                           {t.summary?.trim() ? t.summary : "—"}
                         </div>
                       </TableCell>
-                      <TableCell>{t.team?.name || "-"}</TableCell>
                       <TableCell>
-                        {registryData?.impacts.find((i: TicketImpact) => i.code === t.impact)?.label || t.impact || "-"}
+                        {t.team ? (
+                          <span className="inline-flex items-center gap-1">
+                            {t.team.name || "-"}
+                            {t.team.active === false && (
+                              <Badge variant="secondary" className="text-[10px]">
+                                Retired
+                              </Badge>
+                            )}
+                          </span>
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {(() => {
+                          if (!t.impact) return "-";
+                          const impact = registryData?.impacts.find((i: TicketImpact) => i.code === t.impact);
+                          return (
+                            <span className="inline-flex items-center gap-1">
+                              {impact?.label || t.impact}
+                              {impact?.active === false && (
+                                <Badge variant="secondary" className="text-[10px]">
+                                  Retired
+                                </Badge>
+                              )}
+                            </span>
+                          );
+                        })()}
                       </TableCell>
                       <TableCell>
                         {(t.tags?.length ?? 0) > 0
-                          ? t.tags
-                              ?.map(getTagLabel)
-                              .filter(Boolean)
-                              .map((tag, idx) => (
-                                <Badge key={`${t.id}-tag-${idx}`} variant="outline" className="mb-1 block w-fit last:mb-0">
-                                  {tag}
+                          ? t.tags?.map((code, idx) => {
+                              const retired = registryData?.tags.find((x: TicketTag) => x.code === code)?.active === false;
+                              return (
+                                <Badge
+                                  key={`${t.id}-tag-${idx}`}
+                                  variant="outline"
+                                  className="mb-1 flex w-fit items-center gap-1 last:mb-0"
+                                >
+                                  {getTagLabel(code)}
+                                  {retired && <span className="text-muted-foreground text-[10px]">(retired)</span>}
                                 </Badge>
-                              ))
+                              );
+                            })
                           : "-"}
                       </TableCell>
                       {isAssignmentEnabled && <TableCell>{t.assignedTo || "-"}</TableCell>}

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -167,16 +167,24 @@ export default function TicketsPage() {
   const ticketsContent = useMemo(() => (ticketsDataTyped?.content as TicketWithLogs[] | undefined) ?? [], [ticketsDataTyped]);
 
   const teamOptions = useMemo(() => {
-    const fromData = ticketsContent.map((t: TicketWithLogs) => t.team?.name).filter((name): name is string => !!name);
-    const fromRegistry = teamsData?.map((t: { name: string }) => t.name).filter(Boolean) ?? [];
-    return Array.from(new Set([...fromData, ...fromRegistry])).sort();
+    const byCode = new Map<string, string>();
+    ticketsContent.forEach((t: TicketWithLogs) => {
+      if (t.team?.name) byCode.set(t.team.name, t.team.label || t.team.name);
+    });
+    (teamsData ?? []).forEach((t: { name: string; label?: string }) => {
+      if (t.name) byCode.set(t.name, t.label || t.name);
+    });
+    return Array.from(byCode, ([value, label]) => ({ value, label })).sort((a, b) => a.label.localeCompare(b.label));
   }, [ticketsContent, teamsData]);
 
   const escalatedToOptions = useMemo(() => {
-    const escalationTeams = ticketsContent.flatMap((t: TicketWithLogs) =>
-      (t.escalations ?? []).map((e) => e.team?.name).filter((name): name is string => !!name)
+    const byCode = new Map<string, string>();
+    ticketsContent.forEach((t: TicketWithLogs) =>
+      (t.escalations ?? []).forEach((e) => {
+        if (e.team?.name) byCode.set(e.team.name, e.team.label || e.team.name);
+      })
     );
-    return Array.from(new Set(escalationTeams)).sort();
+    return Array.from(byCode, ([value, label]) => ({ value, label })).sort((a, b) => a.label.localeCompare(b.label));
   }, [ticketsContent]);
 
   // --- Filter tickets based on superuser/team + UI filters ---
@@ -375,10 +383,7 @@ export default function TicketsPage() {
             title="Team"
             value={teamFilter || undefined}
             onChange={(v) => setParams({ teamFilter: v ?? "" })}
-            options={[
-              ...(!isViewingAllTeams ? [{ label: "All Teams", value: ALL_TEAMS_FILTER }] : []),
-              ...teamOptions.map((name: string) => ({ label: name, value: name })),
-            ]}
+            options={[...(!isViewingAllTeams ? [{ label: "All Teams", value: ALL_TEAMS_FILTER }] : []), ...teamOptions]}
           />
         )}
         <SingleSelectFilter
@@ -417,7 +422,7 @@ export default function TicketsPage() {
           title="Escalated To"
           value={escalatedToFilter || undefined}
           onChange={(v) => setParams({ escalatedTo: v ?? "" })}
-          options={escalatedToOptions.map((name: string) => ({ label: name, value: name }))}
+          options={escalatedToOptions}
         />
       </div>
 
@@ -501,7 +506,7 @@ export default function TicketsPage() {
                 paginatedTickets.map((t: TicketWithLogs) => {
                   const { opened, closed } = getOpenedClosed(t);
                   const escalatedTo = Array.from(
-                    new Set((t.escalations ?? []).map((e) => e.team?.name).filter((name): name is string => !!name))
+                    new Set((t.escalations ?? []).map((e) => e.team?.label || e.team?.name).filter((name): name is string => !!name))
                   );
                   return (
                     <TableRow
@@ -537,7 +542,7 @@ export default function TicketsPage() {
                       <TableCell>
                         {t.team ? (
                           <span className="inline-flex items-center gap-1">
-                            {t.team.name || "-"}
+                            {t.team.label || t.team.name || "-"}
                             {t.team.active === false && (
                               <Badge variant="secondary" className="text-[10px]">
                                 Retired

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -572,14 +572,15 @@ export default function TicketsPage() {
                       <TableCell>
                         {(t.tags?.length ?? 0) > 0
                           ? t.tags?.map((code, idx) => {
-                              const retired = registryData?.tags.find((x: TicketTag) => x.code === code)?.active === false;
+                              const tagMeta = registryData?.tags.find((x: TicketTag) => x.code === code);
+                              const retired = tagMeta?.active === false;
                               return (
                                 <Badge
                                   key={`${t.id}-tag-${idx}`}
                                   variant="outline"
                                   className="mb-1 flex w-fit items-center gap-1 last:mb-0"
                                 >
-                                  {getTagLabel(code)}
+                                  {tagMeta?.label || getTagLabel(code)}
                                   {retired && <span className="text-muted-foreground text-[10px]">(retired)</span>}
                                 </Badge>
                               );

--- a/ui/src/lib/hooks/index.ts
+++ b/ui/src/lib/hooks/index.ts
@@ -204,6 +204,7 @@ export function useEscalationTeams(enabled: boolean = true) {
 
 export interface Team {
   name: string;
+  label?: string;
 }
 
 export function useTenantTeams() {

--- a/ui/src/lib/hooks/index.ts
+++ b/ui/src/lib/hooks/index.ts
@@ -304,8 +304,8 @@ export const useRatings = (from?: string, to?: string) => {
 };
 
 export interface Registry {
-  impacts: { label: string; code: string }[];
-  tags: { label: string; code: string }[];
+  impacts: { label: string; code: string; active?: boolean }[];
+  tags: { label: string; code: string; active?: boolean }[];
 }
 
 export function useRegistry() {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -31,7 +31,7 @@ export interface Escalation {
   hasThread: boolean;
   openedAt: string;
   resolvedAt: string | null;
-  team: { name: string } | null;
+  team: { name: string; active?: boolean } | null;
   escalatingTeam: string;
   tags: string[];
   impact: string | null;
@@ -56,7 +56,7 @@ export interface ParsedTicketLog extends TicketLog {
 export type TicketWithLogs = {
   id: string;
   status: string;
-  team?: { name: string } | null;
+  team?: { name: string; active?: boolean } | null;
   query?: {
     link?: string;
     text?: string;
@@ -73,6 +73,7 @@ export type TicketWithLogs = {
 
 export type TicketTeam = {
   name: string;
+  active?: boolean;
 };
 
 export interface EscalationTeam extends TicketTeam {
@@ -82,11 +83,13 @@ export interface EscalationTeam extends TicketTeam {
 export type TicketImpact = {
   code: string;
   label: string;
+  active?: boolean;
 };
 
 export type TicketTag = {
   code: string;
   label: string;
+  active?: boolean;
 };
 
 export interface PaginatedTickets {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -31,7 +31,7 @@ export interface Escalation {
   hasThread: boolean;
   openedAt: string;
   resolvedAt: string | null;
-  team: { name: string; active?: boolean } | null;
+  team: { name: string; label?: string; active?: boolean } | null;
   escalatingTeam: string;
   tags: string[];
   impact: string | null;
@@ -56,7 +56,7 @@ export interface ParsedTicketLog extends TicketLog {
 export type TicketWithLogs = {
   id: string;
   status: string;
-  team?: { name: string; active?: boolean } | null;
+  team?: { name: string; label?: string; active?: boolean } | null;
   query?: {
     link?: string;
     text?: string;
@@ -73,6 +73,7 @@ export type TicketWithLogs = {
 
 export type TicketTeam = {
   name: string;
+  label?: string;
   active?: boolean;
 };
 


### PR DESCRIPTION
## What & why

Tags, impacts and (escalation) teams are keyed by an immutable `code`, with `label`/`name` as display values. Persisted tickets and escalations store these codes, so renaming a code or deleting a config entry orphaned existing data — the bot threw a `NullPointerException` rendering a ticket summary, and orphaned values silently disappeared from the UI. This change makes config enum updates safe and adds a clear "Retired" UX.

## Changes

**Graceful resolution + team-label persistence**
- New `team` history table records every team's code+label at startup (platform, escalation, support, leadership), mirroring the tags/impacts pattern. `TeamService.resolveForDisplay` maps a code to active team → retired history label → raw code (never null), so a ticket on a removed team of **any** type renders its last-known label (marked retired) instead of NPE-ing or disappearing. Also removes a second `checkNotNull` NPE in escalation processing.

**Impacts mirror tags**
- Pickers list active impacts only; a ticket's current impact still resolves (including soft-deleted) so history renders.

**Static-team identity vs. display**
- Static teams gain an optional immutable `code` (defaults to `name`); `name` becomes the display value. The escalation↔platform join and ticket/author-team resolution match on `code`. Membership-based access scoping is unaffected by the re-keying.

**Fail loud**
- Startup validation fails fast on internally-inconsistent config (duplicate/blank codes). A separate, fully-guarded scan reports references to retired codes via logs and a Micrometer gauge `support_bot.orphaned_references{type}` (non-fatal — never blocks startup).

**"Retired" indicator (UI)**
- `/registry` flags tags/impacts with `active`; every selection control filters to active; the tickets table shows a "Retired" badge next to retired tags, impacts and teams.

## Backward compatibility

No breaking config change: `code` defaults to `name`, the migration is additive (no new foreign key), and the UI `active` flag is optional. Existing configs behave identically; explicit codes are opt-in.

## Testing

- Backend: full compile + unit tests + Checkstyle/ErrorProne green. DB-level behaviour of the new repository and the orphan scan is exercised by the functional harness.
- UI: typecheck + Jest + prettier green.

## Update

Incorporated review feedback and follow-ups (see the "Review fixes" comment):
- Team **display names** now render across the UI (tables, filters, team selector); the immutable `code` stays the identity used for filtering and scoping.
- All review findings addressed — retired-impact pickers (Slack + web), retired escalation-team rendering, validator ordering + static-team validation, escalations filters, tag labels, plus cleanup — and the integration-tests `TeamUI` DTO updated to match the new `active` field.

Re-tested locally: backend `:service:build` (1100 tests) and UI Jest (642) green, with the key paths exercised against a live local stack.

## Upgrade notes

Backward-compatible — **no config changes are required** for a well-formed config (the static-team `code` and the UI `active` flag are optional; the DB migration is additive). On upgrade:

- **Startup now fails fast on duplicate or blank codes** across `enums.tags`, `enums.impacts`, `enums.escalation-teams`, and — newly — the static `platform-integration.teams-scraping.static.teams`. Duplicate tag/impact/escalation codes already failed before; **duplicate static-team codes are newly enforced** (previously they silently merged). Ensure no duplicate/blank codes before rolling out.
- **Escalation↔platform teams match by `code`.** The default case (`code == name`) is unchanged; if you set an explicit `code` on a team that is both a platform *and* an escalation team, set the **same** code on both entries or startup fails with "Unknown escalation teams…".
- **Opt-in:** add an explicit `code` to a static team to change its display `name`/`label` later without orphaning references.
- **Behavior:** removed tags/impacts/teams now render as "Retired" on existing records instead of crashing or vanishing; the `support_bot.orphaned_references` gauge surfaces stale references (see `docs/runbooks/orphaned-enum-references.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)