### PR TITLE
feat(pr-tracking): foundation F1 — author identity + admission/codeowner/dynamic-approval config

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/config/PrTrackingProps.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/config/PrTrackingProps.java
@@ -58,7 +58,11 @@ public record PrTrackingProps(
                                 repository.paths(),
                                 repository.sla(),
                                 repository.gitlab(),
-                                repository.messages()))
+                                repository.messages(),
+                                repository.allowedAuthorTeams(),
+                                repository.requiresCodeowners(),
+                                repository.codeownerTeam(),
+                                repository.dynamicApprovals()))
                         .toList();
         this.slaDiscovery = slaDiscovery == null ? new SlaDiscovery(null) : slaDiscovery;
         this.github = github == null ? GitHub.defaultTokenModeConfig() : github;
@@ -245,7 +249,11 @@ public record PrTrackingProps(
             List<String> paths,
             @Nullable Sla sla,
             @Nullable Gitlab gitlab,
-            @Nullable Messages messages) {
+            @Nullable Messages messages,
+            List<String> allowedAuthorTeams,
+            boolean requiresCodeowners,
+            @Nullable String codeownerTeam,
+            boolean dynamicApprovals) {
         @ConstructorBinding
         public Repository(
                 String name,
@@ -256,7 +264,11 @@ public record PrTrackingProps(
                 @Nullable List<String> paths,
                 @Nullable Sla sla,
                 @Nullable Gitlab gitlab,
-                @Nullable Messages messages) {
+                @Nullable Messages messages,
+                @Nullable List<String> allowedAuthorTeams,
+                boolean requiresCodeowners,
+                @Nullable String codeownerTeam,
+                boolean dynamicApprovals) {
             requireNonNull(name, "name must not be null");
             requireNonNull(owningTeam, "owningTeam must not be null");
             Provider resolvedProvider = provider == null ? Provider.GITHUB : provider;
@@ -265,6 +277,16 @@ public record PrTrackingProps(
             }
             if (gitlabGroupPath != null && gitlabGroupPath.isBlank()) {
                 throw new IllegalArgumentException("gitlabGroupPath must not be blank when provided");
+            }
+            if (codeownerTeam != null && codeownerTeam.isBlank()) {
+                throw new IllegalArgumentException("codeownerTeam must not be blank when provided");
+            }
+            List<String> normalisedAllowedAuthorTeams =
+                    allowedAuthorTeams == null ? List.of() : List.copyOf(allowedAuthorTeams);
+            for (String team : normalisedAllowedAuthorTeams) {
+                if (team.isBlank()) {
+                    throw new IllegalArgumentException("allowed-author-teams[] must not be blank (repo: " + name + ")");
+                }
             }
             // Provider-scoped fields fail fast at config-bind time so a misconfigured repo never
             // makes it through to the adapter, where the mismatch would manifest as a confusing
@@ -277,6 +299,10 @@ public record PrTrackingProps(
                 if (gitlab != null) {
                     throw new IllegalArgumentException(
                             "per-repo gitlab override block is only valid when provider=gitlab (repo: " + name + ")");
+                }
+                if (dynamicApprovals) {
+                    throw new IllegalArgumentException(
+                            "dynamic-approvals is only valid when provider=gitlab (repo: " + name + ")");
                 }
             } else if (resolvedProvider == Provider.GITLAB) {
                 if (githubTeamSlug != null) {
@@ -293,6 +319,40 @@ public record PrTrackingProps(
             this.sla = sla;
             this.gitlab = gitlab;
             this.messages = messages;
+            this.allowedAuthorTeams = normalisedAllowedAuthorTeams;
+            this.requiresCodeowners = requiresCodeowners;
+            this.codeownerTeam = codeownerTeam;
+            this.dynamicApprovals = dynamicApprovals;
+        }
+
+        /**
+         * Convenience for callers predating the admission/codeowner/dynamic-approval fields: defaults
+         * allowed-author-teams to empty and the codeowner/dynamic-approval flags off.
+         */
+        public Repository(
+                String name,
+                String owningTeam,
+                @Nullable Provider provider,
+                @Nullable String githubTeamSlug,
+                @Nullable String gitlabGroupPath,
+                @Nullable List<String> paths,
+                @Nullable Sla sla,
+                @Nullable Gitlab gitlab,
+                @Nullable Messages messages) {
+            this(
+                    name,
+                    owningTeam,
+                    provider,
+                    githubTeamSlug,
+                    gitlabGroupPath,
+                    paths,
+                    sla,
+                    gitlab,
+                    messages,
+                    List.of(),
+                    false,
+                    null,
+                    false);
         }
 
         /** Test/legacy convenience: GitHub repo without GitLab fields. */
@@ -303,7 +363,20 @@ public record PrTrackingProps(
                 List<String> paths,
                 @Nullable Sla sla,
                 @Nullable Messages messages) {
-            this(name, owningTeam, Provider.GITHUB, githubTeamSlug, null, paths, sla, null, messages);
+            this(
+                    name,
+                    owningTeam,
+                    Provider.GITHUB,
+                    githubTeamSlug,
+                    null,
+                    paths,
+                    sla,
+                    null,
+                    messages,
+                    List.of(),
+                    false,
+                    null,
+                    false);
         }
 
         /** Test/legacy convenience: GitHub repo without messages or GitLab fields. */
@@ -313,7 +386,20 @@ public record PrTrackingProps(
                 @Nullable String githubTeamSlug,
                 List<String> paths,
                 @Nullable Sla sla) {
-            this(name, owningTeam, Provider.GITHUB, githubTeamSlug, null, paths, sla, null, null);
+            this(
+                    name,
+                    owningTeam,
+                    Provider.GITHUB,
+                    githubTeamSlug,
+                    null,
+                    paths,
+                    sla,
+                    null,
+                    null,
+                    List.of(),
+                    false,
+                    null,
+                    false);
         }
 
         /** Returns true when this repository has no SLA configured (no-SLA tracking mode). */

--- a/api/service/src/main/java/com/coreeng/supportbot/github/GitHubPullRequest.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/github/GitHubPullRequest.java
@@ -14,7 +14,8 @@ public record GitHubPullRequest(
         @Nullable Boolean mergeable,
         @Nullable String mergeableState,
         List<String> requestedTeamReviewerLogins,
-        List<GitHubPullRequestReview> reviews) {
+        List<GitHubPullRequestReview> reviews,
+        @Nullable String authorLogin) {
     public GitHubPullRequest {
         requireNonNull(repositoryName, "repositoryName must not be null");
         requireNonNull(createdAt, "createdAt must not be null");
@@ -24,6 +25,28 @@ public record GitHubPullRequest(
         if (pullRequestNumber <= 0) {
             throw new IllegalArgumentException("pullRequestNumber must be positive, was " + pullRequestNumber);
         }
+    }
+
+    /** Convenience constructor for callers (and tests) that don't supply an author. */
+    public GitHubPullRequest(
+            String repositoryName,
+            int pullRequestNumber,
+            Instant createdAt,
+            PrState state,
+            @Nullable Boolean mergeable,
+            @Nullable String mergeableState,
+            List<String> requestedTeamReviewerLogins,
+            List<GitHubPullRequestReview> reviews) {
+        this(
+                repositoryName,
+                pullRequestNumber,
+                createdAt,
+                state,
+                mergeable,
+                mergeableState,
+                requestedTeamReviewerLogins,
+                reviews,
+                null);
     }
 
     public boolean isOpen() {

--- a/api/service/src/main/java/com/coreeng/supportbot/github/Hub4jGitHubClient.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/github/Hub4jGitHubClient.java
@@ -204,6 +204,8 @@ public final class Hub4jGitHubClient implements GitHubClient {
             }
             Boolean mergeable = pr.getMergeable();
             String mergeableState = pr.getMergeableState();
+            GHUser author = pr.getUser();
+            String authorLogin = author != null ? author.getLogin() : null;
             List<String> requestedTeamReviewerLogins;
             List<GitHubPullRequestReview> reviews;
             if (prState == GitHubPullRequest.PrState.OPEN) {
@@ -224,7 +226,8 @@ public final class Hub4jGitHubClient implements GitHubClient {
                     mergeable,
                     mergeableState,
                     requestedTeamReviewerLogins,
-                    reviews);
+                    reviews,
+                    authorLogin);
         } catch (IllegalArgumentException e) {
             throw new GitHubApiException(
                     0, "Invalid repository name '%s': %s".formatted(repositoryName, e.getMessage()), e);

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/TeamReviewFilter.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/TeamReviewFilter.java
@@ -5,6 +5,7 @@ import com.coreeng.supportbot.prtracking.source.PrMetadata;
 import com.coreeng.supportbot.prtracking.source.PrSourceClients;
 import com.coreeng.supportbot.prtracking.source.PrSourceException;
 import com.coreeng.supportbot.prtracking.source.Provider;
+import com.coreeng.supportbot.prtracking.source.RepoCoord;
 import com.coreeng.supportbot.prtracking.source.Review;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -58,13 +59,13 @@ public class TeamReviewFilter {
             // GitLab: only an explicit group path triggers filtering. No equivalent to GitHub's
             // "requested team reviewers" — empty means accept all.
             if (repoConfig != null && repoConfig.gitlabGroupPath() != null) {
-                return resolveByTeamRef(pr, repoConfig.gitlabGroupPath(), cache);
+                return resolveTeamMembers(pr.coord(), repoConfig.gitlabGroupPath(), cache);
             }
             return Set.of();
         }
         // GitHub: explicit team slug configured — use Teams API
         if (repoConfig != null && repoConfig.githubTeamSlug() != null) {
-            return resolveByTeamRef(pr, repoConfig.githubTeamSlug(), cache);
+            return resolveTeamMembers(pr.coord(), repoConfig.githubTeamSlug(), cache);
         }
         // GitHub fallback: requested team reviewers already fetched with the PR. Empty list means
         // no teams were requested, so all reviews are accepted without filtering.
@@ -73,23 +74,28 @@ public class TeamReviewFilter {
     }
 
     /**
-     * Resolves group/team members via {@link com.coreeng.supportbot.prtracking.source.PrSourceClient#resolveTeamMembers}.
-     * Cache key folds in the provider so a GitHub team slug and a GitLab group path that happen to
-     * share a name in the same org/group can't collide.
+     * Resolves the members of a team/group reference via
+     * {@link com.coreeng.supportbot.prtracking.source.PrSourceClient#resolveTeamMembers}, memoising the
+     * outcome (success or failure) in the supplied per-poll cache. Returns {@code null} when membership
+     * could not be resolved (API failure); callers treat that as "cannot verify — don't filter".
+     *
+     * <p>Exposed for reuse by admission-time checks (author allow-listing, codeowner resolution) that
+     * build on the same cached lookup. The cache key folds in the provider so a GitHub team slug and a
+     * GitLab group path that happen to share a name in the same org/group can't collide.
      */
-    private @Nullable Set<String> resolveByTeamRef(
-            PrMetadata pr, String teamRef, Map<String, Optional<Set<String>>> cache) {
-        String scope = pr.coord().provider() == Provider.GITHUB
-                ? Iterables.get(Splitter.on('/').split(pr.coord().name()), 0)
-                : pr.coord().name();
-        String key = pr.coord().provider() + ":" + scope + "/" + teamRef;
+    public @Nullable Set<String> resolveTeamMembers(
+            RepoCoord coord, String teamRef, Map<String, Optional<Set<String>>> cache) {
+        String scope = coord.provider() == Provider.GITHUB
+                ? Iterables.get(Splitter.on('/').split(coord.name()), 0)
+                : coord.name();
+        String key = coord.provider() + ":" + scope + "/" + teamRef;
         if (cache.containsKey(key)) {
             // Optional.empty() = previous fetch failed; Optional.of(set) = members resolved
             return cache.get(key).orElse(null);
         }
         try {
-            Set<String> members = Set.copyOf(
-                    prSourceClients.forProvider(pr.coord().provider()).resolveTeamMembers(pr.coord(), teamRef));
+            Set<String> members =
+                    Set.copyOf(prSourceClients.forProvider(coord.provider()).resolveTeamMembers(coord, teamRef));
             cache.put(key, Optional.of(members));
             return members;
         } catch (PrSourceException e) {

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/GitHubPrSourceClient.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/GitHubPrSourceClient.java
@@ -32,7 +32,8 @@ public class GitHubPrSourceClient implements PrSourceClient {
                     mapState(pr.state()),
                     pr.mergeable(),
                     pr.requestedTeamReviewerLogins(),
-                    pr.reviews().stream().map(GitHubPrSourceClient::mapReview).toList());
+                    pr.reviews().stream().map(GitHubPrSourceClient::mapReview).toList(),
+                    pr.authorLogin());
         } catch (GitHubApiException e) {
             throw new PrSourceException(e.getMessage(), e);
         }

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/GitLabPrSourceClient.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/GitLabPrSourceClient.java
@@ -107,7 +107,9 @@ public class GitLabPrSourceClient implements PrSourceClient {
             reviews = List.of();
         }
 
-        return new PrMetadata(coord, prNumber, createdAt, state, mergeable, List.of(), reviews);
+        UserRefDto authorRef = mr.author();
+        String authorLogin = authorRef != null ? authorRef.username() : null;
+        return new PrMetadata(coord, prNumber, createdAt, state, mergeable, List.of(), reviews, authorLogin);
     }
 
     @Override
@@ -398,6 +400,7 @@ public class GitLabPrSourceClient implements PrSourceClient {
             @JsonProperty("created_at") @Nullable Instant createdAt,
             @JsonProperty("updated_at") @Nullable Instant updatedAt,
             @Nullable String state,
+            @JsonProperty("author") @Nullable UserRefDto author,
             @JsonProperty("detailed_merge_status") @Nullable String detailedMergeStatus) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/PrMetadata.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/PrMetadata.java
@@ -13,7 +13,8 @@ public record PrMetadata(
         PrState state,
         @Nullable Boolean mergeable,
         List<String> requestedTeamReviewerLogins,
-        List<Review> reviews) {
+        List<Review> reviews,
+        @Nullable String authorLogin) {
     public PrMetadata {
         requireNonNull(coord, "coord must not be null");
         requireNonNull(createdAt, "createdAt must not be null");
@@ -23,6 +24,21 @@ public record PrMetadata(
         if (number <= 0) {
             throw new IllegalArgumentException("number must be positive, was " + number);
         }
+    }
+
+    /**
+     * Convenience constructor for callers (and tests) that don't supply an author. The author is
+     * captured natively by the source clients; an unknown author is represented as {@code null}.
+     */
+    public PrMetadata(
+            RepoCoord coord,
+            int number,
+            Instant createdAt,
+            PrState state,
+            @Nullable Boolean mergeable,
+            List<String> requestedTeamReviewerLogins,
+            List<Review> reviews) {
+        this(coord, number, createdAt, state, mergeable, requestedTeamReviewerLogins, reviews, null);
     }
 
     public boolean isOpen() {

--- a/api/service/src/main/resources/application.yaml
+++ b/api/service/src/main/resources/application.yaml
@@ -139,6 +139,10 @@ pr-review-tracking:
   #   - name: my-org/my-repo
   #     owning-team: <team-code from enums.escalation-teams>
   #     github-team-slug: <slug>  # optional: GitHub team slug for review validation; when absent, falls back to PR requested teams
+  #     allowed-author-teams:     # optional (PT-521): only track PRs whose author is in one of these GitHub teams
+  #       - <slug>
+  #     requires-codeowners: false  # optional (PT-445): repo needs a codeowner approval before the owning team merges
+  #     codeowner-team: <slug>      # optional (PT-445): team whose approval counts as the codeowner gate
   #     sla:
   #       file: ".pr-sla.yaml"  # optional: read SLA from this file in the repo
   #       default: 48h          # default SLA duration (required when file is not configured)
@@ -189,6 +193,9 @@ pr-review-tracking:
   #     provider: gitlab
   #     owning-team: <team-code from enums.escalation-teams>
   #     gitlab-group-path: my-group/reviewers   # group whose members count as owning-team reviewers
+  #     allowed-author-teams:                   # optional (PT-521): GitLab group paths whose members may have MRs tracked
+  #       - my-group/engineers
+  #     dynamic-approvals: false                # optional (PT-522): GitLab-only — wait for CI + MR Approval Policies to decide required approvals
   #     sla:
   #       default: 48h
   #   - name: platform/infra/cluster-config

--- a/api/service/src/test/java/com/coreeng/supportbot/config/PrTrackingConfigValidationTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/config/PrTrackingConfigValidationTest.java
@@ -993,6 +993,119 @@ class PrTrackingConfigValidationTest {
                 .hasMessageContaining("contains duplicates");
     }
 
+    // ---- Admission / codeowner / dynamic-approval fields (foundation for PT-521/445/522) ---------
+
+    @Test
+    void defaultsAdmissionFieldsWhenNotConfigured() {
+        // given — a repo built via the legacy convenience constructor (no new fields supplied)
+        PrTrackingProps.Repository repo = validRepo();
+
+        // then — the new fields default to "off"
+        assertThat(repo.allowedAuthorTeams()).isEmpty();
+        assertThat(repo.requiresCodeowners()).isFalse();
+        assertThat(repo.dynamicApprovals()).isFalse();
+        assertThat(repo.codeownerTeam()).isNull();
+    }
+
+    @Test
+    void acceptsAllowedAuthorTeamsAndCodeownerTeam() {
+        assertThatCode(() -> new PrTrackingProps.Repository(
+                        "my-org/repo",
+                        "wow",
+                        Provider.GITHUB,
+                        null,
+                        null,
+                        List.of(),
+                        sla(Duration.ofDays(2)),
+                        null,
+                        null,
+                        List.of("platform-team"),
+                        true,
+                        "codeowners-team",
+                        false))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsBlankAllowedAuthorTeam() {
+        assertThatThrownBy(() -> new PrTrackingProps.Repository(
+                        "my-org/repo",
+                        "wow",
+                        Provider.GITHUB,
+                        null,
+                        null,
+                        List.of(),
+                        sla(Duration.ofDays(2)),
+                        null,
+                        null,
+                        List.of("platform-team", "  "),
+                        false,
+                        null,
+                        false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("allowed-author-teams[] must not be blank");
+    }
+
+    @Test
+    void rejectsBlankCodeownerTeam() {
+        assertThatThrownBy(() -> new PrTrackingProps.Repository(
+                        "my-org/repo",
+                        "wow",
+                        Provider.GITHUB,
+                        null,
+                        null,
+                        List.of(),
+                        sla(Duration.ofDays(2)),
+                        null,
+                        null,
+                        List.of(),
+                        false,
+                        "  ",
+                        false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("codeownerTeam must not be blank");
+    }
+
+    @Test
+    void rejectsDynamicApprovalsOnGithubRepo() {
+        // dynamic-approvals is GitLab-only (MR Approval Policies); reject it at config-bind time on GitHub.
+        assertThatThrownBy(() -> new PrTrackingProps.Repository(
+                        "my-org/repo",
+                        "wow",
+                        Provider.GITHUB,
+                        null,
+                        null,
+                        List.of(),
+                        sla(Duration.ofDays(2)),
+                        null,
+                        null,
+                        List.of(),
+                        false,
+                        null,
+                        true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dynamic-approvals is only valid when provider=gitlab");
+    }
+
+    @Test
+    void acceptsDynamicApprovalsOnGitlabRepo() {
+        assertThatCode(() -> new PrTrackingProps.Repository(
+                        "my-group/project",
+                        "wow",
+                        Provider.GITLAB,
+                        null,
+                        "my-group/reviewers",
+                        List.of(),
+                        sla(Duration.ofDays(2)),
+                        null,
+                        null,
+                        List.of(),
+                        false,
+                        null,
+                        true))
+                .doesNotThrowAnyException();
+    }
+
     private static PrTrackingProps.Repository gitlabRepo(String name) {
         return new PrTrackingProps.Repository(
                 name,

--- a/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
@@ -77,6 +77,23 @@ class Hub4jGitHubClientTest {
     }
 
     @Test
+    void capturesAuthorLoginFromPullRequest() throws IOException {
+        // given
+        TestPullRequest pr = stubPullRequest("my-org/my-repo", 42, instant("2026-01-01T00:00:00Z"), GHIssueState.OPEN);
+        pr.testMergeable = true;
+        pr.testMergeableState = "clean";
+        pr.testRequestedTeams = List.of();
+        pr.testAuthorLogin = "octocat";
+        stubReviews(pr, List.of());
+
+        // when
+        GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
+
+        // then
+        assertThat(result.authorLogin()).isEqualTo("octocat");
+    }
+
+    @Test
     void returnsMergedStateWhenMergedAtIsNonNull() throws IOException {
         // given
         TestPullRequest pr =
@@ -552,6 +569,8 @@ class Hub4jGitHubClientTest {
 
         @Nullable String testMergeableState;
 
+        @Nullable String testAuthorLogin;
+
         List<GHTeam> testRequestedTeams = List.of();
 
         @Nullable IOException testRequestedTeamsException;
@@ -586,6 +605,16 @@ class Hub4jGitHubClientTest {
         @Override
         public String getMergeableState() throws IOException {
             return testMergeableState;
+        }
+
+        @Override
+        public GHUser getUser() throws IOException {
+            if (testAuthorLogin == null) {
+                return null;
+            }
+            GHUser user = mock(GHUser.class);
+            when(user.getLogin()).thenReturn(testAuthorLogin);
+            return user;
         }
 
         @Override

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/source/GitLabPrSourceClientTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/source/GitLabPrSourceClientTest.java
@@ -66,6 +66,7 @@ class GitLabPrSourceClientTest {
                           "state": "opened",
                           "created_at": "2026-01-01T10:00:00Z",
                           "updated_at": "2026-01-02T11:00:00Z",
+                          "author": {"username": "carol"},
                           "detailed_merge_status": "mergeable"
                         }
                         """, MediaType.APPLICATION_JSON));
@@ -86,6 +87,7 @@ class GitLabPrSourceClientTest {
         assertThat(metadata.state()).isEqualTo(PrMetadata.PrState.OPEN);
         assertThat(metadata.createdAt()).isEqualTo(Instant.parse("2026-01-01T10:00:00Z"));
         assertThat(metadata.mergeable()).isTrue();
+        assertThat(metadata.authorLogin()).isEqualTo("carol");
         assertThat(metadata.requestedTeamReviewerLogins()).isEmpty();
         assertThat(metadata.reviews())
                 .extracting(Review::userLogin, Review::state)


### PR DESCRIPTION
## Summary

Foundation (**F1**) for the PR/MR tracking enhancements. This is the shared groundwork; the three features stack on top per the spike's [delivery strategy] — **A** (author admission), **C** (codeowners + close-on-merge, ), **B** (GitLab dynamic approvals).

F1 is deliberately scoped to be self-contained and low-risk: **no DB migration, no behaviour change to the live poller.**

## What's included

- **Author identity on `PrMetadata`** (transient DTO field): GitHub `user.login`, GitLab `author.username`, threaded through both source clients. Merger identity **deferred** — no A/B/C decision uses it (C closes on `MERGED` without a merger check).
- **Per-repo config** on `PrTrackingProps.Repository`: `allowed-author-teams`, `requires-codeowners` + `codeowner-team` , `dynamic-approvals` (**GitLab-only** — rejected on GitHub repos at config-bind time). Documented in `application.yaml`.
- **Reusable team resolver**: `TeamReviewFilter.resolveTeamMembers(RepoCoord, …)` extracted public for the upcoming admission gate and codeowner resolution (behaviour-preserving).

## Why no migration

Author is read **live at detection** (the admission gate runs before a tracking record is created), so it is never persisted. The `pr_tracking_status` enum extensions (`AWAITING_MERGE`, `AWAITING_APPROVALS`) ship with features C and B respectively.

## Testing

`make -C api db-up && ./gradlew :service:test :service:checkstyleMain :service:checkstyleTest :service:spotlessCheck -Ddocker=true` — full suite green (ErrorProne/NullAway enforced at `compileJava`).

New tests: GitHub + GitLab author capture; config validation for the new fields (dynamic-approvals GitHub rejection, blank team refs, sensible defaults).

## Follow-ups (stacked)

- **F2** — FSM declarative-table refactor + mermaid-from-code (other half of the foundation; unblocks C/B).
- **A** — author admission gate in `PrDetectionService`, building on this PR's resolver + config.

[delivery strategy]: https://github.com/coreeng/support-bot/blob/spike/pr-tracking-enhancements/docs/spikes/pr-tracking-enhancements.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
