### PR TITLE
Sanitize unsupported Slack modal blocks

### DIFF
--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.flywaydb.gradle.task.AbstractFlywayTask
 import org.jooq.codegen.gradle.CodegenTask
 import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy
+import org.testcontainers.postgresql.PostgreSQLContainer
 import org.gradle.api.Action
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.ErrorProneOptions
@@ -93,7 +93,7 @@ dependencies {
     implementation("com.microsoft.kiota:microsoft-kiota-http-okHttp:1.9.1")
 
     jooqCodegen("org.postgresql:postgresql:42.7.11")
-    jooqCodegen("org.testcontainers:postgresql:1.20.4")
+    jooqCodegen("org.testcontainers:testcontainers-postgresql:2.0.5")
     jooqCodegen("org.jooq:jooq-codegen:3.19.18")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -102,8 +102,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("com.slack.api:bolt-jakarta-socket-mode:1.45.4")
-    implementation("com.slack.api:bolt-jakarta-servlet:1.45.4")
+    implementation("com.slack.api:bolt-jakarta-socket-mode:1.49.0")
+    implementation("com.slack.api:bolt-jakarta-servlet:1.49.0")
     compileOnly("jakarta.websocket:jakarta.websocket-client-api:2.2.0")
     implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:2.2.0")
     implementation("com.google.guava:guava:33.4.0-jre")
@@ -220,7 +220,7 @@ buildscript {
     dependencies {
         classpath("org.flywaydb:flyway-database-postgresql:12.0.0")
         classpath("org.postgresql:postgresql:42.7.11")
-        classpath("org.testcontainers:postgresql:1.20.4")
+        classpath("org.testcontainers:testcontainers-postgresql:2.0.5")
         classpath("org.jooq:jooq-codegen:3.19.18")
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/SlackModalBlockSanitizer.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/SlackModalBlockSanitizer.java
@@ -1,0 +1,234 @@
+package com.coreeng.supportbot.ticket;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.slack.api.model.block.ActionsBlock;
+import com.slack.api.model.block.ContextActionsBlock;
+import com.slack.api.model.block.ContextActionsBlockElement;
+import com.slack.api.model.block.ContextBlock;
+import com.slack.api.model.block.ContextBlockElement;
+import com.slack.api.model.block.InputBlock;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.RichTextBlock;
+import com.slack.api.model.block.SectionBlock;
+import com.slack.api.model.block.UnknownBlock;
+import com.slack.api.model.block.UnknownBlockElement;
+import com.slack.api.model.block.UnknownContextActionsBlockElement;
+import com.slack.api.model.block.UnknownContextBlockElement;
+import com.slack.api.model.block.composition.TextObject;
+import com.slack.api.model.block.composition.UnknownTextObject;
+import com.slack.api.model.block.element.BlockElement;
+import com.slack.api.model.block.element.RichTextElement;
+import com.slack.api.model.block.element.RichTextListElement;
+import com.slack.api.model.block.element.RichTextPreformattedElement;
+import com.slack.api.model.block.element.RichTextQuoteElement;
+import com.slack.api.model.block.element.RichTextSectionElement;
+import com.slack.api.model.block.element.RichTextUnknownElement;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+final class SlackModalBlockSanitizer {
+    private SlackModalBlockSanitizer() {}
+
+    static ImmutableList<LayoutBlock> sanitize(List<LayoutBlock> blocks) {
+        return blocks.stream()
+                .map(SlackModalBlockSanitizer::sanitizeLayoutBlock)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+    }
+
+    @Nullable private static LayoutBlock sanitizeLayoutBlock(LayoutBlock block) {
+        switch (block) {
+            case UnknownBlock unknownBlock -> {
+                return null;
+            }
+            case RichTextBlock richTextBlock -> {
+                ImmutableList<BlockElement> elements = richTextBlock.getElements().stream()
+                        .map(SlackModalBlockSanitizer::sanitizeBlockElement)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList());
+                if (elements.isEmpty()) {
+                    return null;
+                }
+
+                return RichTextBlock.builder()
+                        .blockId(richTextBlock.getBlockId())
+                        .elements(elements)
+                        .build();
+            }
+            case ActionsBlock actionsBlock -> {
+                ImmutableList<BlockElement> elements = actionsBlock.getElements().stream()
+                        .map(SlackModalBlockSanitizer::sanitizeBlockElement)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList());
+                if (elements.isEmpty()) {
+                    return null;
+                }
+
+                return ActionsBlock.builder()
+                        .blockId(actionsBlock.getBlockId())
+                        .elements(elements)
+                        .build();
+            }
+            case ContextBlock contextBlock -> {
+                ImmutableList<ContextBlockElement> elements = contextBlock.getElements().stream()
+                        .map(SlackModalBlockSanitizer::sanitizeContextBlockElement)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList());
+                if (elements.isEmpty()) {
+                    return null;
+                }
+
+                return ContextBlock.builder()
+                        .blockId(contextBlock.getBlockId())
+                        .elements(elements)
+                        .build();
+            }
+            case ContextActionsBlock contextActionsBlock -> {
+                ImmutableList<ContextActionsBlockElement> elements = contextActionsBlock.getElements().stream()
+                        .map(SlackModalBlockSanitizer::sanitizeContextActionsBlockElement)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList());
+                if (elements.isEmpty()) {
+                    return null;
+                }
+
+                return ContextActionsBlock.builder()
+                        .blockId(contextActionsBlock.getBlockId())
+                        .elements(elements)
+                        .build();
+            }
+            case SectionBlock sectionBlock -> {
+                TextObject text = sanitizeTextObject(sectionBlock.getText());
+                ImmutableList<TextObject> fields = sectionBlock.getFields() == null
+                        ? ImmutableList.of()
+                        : sectionBlock.getFields().stream()
+                                .map(SlackModalBlockSanitizer::sanitizeTextObject)
+                                .filter(Objects::nonNull)
+                                .collect(toImmutableList());
+                BlockElement accessory =
+                        sectionBlock.getAccessory() != null ? sanitizeBlockElement(sectionBlock.getAccessory()) : null;
+                if (text == null && fields.isEmpty()) {
+                    return null;
+                }
+
+                return SectionBlock.builder()
+                        .blockId(sectionBlock.getBlockId())
+                        .text(text)
+                        .fields(fields.isEmpty() ? null : fields)
+                        .accessory(accessory)
+                        .expand(sectionBlock.getExpand())
+                        .build();
+            }
+            case InputBlock inputBlock -> {
+                BlockElement element =
+                        inputBlock.getElement() != null ? sanitizeBlockElement(inputBlock.getElement()) : null;
+                if (element == null) {
+                    return null;
+                }
+
+                return InputBlock.builder()
+                        .blockId(inputBlock.getBlockId())
+                        .label(inputBlock.getLabel())
+                        .element(element)
+                        .dispatchAction(inputBlock.getDispatchAction())
+                        .hint(inputBlock.getHint())
+                        .optional(inputBlock.isOptional())
+                        .build();
+            }
+            default -> {}
+        }
+
+        return block;
+    }
+
+    @Nullable private static TextObject sanitizeTextObject(@Nullable TextObject textObject) {
+        return textObject instanceof UnknownTextObject ? null : textObject;
+    }
+
+    @Nullable private static ContextBlockElement sanitizeContextBlockElement(ContextBlockElement element) {
+        if (element instanceof UnknownContextBlockElement || element instanceof UnknownTextObject) {
+            return null;
+        }
+        return element;
+    }
+
+    @Nullable private static ContextActionsBlockElement sanitizeContextActionsBlockElement(ContextActionsBlockElement element) {
+        if (element instanceof UnknownContextActionsBlockElement) {
+            return null;
+        }
+        return element;
+    }
+
+    @Nullable private static BlockElement sanitizeBlockElement(BlockElement element) {
+        if (element instanceof UnknownBlockElement) {
+            return null;
+        }
+        if (!(element instanceof RichTextElement richTextElement)) {
+            return element;
+        }
+        RichTextElement sanitized = sanitizeRichTextElement(richTextElement);
+        return sanitized instanceof BlockElement blockElement ? blockElement : null;
+    }
+
+    @Nullable private static RichTextElement sanitizeRichTextElement(RichTextElement element) {
+        if (element instanceof RichTextUnknownElement) {
+            return null;
+        }
+
+        if (element instanceof RichTextSectionElement sectionElement) {
+            ImmutableList<RichTextElement> elements = sanitizeRichTextElements(sectionElement.getElements());
+            if (elements.isEmpty()) {
+                return null;
+            }
+            return RichTextSectionElement.builder().elements(elements).build();
+        }
+
+        if (element instanceof RichTextListElement listElement) {
+            ImmutableList<RichTextElement> elements = sanitizeRichTextElements(listElement.getElements());
+            if (elements.isEmpty()) {
+                return null;
+            }
+            return RichTextListElement.builder()
+                    .elements(elements)
+                    .style(listElement.getStyle())
+                    .indent(listElement.getIndent())
+                    .offset(listElement.getOffset())
+                    .border(listElement.getBorder())
+                    .build();
+        }
+
+        if (element instanceof RichTextQuoteElement quoteElement) {
+            ImmutableList<RichTextElement> elements = sanitizeRichTextElements(quoteElement.getElements());
+            if (elements.isEmpty()) {
+                return null;
+            }
+            return RichTextQuoteElement.builder()
+                    .elements(elements)
+                    .border(quoteElement.getBorder())
+                    .build();
+        }
+
+        if (element instanceof RichTextPreformattedElement preformattedElement) {
+            ImmutableList<RichTextElement> elements = sanitizeRichTextElements(preformattedElement.getElements());
+            if (elements.isEmpty()) {
+                return null;
+            }
+            return RichTextPreformattedElement.builder()
+                    .elements(elements)
+                    .border(preformattedElement.getBorder())
+                    .build();
+        }
+
+        return element;
+    }
+
+    private static ImmutableList<RichTextElement> sanitizeRichTextElements(List<RichTextElement> elements) {
+        return elements.stream()
+                .map(SlackModalBlockSanitizer::sanitizeRichTextElement)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+    }
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/ticket/TicketSummaryService.java
@@ -148,7 +148,10 @@ public class TicketSummaryService {
         }
 
         if (queryMessage.getBlocks() != null && !queryMessage.getBlocks().isEmpty()) {
-            return ImmutableList.copyOf(queryMessage.getBlocks());
+            ImmutableList<LayoutBlock> sanitizedBlocks = SlackModalBlockSanitizer.sanitize(queryMessage.getBlocks());
+            if (!sanitizedBlocks.isEmpty()) {
+                return sanitizedBlocks;
+            }
         }
 
         if (text != null && !text.isBlank()) {

--- a/api/service/src/test/java/com/coreeng/supportbot/ticket/SlackModalBlockSanitizerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/ticket/SlackModalBlockSanitizerTest.java
@@ -1,0 +1,89 @@
+package com.coreeng.supportbot.ticket;
+
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.slack.api.model.block.ActionsBlock;
+import com.slack.api.model.block.ContextActionsBlock;
+import com.slack.api.model.block.ContextBlock;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.RichTextBlock;
+import com.slack.api.model.block.UnknownBlock;
+import com.slack.api.model.block.UnknownBlockElement;
+import com.slack.api.model.block.UnknownContextActionsBlockElement;
+import com.slack.api.model.block.UnknownContextBlockElement;
+import com.slack.api.model.block.composition.TextObject;
+import com.slack.api.model.block.composition.UnknownTextObject;
+import com.slack.api.model.block.element.RichTextSectionElement;
+import com.slack.api.model.block.element.RichTextUnknownElement;
+import org.junit.jupiter.api.Test;
+
+class SlackModalBlockSanitizerTest {
+    @Test
+    void removesSdkUnknownFallbacksBeforeRenderingModal() {
+        RichTextSectionElement.Text beforeUnknown =
+                RichTextSectionElement.Text.builder().text("Before ").build();
+        RichTextUnknownElement unknown =
+                RichTextUnknownElement.builder().type("message_mention").build();
+        RichTextSectionElement.Text afterUnknown =
+                RichTextSectionElement.Text.builder().text(" after").build();
+        RichTextSectionElement section = RichTextSectionElement.builder()
+                .elements(ImmutableList.of(beforeUnknown, unknown, afterUnknown))
+                .build();
+        RichTextBlock richTextBlock = RichTextBlock.builder()
+                .blockId("message-block")
+                .elements(ImmutableList.of(section))
+                .build();
+        TextObject contextText = markdownText("Known context");
+        ContextBlock contextBlock = ContextBlock.builder()
+                .blockId("context-block")
+                .elements(ImmutableList.of(
+                        UnknownTextObject.builder()
+                                .type("unknown_text")
+                                .text("ignored")
+                                .build(),
+                        UnknownContextBlockElement.builder()
+                                .type("unknown_context")
+                                .build(),
+                        contextText))
+                .build();
+
+        ImmutableList<LayoutBlock> result = SlackModalBlockSanitizer.sanitize(ImmutableList.of(
+                UnknownBlock.builder()
+                        .type("unknown_block")
+                        .blockId("unknown-block")
+                        .build(),
+                richTextBlock,
+                ActionsBlock.builder()
+                        .blockId("actions-block")
+                        .elements(ImmutableList.of(UnknownBlockElement.builder()
+                                .type("unknown_action")
+                                .build()))
+                        .build(),
+                ContextActionsBlock.builder()
+                        .blockId("context-actions-block")
+                        .elements(ImmutableList.of(UnknownContextActionsBlockElement.builder()
+                                .type("unknown_context_action")
+                                .build()))
+                        .build(),
+                contextBlock));
+
+        assertThat(result)
+                .hasSize(2)
+                .noneMatch(UnknownBlock.class::isInstance)
+                .noneMatch(ActionsBlock.class::isInstance)
+                .noneMatch(ContextActionsBlock.class::isInstance);
+        RichTextBlock sanitizedBlock = (RichTextBlock) result.getFirst();
+        RichTextSectionElement sanitizedSection =
+                (RichTextSectionElement) sanitizedBlock.getElements().getFirst();
+        assertThat(sanitizedSection.getElements())
+                .containsExactly(beforeUnknown, afterUnknown)
+                .noneMatch(RichTextUnknownElement.class::isInstance);
+        ContextBlock sanitizedContextBlock = (ContextBlock) result.get(1);
+        assertThat(sanitizedContextBlock.getElements())
+                .containsExactly(contextText)
+                .noneMatch(UnknownTextObject.class::isInstance)
+                .noneMatch(UnknownContextBlockElement.class::isInstance);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes ticket summary modal rendering for Slack messages that contain Block Kit elements the Java SDK does not fully model.

## Root cause

The ticket summary view reused Slack message blocks directly when opening a modal. Some Slack rich text and container payloads can include elements that are valid in Slack but are represented by the Java SDK as unknown fallback model types. When those fallback objects are serialized into a modal payload, required Slack fields can be lost, so Slack rejects the modal request during schema validation.

Upgrading the Slack SDK alone does not fully address this because unknown fallback types can still appear at multiple block levels.

## How to reproduce

1. Create or fetch a ticket whose original Slack message contains a rich Block Kit structure with an element unsupported by the SDK model.
2. Open the ticket summary modal.
3. The app forwards the parsed message blocks into the modal open request.
4. Slack rejects the modal payload with an invalid-arguments response because the serialized fallback element is incomplete for modal rendering.

## Fix

- Upgrade the Slack SDK to the newer version already tested for this issue.
- Add a dedicated modal block sanitizer that removes SDK unknown fallback blocks, block elements, context elements, context-action elements, text objects, and rich text children before rendering the modal.
- Preserve supported message structure where possible and fall back to message text only if all blocks are removed.
- Keep the sanitizer separate from ticket summary assembly so the behavior is focused and testable.
- Upgrade Testcontainers to the current Postgres module and use the non-deprecated Postgres container class so local verification works with the current Docker engine.

## Validation

- `rtk ./gradlew :service:flywayMigrate :service:jooqCodegen`
- `rtk ./gradlew :service:test --tests com.coreeng.supportbot.ticket.SlackModalBlockSanitizerTest --tests com.coreeng.supportbot.ticket.TicketSummaryServiceTest`
- `rtk ./gradlew :service:spotlessCheck`
- `rtk git diff --check`