### PR TITLE
chore: ignore false-positive image-scan secret findings

### DIFF
--- a/.p2p-security-ignore.yaml
+++ b/.p2p-security-ignore.yaml
@@ -1,0 +1,29 @@
+# P2P-owned security ignore file, read from the repository root by the coreeng/p2p
+# image- and source-scan workflows. v1 schema — a malformed file FAILS the scan/report job.
+# See coreeng/p2p docs/how-to/ignore-security-findings.md.
+#
+# Only confirmed false positives / accepted risk belong here. Each entry is matched by the
+# standard P2P image name plus the finding `id` exactly as it appears in the scan report.
+version: 1
+
+images:
+  # api image — UBI9 runtime base (registry.access.redhat.com/ubi9/openjdk-25-runtime,
+  # final stage of api/Dockerfile).
+  - name: support-bot
+    secrets:
+      - id: p2psec_9756474ad1dca77c
+        reason: >-
+          False positive: TruffleHog "Box" detector matched a high-entropy byte sequence in
+          /usr/lib64/libgnutls.so.30.40.4 — the GnuTLS shared library shipped by the UBI9 base
+          image. It is a compiled ELF binary, not a Box credential, and the finding status was
+          "unverified" (live verification did not confirm an active credential).
+
+  # ui image — node:24.10.0-alpine3.22 base (ui/Dockerfile).
+  - name: support-bot-ui
+    secrets:
+      - id: p2psec_fa1393fff9412357
+        reason: >-
+          False positive: TruffleHog "Circle" detector matched the CircleCI status-badge token in
+          /opt/yarn-v1.22.22/README.md — yarn's own README bundled in the node base image
+          (line: circleci.com/gh/yarnpkg/yarn.svg?style=shield&circle-token=...). It is a public
+          build-status badge token, not an API credential, and the finding status was "unverified".


### PR DESCRIPTION
## What

Add a repository-root `.p2p-security-ignore.yaml` (P2P v1 schema) recording two
image-scan secret findings as confirmed false positives, so they are excluded
from active findings, blocking counts, and policy failures.

## Why

The coreeng/p2p image scan runs TruffleHog and reports two `unverified` secret
findings that originate in upstream base images, not in this project's code:

| Image | Detector | Path | What it actually is |
|-------|----------|------|---------------------|
| `support-bot` | Box | `/usr/lib64/libgnutls.so.30.40.4` | The GnuTLS shared library shipped by the UBI9 runtime base (`api/Dockerfile` final stage). A compiled ELF binary — the detector matched high-entropy bytes, not a Box credential. |
| `support-bot-ui` | Circle | `/opt/yarn-v1.22.22/README.md` | yarn's own README bundled in the `node` base image (`ui/Dockerfile`). The match is yarn's public CircleCI **status-badge** token (`...yarn.svg?style=shield&circle-token=...`), not an API credential. |

Both finding statuses are `unverified` (TruffleHog's live verification did not
confirm an active credential). The findings are matched by the standard P2P
image name plus the finding `id` from the scan report.

## Notes

- Ignored findings remain visible in `image-security-findings.json` with their
  reason, so accepted risk stays auditable.
- No expiry is set: the `id` is derived from the secret content, so it changes
  if a base image bump alters the matched bytes — which naturally forces a
  re-review at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
