### PR TITLE
fix(helm): allow exclude-author-teams on pr-review-tracking repositories

### DIFF
--- a/helm-chart/tests/configmap_test.yaml
+++ b/helm-chart/tests/configmap_test.yaml
@@ -44,7 +44,7 @@ tests:
           pattern: 'messages:\n\s+approved: Approved\n\s+changes-requested: Changes requested\n\s+closed: Closed\n\s+detected: PR detected\n\s+escalated: Please escalate\n\s+merged: Merged'
       - matchRegex:
           path: data["application.yaml"]
-          pattern: 'name: coreeng/no-sla-repo\n\s+owning-team: docs-team\n\s+paths:\n\s+- docs/\*\*'
+          pattern: 'exclude-author-teams:\n\s+- docs-team\n\s+name: coreeng/no-sla-repo\n\s+owning-team: docs-team\n\s+paths:\n\s+- docs/\*\*'
 
   - it: does not inject extra pr review tracking defaults when omitted from configMap.config
     values:

--- a/helm-chart/tests/values/pr-review-tracking-positive.yaml
+++ b/helm-chart/tests/values/pr-review-tracking-positive.yaml
@@ -33,6 +33,8 @@ configMap:
           owning-team: docs-team
           paths:
             - docs/**
+          exclude-author-teams:
+            - docs-team
       sla-discovery:
         cache: PT5M
       github:

--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -122,6 +122,10 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "exclude-author-teams": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "sla": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
## Summary
- The Helm chart's `values.schema.json` didn't include `exclude-author-teams` under `prReviewRepository`, so any values.yaml using it (as documented in `configuration.md` and implemented by #288) failed with `Additional property exclude-author-teams is not allowed`.
- Added the missing property to the schema, and extended the existing helm-unittest fixture/assertion so a regression is caught by `make test-chart`.

Fixes #295

## Test plan
- [x] Reproduced the exact `helm upgrade`/`helm template` failure from the issue using the reporter's values.yaml
- [x] Confirmed the fix resolves it and `exclude-author-teams` renders correctly in the configmap
- [x] `make test-chart` — all 40 helm-unittest tests pass
- [x] `make validate-chart-values` — all values fixtures lint/render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)