### PR TITLE
fix(ci): scope image scan to deployable images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ P2P_TENANT_NAME ?= support-bot
 P2P_APP_NAME ?= support-bot
 HELM_CHART_PATH ?= helm-chart
 
-P2P_IMAGE_NAMES := $(P2P_APP_NAME) $(P2P_APP_NAME)-ui $(P2P_APP_NAME)-ui-functional $(P2P_APP_NAME)-ui-nft $(P2P_APP_NAME)-dex
+P2P_IMAGE_NAMES := $(P2P_APP_NAME) $(P2P_APP_NAME)-ui $(P2P_APP_NAME)-dex
 
 # Download and include p2p makefile
 $(shell curl -fsSL "https://raw.githubusercontent.com/coreeng/p2p/v1/p2p.mk" -o ".p2p.mk")


### PR DESCRIPTION
## Problem

The p2p `image-scan` job fails on every pull request:

```
ERROR: …/fast-feedback/support-bot-ui-functional:<version>-<sha>: not found
```

`make p2p-images` listed the UI functional and NFT **test** images
(`support-bot-ui-functional`, `support-bot-ui-nft`) in `P2P_IMAGE_NAMES`. The
image-scan job (`needs: build`) resolves images from that target and tries to
pull each one at the build version tag.

But the `build` job only produces the **deployable** images
(`support-bot`, `support-bot-ui`, `support-bot-dex`). The UI test images are
built by the separate `functional`/`nft` jobs and only ever exist at the plain
release tag. So on a PR the scan requests
`support-bot-ui-functional:<version>-<sha>`, which is never published, and the
job fails. `main` is unaffected only because the test images exist at the
release tag from earlier runs.

## Fix

Drop the test-only images from `P2P_IMAGE_NAMES` so `make p2p-images` lists only
deployable images (matching the p2p contract that this target prints standard
deployable image names).

- The UI test images keep their own `build-/push-/deploy-ui-functional` (and
  `-nft`) targets in the functional/nft jobs — unaffected by this change.
- `push-extended-test` is a no-op ("uses promoted image"), and nothing consumes
  the *promoted* test images, so `promote` is unaffected in practice; it simply
  stops copying two images that were never used downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
