### PR TITLE
ci: align P2P workflow inputs

### DIFF
--- a/.github/workflows/ldap-fast-feedback.yaml
+++ b/.github/workflows/ldap-fast-feedback.yaml
@@ -1,3 +1,4 @@
+---
 name: LDAP Fast Feedback
 
 on:
@@ -30,11 +31,13 @@ jobs:
       version-prefix: ldap/v
     secrets:
       git-token: ${{ secrets.GITHUB_TOKEN }}
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
 
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: |
         LDAP_BOOTSTRAP_USER_PASSWORD=${{ secrets.LDAP_BOOTSTRAP_USER_PASSWORD }}
     with:

--- a/.github/workflows/support-bot-extended-test.yaml
+++ b/.github/workflows/support-bot-extended-test.yaml
@@ -1,3 +1,4 @@
+---
 name: support-bot Extended Test
 
 on:
@@ -12,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: support-bot
       tenant-name: support-bot
@@ -20,6 +23,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: |
         SLACK_TOKEN=${{ secrets.SLACK_TOKEN_INTEGRATION }}
         SLACK_SOCKET_TOKEN=${{ secrets.SLACK_SOCKET_TOKEN_INTEGRATION }}

--- a/.github/workflows/support-bot-fast-feedback.yaml
+++ b/.github/workflows/support-bot-fast-feedback.yaml
@@ -1,3 +1,4 @@
+---
 name: support-bot Fast Feedback
 
 on:
@@ -28,11 +29,13 @@ jobs:
       version-prefix: v
     secrets:
       git-token: ${{ secrets.GITHUB_TOKEN }}
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
 
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: |
         SLACK_TOKEN=${{ secrets.SLACK_TOKEN_INTEGRATION }}
         SLACK_SOCKET_TOKEN=${{ secrets.SLACK_SOCKET_TOKEN_INTEGRATION }}

--- a/.github/workflows/support-bot-monitoring.yaml
+++ b/.github/workflows/support-bot-monitoring.yaml
@@ -1,3 +1,4 @@
+---
 name: support-bot Monitoring
 
 on:

--- a/.github/workflows/support-bot-prod.yaml
+++ b/.github/workflows/support-bot-prod.yaml
@@ -1,3 +1,4 @@
+---
 name: support-bot Prod
 
 on:
@@ -13,6 +14,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: support-bot
       tenant-name: support-bot
@@ -21,6 +24,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: support-bot

--- a/.github/workflows/support-bot-security-scan.yaml
+++ b/.github/workflows/support-bot-security-scan.yaml
@@ -1,3 +1,4 @@
+---
 name: support-bot Security Scan
 
 on:
@@ -15,6 +16,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: support-bot
       tenant-name: support-bot
-      working-directory: ./
       security-scan-blocking-severity: "off"
+      working-directory: ./


### PR DESCRIPTION
## Summary
- Add YAML document markers to support-bot P2P workflows.
- Add missing app-name and reorder scheduled security scan inputs to match the software template skeleton.
- Add missing P2P Slack webhook secrets to version/get-latest and execution jobs.
- Preserve custom env_vars blocks, paths-ignore, artifacts, prod packages permission, commented prod schedule, and the bespoke monitoring command workflow.