### PR TITLE
build(api): replace dependency forces with constraints

### DIFF
--- a/.p2p-security-ignore.yaml
+++ b/.p2p-security-ignore.yaml
@@ -17,6 +17,18 @@ images:
           /usr/lib64/libgnutls.so.30.40.4 — the GnuTLS shared library shipped by the UBI9 base
           image. It is a compiled ELF binary, not a Box credential, and the finding status was
           "unverified" (live verification did not confirm an active credential).
+      - id: p2psec_146d28c666737e01
+        reason: >-
+          False positive: TruffleHog "Box" detector matched a high-entropy byte sequence in
+          /usr/lib/jvm/java-25-openjdk/lib/server/libjvm.so — the JVM shared library shipped in
+          the runtime image. It is a compiled ELF binary, not a Box credential, and the finding
+          status was "unverified" (live verification did not confirm an active credential).
+      - id: p2psec_8e1e664bef38e6e5
+        reason: >-
+          False positive: TruffleHog "Gitlab" detector matched byte sequences in
+          /var/lib/rpm/rpmdb.sqlite — the RPM package database from the runtime image. It is
+          package-manager metadata, not a GitLab credential, and the finding status was
+          "unverified" (live verification did not confirm an active credential).
 
   # ui image — node:24.10.0-alpine3.22 base (ui/Dockerfile).
   - name: support-bot-ui

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -44,12 +44,25 @@ val safeDependencyVersions =
         "org.springframework:spring-web" to "6.2.18",
         "org.springframework:spring-webmvc" to "6.2.18",
     )
-val safeDependencyCoordinates = safeDependencyVersions.map { (dependency, version) -> "$dependency:$version" }.toTypedArray()
+val managedDependencyVersions =
+    mapOf(
+        "asm.version" to "9.9.1",
+        "byte-buddy.version" to "1.18.4",
+        "commons-lang3.version" to safeDependencyVersions.getValue("org.apache.commons:commons-lang3"),
+        "mockito.version" to "5.21.0",
+        "netty.version" to safeDependencyVersions.getValue("io.netty:netty-common"),
+        "opentelemetry.version" to safeDependencyVersions.getValue("io.opentelemetry:opentelemetry-api"),
+        "postgresql.version" to safeDependencyVersions.getValue("org.postgresql:postgresql"),
+        "spring-framework.version" to safeDependencyVersions.getValue("org.springframework:spring-core"),
+    )
 
 subprojects {
     apply(plugin = "com.diffplug.spotless")
 
     extra["jackson-bom.version"] = jacksonVersion
+    managedDependencyVersions.forEach { (property, version) ->
+        extra[property] = version
+    }
 
     plugins.withType<JavaPlugin> {
         dependencies {
@@ -62,11 +75,12 @@ subprojects {
     }
 
     configurations.configureEach {
-        resolutionStrategy {
-            force(*safeDependencyCoordinates)
-            eachDependency {
-                safeDependencyVersions["${requested.group}:${requested.name}"]?.let { safeVersion ->
-                    useVersion(safeVersion)
+        if (isCanBeDeclared) {
+            safeDependencyVersions.forEach { (dependency, safeVersion) ->
+                project.dependencies.constraints.add(name, dependency) {
+                    version {
+                        strictly(safeVersion)
+                    }
                     because("Patched version required for Dependabot security alerts")
                 }
             }

--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -58,16 +58,6 @@ repositories {
     mavenCentral()
 }
 
-// Java 25 compatibility: override transitive dependency versions
-extra["byte-buddy.version"] = "1.18.4"
-extra["mockito.version"] = "5.21.0"
-extra["asm.version"] = "9.9.1"
-extra["commons-lang3.version"] = "3.18.0"
-extra["netty.version"] = "4.1.135.Final"
-extra["opentelemetry.version"] = "1.62.0"
-extra["postgresql.version"] = "42.7.11"
-extra["spring-framework.version"] = "6.2.18"
-
 val lombokVersion = "1.18.42"
 val errorProneVersion = "2.47.0"
 val nullAwayVersion = "0.13.1"


### PR DESCRIPTION
## Motivation

After the Dependabot remediation PR merged, GitHub still reports Maven alerts even though local Gradle resolution selects patched versions. The remaining alerts appear to come from GitHub's dependency graph seeing vulnerable requested transitive versions alongside the patched selected versions.

This PR changes the API dependency remediation mechanism from resolution-time `force`/`eachDependency` overrides to Gradle-native strict dependency constraints. The goal is to preserve the same resolved patched versions while expressing the policy in dependency metadata that GitHub's Gradle dependency submission may understand better.

The PR also accepts newly reported unverified P2P image-secret false positives in the `support-bot` runtime image, based on the canonical scanner IDs reported in the PR image-scan comment.

## Summary

- Replace the root `safeDependencyVersions` `resolutionStrategy.force` and `eachDependency/useVersion` block with strict dependency constraints applied to declarable subproject configurations.
- Keep the existing patched version map and Jackson BOM override.
- Move Spring dependency-management version properties from `service` into the API root so these overrides are centralized with the rest of the dependency remediation setup.
- Derive overlapping Spring managed-version properties from `safeDependencyVersions` where the same dependency is represented in both mechanisms.
- Add P2P image-secret ignores for unverified `support-bot` image false positives in `libjvm.so` and `rpmdb.sqlite`.
- Leave direct dependency declarations in submodules unchanged.

## Validation

- `./gradlew :testkit:compileJava :integration-tests:compileTestJava spotlessGradleCheck`
- `./gradlew :service:dependencies --configuration runtimeClasspath` confirms key packages still resolve to patched versions, including:
  - `jackson-databind -> 2.22.0`
  - `jackson-core -> 2.22.0`
  - `opennlp-tools -> 2.5.9`
  - `commons-lang3 -> 3.18.0`
  - `netty-common -> 4.1.135.Final`
- `./gradlew :service:dependencyInsight --configuration runtimeClasspath --dependency org.springframework:spring-core` confirms Spring Framework still resolves to `6.2.18` after moving the Spring managed-version properties.
- `ruby -e 'require "yaml"; YAML.load_file(".p2p-security-ignore.yaml")'`

## Notes

This is intentionally an experiment. Strict constraints preserve the old force-like exact selected versions, including downgrading newer requested versions such as `commons-lang3:3.20.0` back to `3.18.0`. If we later want security floors rather than exact pins, this should change to non-strict/rich constraints or parent dependency upgrades.

This PR replaces the force/eachDependency mechanism for `safeDependencyVersions`; it does not eliminate Spring dependency-management property overrides. Those property overrides are still needed for Spring-managed dependencies and are now defined in the API root.
