### PR TITLE
Fix a bug with date pickers, reuse url params

### DIFF
--- a/ui/src/components/dashboards/__tests__/dashboards.shell.test.tsx
+++ b/ui/src/components/dashboards/__tests__/dashboards.shell.test.tsx
@@ -1,3 +1,4 @@
+import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
 import { fireEvent, render, screen } from "@testing-library/react";
 import DashboardsPage from "../dashboards";
 
@@ -23,14 +24,7 @@ jest.mock("../../../contexts/TeamFilterContext", () => ({
 // changes re-render the component correctly.
 jest.mock("../../../lib/hooks/useUrlParams", () => ({
   ...jest.requireActual("../../../lib/hooks/useUrlParams"),
-  useUrlParams: (defaults: Record<string, string>) => {
-    const { useState } = require("react") as typeof import("react");
-    const [params, setParamsState] = useState<Record<string, string>>(defaults);
-    const setParams = (updates: Record<string, string>) => {
-      setParamsState((prev: Record<string, string>) => ({ ...prev, ...updates }));
-    };
-    return [params, setParams];
-  },
+  useUrlParams: mockUseUrlParams,
 }));
 
 jest.mock("../../../lib/hooks", () => ({

--- a/ui/src/components/escalations/EscalatedToMyTeamTable.tsx
+++ b/ui/src/components/escalations/EscalatedToMyTeamTable.tsx
@@ -8,7 +8,7 @@ import { SingleSelectFilter } from "@/components/ui/single-select-filter";
 import { useTeamFilter } from "@/contexts/TeamFilterContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useNow } from "@/hooks/useNow";
-import { getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
+import { DateFilter, getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
 import { useEscalations, useRegistry } from "@/lib/hooks";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -23,7 +23,6 @@ export default function EscalatedToMyTeamTable() {
   const [statusFilter, setStatusFilter] = useState<"all" | "ongoing" | "resolved">("all");
   const [impactFilter, setImpactFilter] = useState<string>("all");
   const [tagFilter, setTagFilter] = useState<string>("");
-  type DateFilter = "" | "lastWeek" | "last2Weeks" | "lastMonth" | "custom";
   const [dateFilter, setDateFilter] = useState<DateFilter>("lastWeek");
   const [customDateRange, setCustomDateRange] = useState<{ start?: string; end?: string }>({});
   type SortColumn = "ticketId" | "openedAt" | "resolvedAt" | "duration";
@@ -32,8 +31,8 @@ export default function EscalatedToMyTeamTable() {
   const [pageIndex, setPageIndex] = useState(0);
   const pageSize = 15;
 
-  // Empty string (= "Any Date") is not in presetDays so falls through to
-  // { from: undefined, to: undefined } inside getDateRangeFromFilter, which is correct.
+  // "all" (= "Any Date") maps to { from: undefined, to: undefined } via allValue,
+  // i.e. no date filtering.
   const dateRange = useMemo(
     () =>
       getDateRangeFromFilter({
@@ -41,6 +40,7 @@ export default function EscalatedToMyTeamTable() {
         customDateRange,
         customValue: "custom",
         fallbackValue: "lastWeek",
+        allValue: "all",
         presetDays: {
           lastWeek: PRESET_DAYS.lastWeek,
           last2Weeks: PRESET_DAYS.last2Weeks,
@@ -178,10 +178,6 @@ export default function EscalatedToMyTeamTable() {
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p className="text-destructive">Error loading escalations</p>;
 
-  const ANY_DATE = "__any";
-  const fromAny = (v: string) => (v === ANY_DATE ? "" : v);
-  const toAny = (v: string) => (v === "" ? ANY_DATE : v);
-
   return (
     <div className="bg-card space-y-4 rounded-xl border p-6">
       <div className="flex items-start justify-between gap-4">
@@ -191,9 +187,9 @@ export default function EscalatedToMyTeamTable() {
         </div>
         <div className="flex items-center gap-2">
           <Select
-            value={toAny(dateFilter)}
-            onValueChange={(v) => {
-              setDateFilter(fromAny(v) as DateFilter);
+            value={dateFilter}
+            onValueChange={(v: string) => {
+              setDateFilter(v as DateFilter);
               setPageIndex(0);
             }}
           >
@@ -201,7 +197,7 @@ export default function EscalatedToMyTeamTable() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ANY_DATE}>Any Date</SelectItem>
+              <SelectItem value="all">Any Date</SelectItem>
               <SelectItem value="lastWeek">Last Week</SelectItem>
               <SelectItem value="last2Weeks">Last 2 Weeks</SelectItem>
               <SelectItem value="lastMonth">Last Month</SelectItem>

--- a/ui/src/components/escalations/__tests__/escalations.test.tsx
+++ b/ui/src/components/escalations/__tests__/escalations.test.tsx
@@ -1,5 +1,7 @@
+import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import * as TeamFilterContext from "../../../contexts/TeamFilterContext";
 import * as AuthHook from "../../../hooks/useAuth";
@@ -15,14 +17,7 @@ jest.mock("../../../hooks/useAuth");
 // interactions that fire events and then inspect the rendered output intact.
 jest.mock("../../../lib/hooks/useUrlParams", () => ({
   ...jest.requireActual("../../../lib/hooks/useUrlParams"),
-  useUrlParams: (defaults: Record<string, string>) => {
-    const { useState } = require("react") as typeof import("react");
-    const [params, setParamsState] = useState<Record<string, string>>(defaults);
-    const setParams = (updates: Record<string, string>) => {
-      setParamsState((prev: Record<string, string>) => ({ ...prev, ...updates }));
-    };
-    return [params, setParams];
-  },
+  useUrlParams: mockUseUrlParams,
 }));
 jest.mock("../EscalatedToMyTeamTable", () => {
   const Mock = () => <div data-testid="escalated-to-my-team-table" />;
@@ -228,6 +223,61 @@ describe("EscalationsPage", () => {
     expect(screen.getByText("Escalated To")).toBeInTheDocument();
     expect(screen.getAllByText("Tenant Alpha").length).toBeGreaterThan(0);
     expect(screen.getByText("Escalation Team 1")).toBeInTheDocument();
+  });
+
+  // Regression: "Any Date" used to be represented by an empty-string dateFilter,
+  // which the real useUrlParams strips from the URL — the filter silently
+  // snapped back to the default "Last Week" and old escalations stayed hidden.
+  it('shows escalations older than the default range when "Any Date" is selected', async () => {
+    const user = userEvent.setup();
+
+    mockUseTeamFilter.mockReturnValue({
+      selectedTeam: null,
+      setSelectedTeam: jest.fn(),
+      teamScope: { mode: "all_teams" },
+      effectiveTeams: [],
+      hasNoTeamScope: false,
+      isViewingAllTeams: true,
+      isViewingAsEscalationTeam: false,
+      hasFullAccess: true,
+      allTeams: [],
+      initialized: true,
+    });
+
+    mockUseEscalations.mockReturnValue({
+      data: {
+        page: 0,
+        totalPages: 1,
+        totalElements: 1,
+        content: [
+          {
+            id: "esc-old",
+            ticketId: "T-OLD",
+            escalatingTeam: "Tenant Alpha",
+            team: { name: "Escalation Team 1" },
+            impact: "high",
+            tags: [],
+            openedAt: daysAgo(100),
+            resolvedAt: null,
+            hasThread: false,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useEscalations>);
+
+    render(<EscalationsPage />, { wrapper: Wrapper });
+
+    // Hidden under the default "Last Week" filter.
+    expect(screen.queryByText("T-OLD")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("escalations-date-filter"));
+    await user.click(await screen.findByRole("option", { name: "Any Date" }));
+
+    // The selection must stick and reveal the old escalation.
+    expect(screen.getByTestId("escalations-date-filter")).toHaveTextContent("Any Date");
+    expect(screen.getByText("T-OLD")).toBeInTheDocument();
   });
 
   it("hides team scope controls and context labels when user has no backend team scope", () => {

--- a/ui/src/components/escalations/escalations.tsx
+++ b/ui/src/components/escalations/escalations.tsx
@@ -10,7 +10,7 @@ import { useTeamFilter } from "@/contexts/TeamFilterContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useNow } from "@/hooks/useNow";
 import { TEAM_SCOPE } from "@/lib/constants";
-import { getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
+import { DateFilter, getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
 import { useEscalations, useRegistry, useTenantTeams } from "@/lib/hooks";
 import { enumValidator, isoDateValidator, nonNegativeIntValidator, useUrlParams } from "@/lib/hooks/useUrlParams";
 import { normalizeTeamKey } from "@/lib/teamUtils";
@@ -59,7 +59,6 @@ export default function EscalationsPage() {
   const { data: tenantTeamsData } = useTenantTeams();
   const { data: registryData } = useRegistry();
   const ALL_TEAMS_FILTER = TEAM_SCOPE.ALL_TEAMS;
-  type EscalationDateFilter = "" | "lastWeek" | "last2Weeks" | "lastMonth" | "custom";
 
   // Persist all filter / sort / page controls in the URL.
   // Validators guard against invalid URL values and auto-correct the URL.
@@ -77,7 +76,7 @@ export default function EscalationsPage() {
       page: "0",
     },
     {
-      dateFilter: enumValidator(["", "lastWeek", "last2Weeks", "lastMonth", "custom"] as const, "lastWeek"),
+      dateFilter: enumValidator(["all", "lastWeek", "last2Weeks", "lastMonth", "custom"] as const, "lastWeek"),
       dateFrom: isoDateValidator,
       dateTo: isoDateValidator,
       status: enumValidator(["all", "ongoing", "resolved"] as const, "all"),
@@ -94,7 +93,7 @@ export default function EscalationsPage() {
   const statusFilter = params.status as "all" | "ongoing" | "resolved";
   const impactFilter = params.impact;
   const tagFilter = params.tag;
-  const dateFilter = params.dateFilter as EscalationDateFilter;
+  const dateFilter = params.dateFilter as DateFilter;
   const sortColumn = params.sortBy as SortColumn;
   const sortDirection = params.sortDir as "asc" | "desc";
   const pageIndex = parseInt(params.page, 10);
@@ -149,8 +148,8 @@ export default function EscalationsPage() {
     minutes < 30 ? "text-success" : minutes < 120 ? "text-warning" : "text-destructive font-semibold";
 
   // --- Date range for date filter ---
-  // Empty string dateFilter (= "Any Date") is not in presetDays so falls through to
-  // { from: undefined, to: undefined } inside getDateRangeFromFilter, which is correct.
+  // "all" (= "Any Date") maps to { from: undefined, to: undefined } via allValue,
+  // i.e. no date filtering.
   const dateRange = useMemo(
     () =>
       getDateRangeFromFilter({
@@ -158,6 +157,7 @@ export default function EscalationsPage() {
         customDateRange: { start: params.dateFrom || undefined, end: params.dateTo || undefined },
         customValue: "custom",
         fallbackValue: "lastWeek",
+        allValue: "all",
         presetDays: {
           lastWeek: PRESET_DAYS.lastWeek,
           last2Weeks: PRESET_DAYS.last2Weeks,
@@ -317,10 +317,6 @@ export default function EscalationsPage() {
   const topTagsTitleSuffix = selectedTeam ? (selectedTeam === ALL_TEAMS_FILTER ? "for All Teams" : `for ${teamLabel(selectedTeam)}`) : "";
   const showEscalatedForColumn = hasFullAccess || selectedTeam === ALL_TEAMS_FILTER;
 
-  const ANY_DATE = "__any";
-  const fromAny = (v: string) => (v === ANY_DATE ? "" : v);
-  const toAny = (v: string) => (v === "" ? ANY_DATE : v);
-
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4">
@@ -357,9 +353,9 @@ export default function EscalationsPage() {
           </div>
           <div className="flex items-center gap-2">
             <Select
-              value={toAny(dateFilter)}
-              onValueChange={(v) => {
-                const next = fromAny(v) as EscalationDateFilter;
+              value={dateFilter}
+              onValueChange={(v: string) => {
+                const next = v as DateFilter;
                 setParams(next !== "custom" ? { dateFilter: next, dateFrom: "", dateTo: "", page: "0" } : { dateFilter: next, page: "0" });
               }}
             >
@@ -367,7 +363,7 @@ export default function EscalationsPage() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={ANY_DATE}>Any Date</SelectItem>
+                <SelectItem value="all">Any Date</SelectItem>
                 <SelectItem value="lastWeek">Last Week</SelectItem>
                 <SelectItem value="last2Weeks">Last 2 Weeks</SelectItem>
                 <SelectItem value="lastMonth">Last Month</SelectItem>

--- a/ui/src/components/health/__tests__/health.test.tsx
+++ b/ui/src/components/health/__tests__/health.test.tsx
@@ -7,6 +7,7 @@
  * - Loading and error states
  */
 
+import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
@@ -34,14 +35,7 @@ jest.mock("../../../lib/hooks");
 // changes re-render the component correctly, keeping all existing interactions intact.
 jest.mock("../../../lib/hooks/useUrlParams", () => ({
   ...jest.requireActual("../../../lib/hooks/useUrlParams"),
-  useUrlParams: (defaults: Record<string, string>) => {
-    const { useState } = require("react") as typeof import("react");
-    const [params, setParamsState] = useState<Record<string, string>>(defaults);
-    const setParams = (updates: Record<string, string>) => {
-      setParamsState((prev: Record<string, string>) => ({ ...prev, ...updates }));
-    };
-    return [params, setParams];
-  },
+  useUrlParams: mockUseUrlParams,
 }));
 
 const mockUseTickets = hooks.useTickets as jest.MockedFunction<typeof hooks.useTickets>;

--- a/ui/src/components/stats/__tests__/stats.test.tsx
+++ b/ui/src/components/stats/__tests__/stats.test.tsx
@@ -8,6 +8,7 @@
  * - Loading and error states
  */
 
+import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import React from "react";
@@ -29,14 +30,7 @@ jest.mock("../../../contexts/TeamFilterContext");
 // test interactions that fire events and then inspect API call arguments.
 jest.mock("../../../lib/hooks/useUrlParams", () => ({
   ...jest.requireActual("../../../lib/hooks/useUrlParams"),
-  useUrlParams: (defaults: Record<string, string>) => {
-    const { useState } = require("react") as typeof import("react");
-    const [params, setParamsState] = useState<Record<string, string>>(defaults);
-    const setParams = (updates: Record<string, string>) => {
-      setParamsState((prev: Record<string, string>) => ({ ...prev, ...updates }));
-    };
-    return [params, setParams];
-  },
+  useUrlParams: mockUseUrlParams,
 }));
 
 // Mock EscalatedToMyTeamWidget

--- a/ui/src/components/tickets/__tests__/tickets.test.tsx
+++ b/ui/src/components/tickets/__tests__/tickets.test.tsx
@@ -1,5 +1,7 @@
+import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import * as hooks from "../../../lib/hooks";
 import Tickets from "../tickets";
@@ -12,14 +14,7 @@ jest.mock("../../../lib/hooks");
 // interactions that fire events and then inspect the rendered output intact.
 jest.mock("../../../lib/hooks/useUrlParams", () => ({
   ...jest.requireActual("../../../lib/hooks/useUrlParams"),
-  useUrlParams: (defaults: Record<string, string>) => {
-    const { useState } = require("react") as typeof import("react");
-    const [params, setParamsState] = useState<Record<string, string>>(defaults);
-    const setParams = (updates: Record<string, string>) => {
-      setParamsState((prev: Record<string, string>) => ({ ...prev, ...updates }));
-    };
-    return [params, setParams];
-  },
+  useUrlParams: mockUseUrlParams,
 }));
 
 const mockUseTickets = hooks.useTickets as jest.MockedFunction<typeof hooks.useTickets>;
@@ -170,6 +165,39 @@ describe("Tickets Component", () => {
       isLoading: false,
       error: null,
     } as unknown as ReturnType<typeof hooks.useAssignmentEnabled>);
+  });
+
+  describe("Date filter", () => {
+    // Regression: "Any Date" used to be represented by an empty-string dateFilter,
+    // which the real useUrlParams strips from the URL — the filter silently
+    // snapped back to the default "Last Week" and kept the bounded date range.
+    it('requests an unbounded date range when "Any Date" is selected', async () => {
+      const user = userEvent.setup();
+      const mockTickets = getMockPaginatedTickets([createMockTicket("1", "opened", "Team A", "high")]);
+
+      mockUseTickets.mockReturnValue({
+        data: mockTickets,
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useTickets>);
+
+      render(<Tickets />, { wrapper: Wrapper });
+
+      // Default "Last Week" filter passes a bounded range to the backend hook.
+      let [, , dateFrom, dateTo] = mockUseTickets.mock.lastCall ?? [];
+      expect(dateFrom).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+      expect(dateTo).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+
+      // The date Select is the only combobox on the page (faceted filters are buttons).
+      await user.click(screen.getByRole("combobox"));
+      await user.click(await screen.findByRole("option", { name: "Any Date" }));
+
+      // The selection must stick and drop the date bounds from the backend query.
+      expect(screen.getByRole("combobox")).toHaveTextContent("Any Date");
+      [, , dateFrom, dateTo] = mockUseTickets.mock.lastCall ?? [];
+      expect(dateFrom).toBeUndefined();
+      expect(dateTo).toBeUndefined();
+    });
   });
 
   describe("Rendering", () => {

--- a/ui/src/components/tickets/tickets.tsx
+++ b/ui/src/components/tickets/tickets.tsx
@@ -9,7 +9,7 @@ import { SingleSelectFilter } from "@/components/ui/single-select-filter";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useTeamFilter } from "@/contexts/TeamFilterContext";
 import { TEAM_SCOPE } from "@/lib/constants";
-import { getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
+import { DateFilter, getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
 import { useAllTickets, useAssignmentEnabled, useRegistry, useTenantTeams, useTickets } from "@/lib/hooks";
 import { enumValidator, isoDateValidator, nonNegativeIntValidator, useUrlParams } from "@/lib/hooks/useUrlParams";
 import { normalizeTeamKey } from "@/lib/teamUtils";
@@ -33,7 +33,6 @@ export default function TicketsPage() {
   const columnCount = isAssignmentEnabled ? BASE_COLUMN_COUNT + 1 : BASE_COLUMN_COUNT;
   const hasNoTeamScope = contextHasNoTeamScope ?? effectiveTeams.includes(TEAM_SCOPE.NO_TEAMS);
   const isViewingAllTeams = contextIsViewingAllTeams ?? (effectiveTeams.length === 0 && !hasNoTeamScope);
-  type TicketDateFilter = "" | "lastWeek" | "last2Weeks" | "lastMonth" | "custom";
   type SortColumn = "openedAt" | "closedAt";
 
   // Selected ticket (UI-only — not persisted in the URL)
@@ -62,7 +61,7 @@ export default function TicketsPage() {
       page: "0",
     },
     {
-      dateFilter: enumValidator(["", "lastWeek", "last2Weeks", "lastMonth", "custom"] as const, "lastWeek"),
+      dateFilter: enumValidator(["all", "lastWeek", "last2Weeks", "lastMonth", "custom"] as const, "lastWeek"),
       dateFrom: isoDateValidator,
       dateTo: isoDateValidator,
       status: enumValidator(["", "opened", "closed", "stale"] as const, ""),
@@ -80,7 +79,7 @@ export default function TicketsPage() {
   // Type assertions are safe for dateFilter, status, escalated, sortBy, and sortDir —
   // each has an enumValidator above. page uses nonNegativeIntValidator and is parsed via parseInt
   // teamFilter, impact, tag, and escalatedTo have no validators and carry raw URL strings.
-  const dateFilter = params.dateFilter as TicketDateFilter;
+  const dateFilter = params.dateFilter as DateFilter;
   const statusFilter = params.status;
   const teamFilter = params.teamFilter;
   const impactFilter = params.impact;
@@ -106,6 +105,7 @@ export default function TicketsPage() {
         customDateRange: { start: params.dateFrom || undefined, end: params.dateTo || undefined },
         customValue: "custom",
         fallbackValue: "lastWeek",
+        allValue: "all",
         presetDays: {
           lastWeek: PRESET_DAYS.lastWeek,
           last2Weeks: PRESET_DAYS.last2Weeks,
@@ -318,11 +318,6 @@ export default function TicketsPage() {
 
   const totalTickets = useServerPagination ? ticketsDataTyped?.totalElements || 0 : sortedTickets.length;
 
-  // shadcn Select needs non-empty values; "" means "any" sentinel.
-  const ANY = "__any";
-  const fromAny = (v: string) => (v === ANY ? "" : v);
-  const toAny = (v: string) => (v === "" ? ANY : v);
-
   // --- Render ---
   return (
     <div className="space-y-6">
@@ -333,9 +328,9 @@ export default function TicketsPage() {
         </div>
         <div className="flex items-center gap-2">
           <Select
-            value={toAny(dateFilter)}
-            onValueChange={(v) => {
-              const next = fromAny(v) as TicketDateFilter;
+            value={dateFilter}
+            onValueChange={(v: string) => {
+              const next = v as DateFilter;
               setParams(next !== "custom" ? { dateFilter: next, dateFrom: "", dateTo: "" } : { dateFilter: next });
             }}
           >
@@ -343,7 +338,7 @@ export default function TicketsPage() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ANY}>Any Date</SelectItem>
+              <SelectItem value="all">Any Date</SelectItem>
               <SelectItem value="lastWeek">Last Week</SelectItem>
               <SelectItem value="last2Weeks">Last 2 Weeks</SelectItem>
               <SelectItem value="lastMonth">Last Month</SelectItem>

--- a/ui/src/lib/hooks/__tests__/useUrlParams.test.ts
+++ b/ui/src/lib/hooks/__tests__/useUrlParams.test.ts
@@ -110,6 +110,24 @@ describe("useUrlParams", () => {
       expect(mockReplace).toHaveBeenCalledWith("/test");
     });
 
+    // Regression guard for the Tickets/Escalations "Any Date" bug: an option
+    // represented by an empty string can never be selected, because setParams
+    // strips empty values from the URL and the next read falls back to the
+    // key's default. "No filter" options must use a non-empty value (e.g. "all").
+    it("cannot represent an empty-string selection for a key with a non-empty default", () => {
+      setupMocks();
+      const { result } = renderHook(() => useUrlParams(DEFAULTS));
+      act(() => {
+        result.current[1]({ dateFilter: "" });
+      });
+      // The param is removed from the URL entirely...
+      expect(mockReplace).toHaveBeenCalledWith("/test");
+      // ...so a hook reading that URL sees the default again, not "".
+      setupMocks({});
+      const { result: afterNavigation } = renderHook(() => useUrlParams(DEFAULTS));
+      expect(afterNavigation.current[0].dateFilter).toBe("lastWeek");
+    });
+
     it("can set multiple params in a single call", () => {
       setupMocks();
       const { result } = renderHook(() => useUrlParams(DEFAULTS));

--- a/ui/src/test-utils/mock-url-params.ts
+++ b/ui/src/test-utils/mock-url-params.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared jest mock for the `useUrlParams` hook.
+ *
+ * Mirrors the real hook's URL semantics closely enough for component tests:
+ * a `useState`-backed store that re-renders on `setParams`, and treats an
+ * empty-string update as "remove the param" (falls back to the key's
+ * default), matching `useUrlParams.ts`'s `router.replace` stripping behavior.
+ *
+ * Usage in a test file (imported under a `mock`-prefixed alias so
+ * babel-plugin-jest-hoist allows referencing it inside `jest.mock`, whose
+ * factory runs before the module's own imports are hoisted):
+ * ```ts
+ * import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
+ *
+ * jest.mock("../../../lib/hooks/useUrlParams", () => ({
+ *   ...jest.requireActual("../../../lib/hooks/useUrlParams"),
+ *   useUrlParams: mockUseUrlParams,
+ * }));
+ * ```
+ */
+
+import { useState } from "react";
+
+type StringRecord = Record<string, string>;
+
+export function useMockUrlParams<T extends StringRecord>(defaults: T): [T, (updates: Partial<T>) => void] {
+  const [params, setParamsState] = useState<T>(defaults);
+  const setParams = (updates: Partial<T>) => {
+    setParamsState((prev) => {
+      const next: StringRecord = { ...prev };
+      for (const [key, value] of Object.entries(updates)) {
+        next[key] = value === "" ? defaults[key as keyof T] : (value as string);
+      }
+      return next as T;
+    });
+  };
+  return [params, setParams];
+}


### PR DESCRIPTION
Summary

- Tickets/Escalations "Any Date" filter used an empty-string sentinel, which useUrlParams strips from the URL and falls back to the default — so it silently reset to "Last Week". Switched to a non-empty "all" sentinel, and fixed the same latent bug in EscalatedToMyTeamTable.
- Deduped the useUrlParams test mock into a shared helper and fixed 3 test files still using the old, incorrect version.
- Added regression tests for the "Any Date" selection.