### PR TITLE
fix(ui): decouple dashboard access from team scope

### DIFF
--- a/ui/src/app/__tests__/page.test.tsx
+++ b/ui/src/app/__tests__/page.test.tsx
@@ -346,7 +346,11 @@ describe("Dashboard - Support Area Summary visibility", () => {
       mockUseTenantInsightsEnabled.mockReturnValue({ data: true, isLoading: false, error: null } as any);
     });
 
-    it("hides every restricted tab when the backend roles provide no capability", async () => {
+    it.each([
+      { description: "USER", roles: ["USER"] },
+      { description: "ESCALATION", roles: ["ESCALATION"] },
+      { description: "USER and ESCALATION", roles: ["USER", "ESCALATION"] },
+    ])("hides every restricted tab for $description roles", async ({ roles }) => {
       mockUseTeamFilter.mockReturnValue({
         hasUnrestrictedDataScope: true,
         selectedTeam: null,
@@ -365,7 +369,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["USER"],
+          roles,
           teams: [],
         },
         isLoading: false,
@@ -384,6 +388,54 @@ describe("Dashboard - Support Area Summary visibility", () => {
         expect(screen.queryByText("SLA Dashboard")).not.toBeInTheDocument();
         expect(screen.queryByText("Support Area Summary")).not.toBeInTheDocument();
         expect(screen.queryByText("Tenant Requests")).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows sidebar placeholders until an authorized session has loaded", async () => {
+      mockUseAuth.mockReturnValue({
+        user: null,
+        isLoading: true,
+        isAuthenticated: false,
+        logout: jest.fn(),
+        isLeadership: false,
+        isEscalationTeam: false,
+        isSupportEngineer: false,
+        actualEscalationTeams: [],
+      });
+
+      const view = renderDashboard();
+
+      expect(view.container.querySelector('[data-sidebar="menu-skeleton"]')).toBeInTheDocument();
+      expect(screen.queryByText("Home")).not.toBeInTheDocument();
+      expect(screen.queryByText("Analytics & Operations")).not.toBeInTheDocument();
+
+      mockUseAuth.mockReturnValue({
+        user: {
+          id: "support@example.com",
+          name: "Support Engineer",
+          email: "support@example.com",
+          roles: ["SUPPORT_ENGINEER"],
+          teams: [],
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        logout: jest.fn(),
+        isLeadership: false,
+        isEscalationTeam: false,
+        isSupportEngineer: true,
+        actualEscalationTeams: [],
+      });
+
+      view.rerender(
+        <DashboardLayoutComponent>
+          <Dashboard />
+        </DashboardLayoutComponent>
+      );
+
+      await waitFor(() => {
+        expect(view.container.querySelector('[data-sidebar="menu-skeleton"]')).not.toBeInTheDocument();
+        expect(screen.getByText("Home")).toBeInTheDocument();
+        expect(screen.getByText("Analytics & Operations")).toBeInTheDocument();
       });
     });
 

--- a/ui/src/app/__tests__/page.test.tsx
+++ b/ui/src/app/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import { useTeamFilter } from "@/contexts/TeamFilterContext";
 import { useAuth } from "@/hooks/useAuth";
-import { useKnowledgeGapsEnabled } from "@/lib/hooks";
+import { useKnowledgeGapsEnabled, useTenantInsightsEnabled } from "@/lib/hooks";
 import { render, screen, waitFor } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import DashboardLayoutComponent from "../(dashboard)/layout";
@@ -22,7 +22,7 @@ jest.mock("../../contexts/TeamFilterContext", () => ({
 
 jest.mock("../../lib/hooks", () => ({
   useKnowledgeGapsEnabled: jest.fn(),
-  useTenantInsightsEnabled: jest.fn(() => ({ data: false, isLoading: false, error: null })),
+  useTenantInsightsEnabled: jest.fn(),
 }));
 
 // Mock all the page components
@@ -76,6 +76,7 @@ const mockRouter = {
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockUseTeamFilter = useTeamFilter as jest.MockedFunction<typeof useTeamFilter>;
 const mockUseKnowledgeGapsEnabled = useKnowledgeGapsEnabled as jest.MockedFunction<typeof useKnowledgeGapsEnabled>;
+const mockUseTenantInsightsEnabled = useTenantInsightsEnabled as jest.MockedFunction<typeof useTenantInsightsEnabled>;
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 
 // Helper to render Dashboard with Layout (simulating the route group structure)
@@ -91,8 +92,9 @@ describe("Dashboard - Support Area Summary visibility", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRouter.mockReturnValue(mockRouter as any);
+    mockUseTenantInsightsEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
     mockUseTeamFilter.mockReturnValue({
-      hasFullAccess: true,
+      hasUnrestrictedDataScope: true,
       selectedTeam: null,
       setSelectedTeam: jest.fn(),
       effectiveTeams: [],
@@ -105,7 +107,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
     });
   });
 
-  describe("when feature is enabled and hasFullAccess is true", () => {
+  describe("when feature and role capability are enabled", () => {
     beforeEach(() => {
       mockUseKnowledgeGapsEnabled.mockReturnValue({
         data: true,
@@ -113,7 +115,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
         error: null,
       } as any);
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: true,
+        hasUnrestrictedDataScope: true,
         selectedTeam: null,
         setSelectedTeam: jest.fn(),
         effectiveTeams: [],
@@ -132,7 +134,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["supportEngineer"],
+          roles: ["SUPPORT_ENGINEER"],
           teams: [],
         },
         isLoading: false,
@@ -152,7 +154,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
     });
   });
 
-  describe("when feature is enabled but hasFullAccess is false", () => {
+  describe("when feature is enabled and a narrower data scope is selected", () => {
     beforeEach(() => {
       mockUseKnowledgeGapsEnabled.mockReturnValue({
         data: true,
@@ -160,7 +162,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
         error: null,
       } as any);
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         selectedTeam: "tenant-team",
         setSelectedTeam: jest.fn(),
         effectiveTeams: ["tenant-team"],
@@ -173,13 +175,13 @@ describe("Dashboard - Support Area Summary visibility", () => {
       });
     });
 
-    it("does NOT show Support Area Summary when tenant team is selected", async () => {
+    it("keeps Support Area Summary visible for a support engineer viewing a tenant team", async () => {
       mockUseAuth.mockReturnValue({
         user: {
           id: "support@example.com",
           name: "Support User",
           email: "support@example.com",
-          roles: ["supportEngineer"],
+          roles: ["SUPPORT_ENGINEER"],
           teams: [],
         },
         isLoading: false,
@@ -194,32 +196,44 @@ describe("Dashboard - Support Area Summary visibility", () => {
       renderDashboard();
 
       await waitFor(() => {
-        expect(screen.queryByText("Support Area Summary")).not.toBeInTheDocument();
+        expect(screen.getByText("Support Area Summary")).toBeInTheDocument();
       });
     });
 
-    it("does NOT show Support Area Summary when escalation team is selected", async () => {
+    it("keeps Support Area Summary visible for leadership viewing an escalation team", async () => {
+      mockUseTeamFilter.mockReturnValue({
+        hasUnrestrictedDataScope: false,
+        selectedTeam: "escalation-team",
+        setSelectedTeam: jest.fn(),
+        effectiveTeams: ["escalation-team"],
+        allTeams: ["tenant-team"],
+        initialized: true,
+        teamScope: { mode: "selected_teams" as const, teams: ["escalation-team"] },
+        hasNoTeamScope: false,
+        isViewingAllTeams: false,
+        isViewingAsEscalationTeam: true,
+      });
       mockUseAuth.mockReturnValue({
         user: {
           id: "leader@example.com",
           name: "Leadership User",
           email: "leader@example.com",
-          roles: ["leadership"],
+          roles: ["LEADERSHIP", "ESCALATION"],
           teams: [],
         },
         isLoading: false,
         isAuthenticated: true,
         logout: jest.fn(),
         isLeadership: true,
-        isEscalationTeam: false,
+        isEscalationTeam: true,
         isSupportEngineer: false,
-        actualEscalationTeams: [],
+        actualEscalationTeams: ["escalation-team"],
       });
 
       renderDashboard();
 
       await waitFor(() => {
-        expect(screen.queryByText("Support Area Summary")).not.toBeInTheDocument();
+        expect(screen.getByText("Support Area Summary")).toBeInTheDocument();
       });
 
       // Verify basic tabs are still visible
@@ -236,7 +250,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
         error: null,
       } as any);
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: true,
+        hasUnrestrictedDataScope: true,
         selectedTeam: null,
         setSelectedTeam: jest.fn(),
         effectiveTeams: [],
@@ -249,13 +263,13 @@ describe("Dashboard - Support Area Summary visibility", () => {
       });
     });
 
-    it("does NOT show Support Area Summary even with full access when feature is disabled", async () => {
+    it("does NOT show Support Area Summary even with the role capability when feature is disabled", async () => {
       mockUseAuth.mockReturnValue({
         user: {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["supportEngineer"],
+          roles: ["SUPPORT_ENGINEER"],
           teams: [],
         },
         isLoading: false,
@@ -283,7 +297,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
         error: null,
       } as any);
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: true,
+        hasUnrestrictedDataScope: true,
         selectedTeam: null,
         setSelectedTeam: jest.fn(),
         effectiveTeams: [],
@@ -296,13 +310,13 @@ describe("Dashboard - Support Area Summary visibility", () => {
       });
     });
 
-    it("does NOT show Support Area Summary while loading even with full access", async () => {
+    it("does NOT show Support Area Summary while its feature flag is loading", async () => {
       mockUseAuth.mockReturnValue({
         user: {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["supportEngineer"],
+          roles: ["SUPPORT_ENGINEER"],
           teams: [],
         },
         isLoading: false,
@@ -329,19 +343,20 @@ describe("Dashboard - Support Area Summary visibility", () => {
         isLoading: false,
         error: null,
       } as any);
+      mockUseTenantInsightsEnabled.mockReturnValue({ data: true, isLoading: false, error: null } as any);
     });
 
-    it("hides all restricted tabs (Analytics, SLA, Support Area Summary) when hasFullAccess is false", async () => {
+    it("hides every restricted tab when the backend roles provide no capability", async () => {
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: false,
-        selectedTeam: "tenant-team",
+        hasUnrestrictedDataScope: true,
+        selectedTeam: null,
         setSelectedTeam: jest.fn(),
-        effectiveTeams: ["tenant-team"],
+        effectiveTeams: [],
         allTeams: ["tenant-team"],
         initialized: true,
-        teamScope: { mode: "selected_teams" as const, teams: ["tenant-team"] },
+        teamScope: { mode: "all_teams" as const },
         hasNoTeamScope: false,
-        isViewingAllTeams: false,
+        isViewingAllTeams: true,
         isViewingAsEscalationTeam: false,
       });
 
@@ -350,7 +365,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["user"],
+          roles: ["USER"],
           teams: [],
         },
         isLoading: false,
@@ -368,24 +383,26 @@ describe("Dashboard - Support Area Summary visibility", () => {
         expect(screen.queryByText("Analytics & Operations")).not.toBeInTheDocument();
         expect(screen.queryByText("SLA Dashboard")).not.toBeInTheDocument();
         expect(screen.queryByText("Support Area Summary")).not.toBeInTheDocument();
+        expect(screen.queryByText("Tenant Requests")).not.toBeInTheDocument();
       });
     });
 
-    it("shows all restricted tabs (except Support Area Summary) when hasFullAccess is true and feature disabled", async () => {
+    it("keeps feature flags independent from the role capability", async () => {
       mockUseKnowledgeGapsEnabled.mockReturnValue({
         data: false,
         isLoading: false,
         error: null,
       } as any);
+      mockUseTenantInsightsEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
 
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: true,
-        selectedTeam: null,
+        hasUnrestrictedDataScope: false,
+        selectedTeam: "tenant-team",
         setSelectedTeam: jest.fn(),
-        effectiveTeams: [],
-        allTeams: [],
+        effectiveTeams: ["tenant-team"],
+        allTeams: ["tenant-team"],
         initialized: true,
-        teamScope: { mode: "uninitialized" as const },
+        teamScope: { mode: "selected_teams" as const, teams: ["tenant-team"] },
         hasNoTeamScope: false,
         isViewingAllTeams: false,
         isViewingAsEscalationTeam: false,
@@ -396,7 +413,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["supportEngineer"],
+          roles: ["SUPPORT_ENGINEER"],
           teams: [],
         },
         isLoading: false,
@@ -414,12 +431,54 @@ describe("Dashboard - Support Area Summary visibility", () => {
         expect(screen.getByText("Analytics & Operations")).toBeInTheDocument();
         expect(screen.getByText("SLA Dashboard")).toBeInTheDocument();
         expect(screen.queryByText("Support Area Summary")).not.toBeInTheDocument();
+        expect(screen.queryByText("Tenant Requests")).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows each feature-enabled restricted tab while viewing a selected team", async () => {
+      mockUseTenantInsightsEnabled.mockReturnValue({ data: true, isLoading: false, error: null } as any);
+      mockUseTeamFilter.mockReturnValue({
+        hasUnrestrictedDataScope: false,
+        selectedTeam: "tenant-team",
+        setSelectedTeam: jest.fn(),
+        effectiveTeams: ["tenant-team"],
+        allTeams: ["tenant-team"],
+        initialized: true,
+        teamScope: { mode: "selected_teams" as const, teams: ["tenant-team"] },
+        hasNoTeamScope: false,
+        isViewingAllTeams: false,
+        isViewingAsEscalationTeam: false,
+      });
+      mockUseAuth.mockReturnValue({
+        user: {
+          id: "leader@example.com",
+          name: "Leader",
+          email: "leader@example.com",
+          roles: ["LEADERSHIP"],
+          teams: [],
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        logout: jest.fn(),
+        isLeadership: true,
+        isEscalationTeam: false,
+        isSupportEngineer: false,
+        actualEscalationTeams: [],
+      });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText("Analytics & Operations")).toBeInTheDocument();
+        expect(screen.getByText("SLA Dashboard")).toBeInTheDocument();
+        expect(screen.getByText("Support Area Summary")).toBeInTheDocument();
+        expect(screen.getByText("Tenant Requests")).toBeInTheDocument();
       });
     });
 
     it("shows all basic tabs for any authenticated user", async () => {
       mockUseTeamFilter.mockReturnValue({
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         selectedTeam: "tenant-team",
         setSelectedTeam: jest.fn(),
         effectiveTeams: ["tenant-team"],
@@ -436,7 +495,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
           id: "user@example.com",
           name: "User",
           email: "user@example.com",
-          roles: ["user"],
+          roles: ["USER"],
           teams: [],
         },
         isLoading: false,

--- a/ui/src/app/api/dashboard/[endpoint]/route.test.ts
+++ b/ui/src/app/api/dashboard/[endpoint]/route.test.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from "next/server";
+import { backendFetch } from "../../_lib/backend-fetch";
+import { GET } from "./route";
+
+jest.mock("../../_lib/backend-fetch", () => ({
+  backendFetch: jest.fn(),
+  errorResponse: (message: string, status = 500) => ({ status, json: async () => ({ error: message }) }),
+  unauthorizedResponse: () => ({ status: 401, json: async () => ({ error: "Unauthorized" }) }),
+}));
+
+const mockBackendFetch = backendFetch as jest.MockedFunction<typeof backendFetch>;
+
+describe("dashboard BFF route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes the authenticated request to the backend without making a UI role decision", async () => {
+    mockBackendFetch.mockResolvedValue({ ok: false, status: 403 } as Response);
+    const request = {
+      nextUrl: new URL("http://localhost/api/dashboard/unattended-queries-count"),
+    } as unknown as NextRequest;
+
+    const response = await GET(request, { params: Promise.resolve({ endpoint: "unattended-queries-count" }) });
+
+    expect(mockBackendFetch).toHaveBeenCalledWith(request, "/dashboard/unattended-queries-count");
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Backend error: 403" });
+  });
+
+  it("returns 401 when the authenticated backend fetch has no session token", async () => {
+    mockBackendFetch.mockResolvedValue(null);
+    const request = {
+      nextUrl: new URL("http://localhost/api/dashboard/unattended-queries-count"),
+    } as unknown as NextRequest;
+
+    const response = await GET(request, { params: Promise.resolve({ endpoint: "unattended-queries-count" }) });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/ui/src/app/api/dashboard/[endpoint]/route.ts
+++ b/ui/src/app/api/dashboard/[endpoint]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 import { backendFetch, errorResponse, unauthorizedResponse } from "../../_lib/backend-fetch";
 
 const FORWARDED_QUERY_PARAMS = ["dateFrom", "dateTo", "allTime", "granularity"] as const;

--- a/ui/src/auth.config.ts
+++ b/ui/src/auth.config.ts
@@ -1,4 +1,5 @@
 import { publicFetch } from "@/app/api/_lib/public-fetch";
+import { normalizeBackendRoles } from "@/lib/auth/capabilities";
 import { isOauthUiKnownProvider } from "@/lib/auth/oauth-ui-callback";
 import type { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
@@ -129,7 +130,7 @@ export const authConfig: NextAuthConfig = {
               ...t,
               name: t.code || t.label,
             })),
-            roles: userData.roles as string[],
+            roles: normalizeBackendRoles(userData.roles),
             accessToken: tokenResult.token,
           };
         } catch (error) {
@@ -177,7 +178,7 @@ export const authConfig: NextAuthConfig = {
                       ...t,
                       name: t.code || t.label,
                     })),
-                    roles: userData.roles as string[],
+                    roles: normalizeBackendRoles(userData.roles),
                     accessToken: json.token,
                   };
                 } else {
@@ -213,7 +214,7 @@ export const authConfig: NextAuthConfig = {
         token.email = user.email!;
         token.name = user.name!;
         token.teams = user.teams as AuthTeam[];
-        token.roles = user.roles as string[];
+        token.roles = normalizeBackendRoles(user.roles);
       }
       return token;
     },
@@ -224,7 +225,7 @@ export const authConfig: NextAuthConfig = {
         session.user.email = token.email as string;
         session.user.name = token.name as string;
         session.user.teams = token.teams as AuthTeam[];
-        session.user.roles = token.roles as string[];
+        session.user.roles = normalizeBackendRoles(token.roles);
       }
       return session;
     },

--- a/ui/src/components/AccessDenied.tsx
+++ b/ui/src/components/AccessDenied.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/hooks/useAuth";
+import { hasUiCapability, UI_CAPABILITIES } from "@/lib/auth/capabilities";
 import { LogOut, ShieldX } from "lucide-react";
 
 export function AccessDenied() {
@@ -44,7 +45,7 @@ export function AccessDenied() {
 }
 
 export function RequireDashboardAccess({ children }: { children: React.ReactNode }) {
-  const { isLeadership, isSupportEngineer, isLoading } = useAuth();
+  const { user, isLoading } = useAuth();
 
   if (isLoading) {
     return (
@@ -57,7 +58,7 @@ export function RequireDashboardAccess({ children }: { children: React.ReactNode
     );
   }
 
-  if (!isLeadership && !isSupportEngineer) {
+  if (!hasUiCapability(user?.roles, UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS)) {
     return <AccessDenied />;
   }
 

--- a/ui/src/components/__tests__/AccessDenied.test.tsx
+++ b/ui/src/components/__tests__/AccessDenied.test.tsx
@@ -64,7 +64,15 @@ describe("AccessDenied", () => {
 
 describe("RequireDashboardAccess", () => {
   it("renders children for support engineers", () => {
-    mockAuth({ isSupportEngineer: true });
+    mockAuth({
+      user: {
+        id: "support-1",
+        email: "support@example.com",
+        name: "Support Engineer",
+        teams: [],
+        roles: ["SUPPORT_ENGINEER"],
+      },
+    });
     render(
       <RequireDashboardAccess>
         <div data-testid="protected-content">Dashboard</div>
@@ -76,7 +84,15 @@ describe("RequireDashboardAccess", () => {
   });
 
   it("renders children for leadership", () => {
-    mockAuth({ isLeadership: true });
+    mockAuth({
+      user: {
+        id: "leader-1",
+        email: "leader@example.com",
+        name: "Leader",
+        teams: [],
+        roles: ["LEADERSHIP"],
+      },
+    });
     render(
       <RequireDashboardAccess>
         <div data-testid="protected-content">Dashboard</div>
@@ -86,8 +102,17 @@ describe("RequireDashboardAccess", () => {
     expect(screen.getByTestId("protected-content")).toBeInTheDocument();
   });
 
-  it("shows access denied for users without required roles", () => {
-    mockAuth({ isLeadership: false, isSupportEngineer: false });
+  it("shows access denied for users without the required backend-issued role", () => {
+    mockAuth({
+      user: {
+        id: "escalation-1",
+        email: "escalation@example.com",
+        name: "Escalation User",
+        teams: [],
+        roles: ["USER", "ESCALATION"],
+      },
+      isEscalationTeam: true,
+    });
     render(
       <RequireDashboardAccess>
         <div data-testid="protected-content">Dashboard</div>

--- a/ui/src/components/__tests__/AccessDenied.test.tsx
+++ b/ui/src/components/__tests__/AccessDenied.test.tsx
@@ -123,6 +123,30 @@ describe("RequireDashboardAccess", () => {
     expect(screen.getByText(/Access Restricted/i)).toBeInTheDocument();
   });
 
+  it.each([
+    ["the user is absent", null],
+    [
+      "the roles array is empty",
+      {
+        id: "user-1",
+        email: "user@example.com",
+        name: "User",
+        teams: [],
+        roles: [],
+      },
+    ],
+  ])("shows access denied when %s", (_description, user) => {
+    mockAuth({ user });
+    render(
+      <RequireDashboardAccess>
+        <div data-testid="protected-content">Dashboard</div>
+      </RequireDashboardAccess>
+    );
+
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+    expect(screen.getByText(/Access Restricted/i)).toBeInTheDocument();
+  });
+
   it("shows loading spinner while auth is loading", () => {
     mockAuth({ isLoading: true });
     render(

--- a/ui/src/components/dashboard-layout/app-sidebar.tsx
+++ b/ui/src/components/dashboard-layout/app-sidebar.tsx
@@ -10,10 +10,13 @@ import { NavMain } from "@/components/dashboard-layout/nav-main";
 import {
   Sidebar,
   SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSkeleton,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useAuth } from "@/hooks/useAuth";
@@ -73,7 +76,7 @@ const SUPPORT_TABS: SupportTab[] = [
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname();
   const { state } = useSidebar();
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
   const { data: isKnowledgeGapsEnabled } = useKnowledgeGapsEnabled();
   const { data: isTenantInsightsEnabled } = useTenantInsightsEnabled();
 
@@ -119,8 +122,21 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
-      <SidebarContent>
-        <NavMain groups={navGroups} />
+      <SidebarContent aria-busy={isLoading || undefined}>
+        {isLoading ? (
+          <SidebarGroup>
+            <SidebarGroupLabel>Support</SidebarGroupLabel>
+            <SidebarMenu>
+              {Array.from({ length: 7 }, (_, index) => (
+                <SidebarMenuItem key={index}>
+                  <SidebarMenuSkeleton showIcon />
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroup>
+        ) : (
+          <NavMain groups={navGroups} />
+        )}
       </SidebarContent>
     </Sidebar>
   );

--- a/ui/src/components/dashboard-layout/app-sidebar.tsx
+++ b/ui/src/components/dashboard-layout/app-sidebar.tsx
@@ -16,7 +16,8 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { useTeamFilter } from "@/contexts/TeamFilterContext";
+import { useAuth } from "@/hooks/useAuth";
+import { type UiCapability, hasUiCapability, UI_CAPABILITIES } from "@/lib/auth/capabilities";
 import { useKnowledgeGapsEnabled, useTenantInsightsEnabled } from "@/lib/hooks";
 
 type NavItem = {
@@ -28,7 +29,7 @@ type NavItem = {
 };
 
 type TabVisibility = {
-  requiresFullAccess?: boolean;
+  requiredCapability?: UiCapability;
   requiresFeatureFlag?: "knowledgeGaps" | "tenantInsights";
 };
 
@@ -47,32 +48,32 @@ const SUPPORT_TABS: SupportTab[] = [
     path: "/knowledge-gaps",
     title: "Support Area Summary",
     icon: BookOpen,
-    visibility: { requiresFullAccess: true, requiresFeatureFlag: "knowledgeGaps" },
+    visibility: { requiredCapability: UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS, requiresFeatureFlag: "knowledgeGaps" },
   },
   {
     path: "/health",
     title: "Analytics & Operations",
     icon: Activity,
-    visibility: { requiresFullAccess: true },
+    visibility: { requiredCapability: UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS },
   },
   {
     path: "/sla",
     title: "SLA Dashboard",
     icon: GaugeCircle,
-    visibility: { requiresFullAccess: true },
+    visibility: { requiredCapability: UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS },
   },
   {
     path: "/tenant-requests",
     title: "Tenant Requests",
     icon: GitPullRequest,
-    visibility: { requiresFullAccess: true, requiresFeatureFlag: "tenantInsights" },
+    visibility: { requiredCapability: UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS, requiresFeatureFlag: "tenantInsights" },
   },
 ];
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname();
   const { state } = useSidebar();
-  const { hasFullAccess } = useTeamFilter();
+  const { user } = useAuth();
   const { data: isKnowledgeGapsEnabled } = useKnowledgeGapsEnabled();
   const { data: isTenantInsightsEnabled } = useTenantInsightsEnabled();
 
@@ -84,7 +85,7 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const isVisible = (tab: SupportTab) => {
     const v = tab.visibility;
     if (!v) return true;
-    if (v.requiresFullAccess && !hasFullAccess) return false;
+    if (v.requiredCapability && !hasUiCapability(user?.roles, v.requiredCapability)) return false;
     if (v.requiresFeatureFlag && flags[v.requiresFeatureFlag] !== true) return false;
     return true;
   };

--- a/ui/src/components/dashboards/__tests__/dashboards.shell.test.tsx
+++ b/ui/src/components/dashboards/__tests__/dashboards.shell.test.tsx
@@ -15,7 +15,7 @@ jest.mock("../../../hooks/useAuth", () => ({
 
 jest.mock("../../../contexts/TeamFilterContext", () => ({
   useTeamFilter: () => ({
-    hasFullAccess: true,
+    hasUnrestrictedDataScope: true,
   }),
 }));
 

--- a/ui/src/components/escalations/__tests__/EscalatedToMyTeamTable.test.tsx
+++ b/ui/src/components/escalations/__tests__/EscalatedToMyTeamTable.test.tsx
@@ -119,7 +119,7 @@ describe("EscalatedToMyTeamTable", () => {
     mockUseTeamFilter.mockReturnValue({
       selectedTeam: "Core-platform",
       setSelectedTeam: jest.fn(),
-      hasFullAccess: false,
+      hasUnrestrictedDataScope: false,
       effectiveTeams: ["Core-platform"],
       allTeams: ["Core-platform"],
       initialized: true,
@@ -143,7 +143,7 @@ describe("EscalatedToMyTeamTable", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: "Other-team", // Not an escalation team
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: ["Other-team"],
         allTeams: ["Core-platform", "Other-team"],
         initialized: true,

--- a/ui/src/components/escalations/__tests__/EscalatedToMyTeamWidget.test.tsx
+++ b/ui/src/components/escalations/__tests__/EscalatedToMyTeamWidget.test.tsx
@@ -107,7 +107,7 @@ describe("EscalatedToMyTeamWidget", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: "Core-platform",
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: ["Core-platform"],
         allTeams: ["Core-platform"],
         initialized: true,
@@ -140,7 +140,7 @@ describe("EscalatedToMyTeamWidget", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: "Other-team", // Not an escalation team
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: ["Other-team"],
         allTeams: ["Core-platform", "Other-team"],
         initialized: true,
@@ -173,7 +173,7 @@ describe("EscalatedToMyTeamWidget", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: "Core-platform",
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: ["Core-platform"],
         allTeams: ["Core-platform"],
         initialized: true,
@@ -206,7 +206,7 @@ describe("EscalatedToMyTeamWidget", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: null, // No team selected
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: [],
         allTeams: ["Core-platform"],
         initialized: true,
@@ -241,7 +241,7 @@ describe("EscalatedToMyTeamWidget", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: "Core-platform",
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: ["Core-platform"],
         allTeams: ["Core-platform"],
         initialized: true,
@@ -320,7 +320,7 @@ describe("EscalatedToMyTeamWidget", () => {
       mockUseTeamFilter.mockReturnValue({
         selectedTeam: "Core-platform",
         setSelectedTeam: jest.fn(),
-        hasFullAccess: false,
+        hasUnrestrictedDataScope: false,
         effectiveTeams: ["Core-platform"],
         allTeams: ["Core-platform"],
         initialized: true,

--- a/ui/src/components/escalations/__tests__/escalations.test.tsx
+++ b/ui/src/components/escalations/__tests__/escalations.test.tsx
@@ -67,7 +67,7 @@ describe("EscalationsPage", () => {
       hasNoTeamScope: false,
       isViewingAllTeams: false,
       isViewingAsEscalationTeam: true,
-      hasFullAccess: false,
+      hasUnrestrictedDataScope: false,
       allTeams: ["Escalation Team 2 Test"],
       initialized: true,
     });
@@ -124,7 +124,7 @@ describe("EscalationsPage", () => {
       hasNoTeamScope: false,
       isViewingAllTeams: false,
       isViewingAsEscalationTeam: true,
-      hasFullAccess: false,
+      hasUnrestrictedDataScope: false,
       allTeams: ["Escalation Team 2 Test"],
       initialized: true,
     });
@@ -178,7 +178,7 @@ describe("EscalationsPage", () => {
       hasNoTeamScope: false,
       isViewingAllTeams: true,
       isViewingAsEscalationTeam: false,
-      hasFullAccess: true,
+      hasUnrestrictedDataScope: true,
       allTeams: [],
       initialized: true,
     });
@@ -239,7 +239,7 @@ describe("EscalationsPage", () => {
       hasNoTeamScope: false,
       isViewingAllTeams: true,
       isViewingAsEscalationTeam: false,
-      hasFullAccess: true,
+      hasUnrestrictedDataScope: true,
       allTeams: [],
       initialized: true,
     });
@@ -289,7 +289,7 @@ describe("EscalationsPage", () => {
       hasNoTeamScope: true,
       isViewingAllTeams: false,
       isViewingAsEscalationTeam: false,
-      hasFullAccess: false,
+      hasUnrestrictedDataScope: false,
       allTeams: [],
       initialized: true,
     });

--- a/ui/src/components/escalations/escalations.tsx
+++ b/ui/src/components/escalations/escalations.tsx
@@ -107,7 +107,7 @@ export default function EscalationsPage() {
   }, [params.dateFilter, params.dateFrom, params.dateTo, setParams]);
 
   const {
-    hasFullAccess,
+    hasUnrestrictedDataScope,
     effectiveTeams,
     hasNoTeamScope: contextHasNoTeamScope,
     isViewingAsEscalationTeam: contextIsViewingAsEscalationTeam,
@@ -224,7 +224,7 @@ export default function EscalationsPage() {
     // to match the home dashboard "Tickets We Own - Escalated" count.
     // Do not dedupe explicit tenant/all-team overrides: those should show raw escalation rows.
     const isCurrentScopeView = !selectedTeam;
-    if (isViewingAsEscalationTeam && !hasFullAccess && isCurrentScopeView) {
+    if (isViewingAsEscalationTeam && !hasUnrestrictedDataScope && isCurrentScopeView) {
       const ticketMap = new Map<string, (typeof baseEscalations)[0]>();
       baseEscalations.forEach((esc) => {
         const existing = ticketMap.get(esc.ticketId);
@@ -246,7 +246,7 @@ export default function EscalationsPage() {
     effectiveTeams,
     hasNoTeamScope,
     isViewingAsEscalationTeam,
-    hasFullAccess,
+    hasUnrestrictedDataScope,
     ALL_TEAMS_FILTER,
   ]);
 
@@ -315,7 +315,7 @@ export default function EscalationsPage() {
   const scopeLabel = effectiveTeams.length === 0 ? "All Teams" : effectiveTeams.map(teamLabel).join(", ");
   const teamFilterLabel = selectedTeam === ALL_TEAMS_FILTER ? "All Teams" : teamLabel(selectedTeam) || "Current Team Scope";
   const topTagsTitleSuffix = selectedTeam ? (selectedTeam === ALL_TEAMS_FILTER ? "for All Teams" : `for ${teamLabel(selectedTeam)}`) : "";
-  const showEscalatedForColumn = hasFullAccess || selectedTeam === ALL_TEAMS_FILTER;
+  const showEscalatedForColumn = hasUnrestrictedDataScope || selectedTeam === ALL_TEAMS_FILTER;
 
   return (
     <div className="space-y-6">

--- a/ui/src/components/stats/__tests__/stats.test.tsx
+++ b/ui/src/components/stats/__tests__/stats.test.tsx
@@ -3,7 +3,7 @@
  *
  * Tests the Home dashboard rendering and behavior:
  * - Role-based view (escalation team split view vs regular view)
- * - Team filtering (hasFullAccess vs restricted)
+ * - Team filtering (unrestricted vs selected data scope)
  * - Metrics calculations (total, open, resolved, escalated tickets)
  * - Loading and error states
  */
@@ -71,7 +71,7 @@ function makeTeamFilter(
     hasNoTeamScope: false,
     isViewingAllTeams: false,
     isViewingAsEscalationTeam: false,
-    hasFullAccess: false,
+    hasUnrestrictedDataScope: false,
     allTeams: [],
     initialized: false,
     ...overrides,
@@ -420,14 +420,14 @@ describe("StatsPage (Home Dashboard)", () => {
   });
 
   describe("Team Filtering", () => {
-    it("should render dashboard when hasFullAccess is true", () => {
+    it("should render dashboard when data scope is unrestricted", () => {
       mockUseTeamFilter.mockReturnValue(
         makeTeamFilter({
           selectedTeam: "Leadership",
           teamScope: { mode: "all_teams" },
           effectiveTeams: ["Team A", "Team B"],
           isViewingAllTeams: true,
-          hasFullAccess: true,
+          hasUnrestrictedDataScope: true,
           allTeams: ["Team A", "Team B"],
           initialized: true,
         })

--- a/ui/src/components/stats/stats.tsx
+++ b/ui/src/components/stats/stats.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useTeamFilter } from "@/contexts/TeamFilterContext";
 import { useAuth } from "@/hooks/useAuth";
+import { hasUiCapability, UI_CAPABILITIES } from "@/lib/auth/capabilities";
 import { TEAM_SCOPE } from "@/lib/constants";
 import { type DateFilter, getDateRangeFromFilter, PRESET_DAYS } from "@/lib/dateRange";
 import { useAllTickets, useIncomingVsResolvedRate, useRegistry } from "@/lib/hooks";
@@ -222,8 +223,8 @@ export default function StatsPage() {
     selectedTeam,
     isViewingAsEscalationTeam: contextIsViewingAsEscalationTeam,
   } = useTeamFilter();
-  const { user, actualEscalationTeams, isLeadership, isSupportEngineer } = useAuth();
-  const hasDashboardAccess = isLeadership || isSupportEngineer;
+  const { user, actualEscalationTeams } = useAuth();
+  const hasDashboardAccess = hasUiCapability(user?.roles, UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS);
   const hasNoTeamScope = contextHasNoTeamScope ?? effectiveTeams.includes(TEAM_SCOPE.NO_TEAMS);
   const isViewingAsEscalationTeam = contextIsViewingAsEscalationTeam ?? (!!selectedTeam && actualEscalationTeams.includes(selectedTeam));
   const chartTeams = useMemo(() => getIncomingResolvedTeamCodes(effectiveTeams, user?.teams ?? []), [effectiveTeams, user?.teams]);

--- a/ui/src/components/tickets/__tests__/tickets.test.tsx
+++ b/ui/src/components/tickets/__tests__/tickets.test.tsx
@@ -105,7 +105,7 @@ const mockUseTeamFilter = jest.requireMock("../../../contexts/TeamFilterContext"
     hasNoTeamScope: boolean;
     isViewingAllTeams: boolean;
     isViewingAsEscalationTeam: boolean;
-    hasFullAccess: boolean;
+    hasUnrestrictedDataScope: boolean;
     allTeams?: string[];
     initialized?: boolean;
   }
@@ -131,7 +131,7 @@ describe("Tickets Component", () => {
       hasNoTeamScope: false,
       isViewingAllTeams: true,
       isViewingAsEscalationTeam: false,
-      hasFullAccess: true,
+      hasUnrestrictedDataScope: true,
       allTeams: ["Team A", "Team B"],
       initialized: true,
     });

--- a/ui/src/contexts/TeamFilterContext.tsx
+++ b/ui/src/contexts/TeamFilterContext.tsx
@@ -17,7 +17,7 @@ type TeamFilterContextType = {
   hasNoTeamScope: boolean; // True when the user has no data teams and no role-wide access scope
   isViewingAllTeams: boolean; // True when effective scope is all teams (unfiltered)
   isViewingAsEscalationTeam: boolean; // True when sidebar scope is one of user's escalation teams
-  hasFullAccess: boolean; // true if should see all features (Leadership viewing All Teams)
+  hasUnrestrictedDataScope: boolean; // True when the selected scope permits data from every team
   allTeams: string[]; // Data teams available for selection (excludes role teams)
   initialized: boolean; // Whether the context has finished initializing
 };
@@ -77,11 +77,11 @@ export const TeamFilterProvider = ({ children }: { children: ReactNode }) => {
     return [];
   }, [teamScope]);
 
-  // Full access rules:
+  // Unrestricted data-scope rules:
   // - True if selected team is a role team (leadership/support) OR no team selected (all) AND user is leadership/support
   // - False if selected team is escalation
   // - False when selecting non-role tenant teams (even if user has leadership/support roles)
-  const hasFullAccess = useMemo(() => {
+  const hasUnrestrictedDataScope = useMemo(() => {
     const selected = user?.teams.find((t) => t.name === selectedTeam) || null;
     const selectedTypes = selected?.types || [];
     const selectedIsRole = selectedTypes.some((type) => /leadership/i.test(type) || /support/i.test(type));
@@ -121,7 +121,7 @@ export const TeamFilterProvider = ({ children }: { children: ReactNode }) => {
         hasNoTeamScope,
         isViewingAllTeams,
         isViewingAsEscalationTeam,
-        hasFullAccess,
+        hasUnrestrictedDataScope,
         allTeams,
         initialized,
       }}

--- a/ui/src/contexts/__tests__/TeamFilterContext.test.tsx
+++ b/ui/src/contexts/__tests__/TeamFilterContext.test.tsx
@@ -16,7 +16,7 @@ const Probe = () => {
     hasNoTeamScope,
     isViewingAllTeams,
     isViewingAsEscalationTeam,
-    hasFullAccess,
+    hasUnrestrictedDataScope,
     allTeams,
     initialized,
   } = useTeamFilter();
@@ -28,7 +28,7 @@ const Probe = () => {
       <div data-testid="has-no-team-scope">{String(hasNoTeamScope)}</div>
       <div data-testid="is-viewing-all-teams">{String(isViewingAllTeams)}</div>
       <div data-testid="is-viewing-as-escalation-team">{String(isViewingAsEscalationTeam)}</div>
-      <div data-testid="has-full-access">{String(hasFullAccess)}</div>
+      <div data-testid="has-unrestricted-data-scope">{String(hasUnrestrictedDataScope)}</div>
       <div data-testid="all-teams">{allTeams.join("|")}</div>
       <div data-testid="initialized">{String(initialized)}</div>
       <button onClick={() => setSelectedTeam("Tenant B")}>select-tenant-b</button>
@@ -119,7 +119,7 @@ describe("TeamFilterContext", () => {
     renderProvider();
 
     await waitFor(() => expect(screen.getByTestId("selected-team")).toHaveTextContent("Support"));
-    expect(screen.getByTestId("has-full-access")).toHaveTextContent("true");
+    expect(screen.getByTestId("has-unrestricted-data-scope")).toHaveTextContent("true");
     expect(screen.getByTestId("team-scope")).toHaveTextContent("all_teams");
     expect(screen.getByTestId("is-viewing-all-teams")).toHaveTextContent("true");
     expect(screen.getByTestId("effective-teams")).toHaveTextContent("");
@@ -156,7 +156,7 @@ describe("TeamFilterContext", () => {
     await waitFor(() => expect(screen.getByTestId("selected-team")).toHaveTextContent("Tenant B"));
     expect(screen.getByTestId("team-scope")).toHaveTextContent("selected_teams");
     expect(screen.getByTestId("effective-teams")).toHaveTextContent("Tenant B");
-    expect(screen.getByTestId("has-full-access")).toHaveTextContent("false");
+    expect(screen.getByTestId("has-unrestricted-data-scope")).toHaveTextContent("false");
   });
 
   it("flags escalation-team viewing when selected team is in escalation set", async () => {

--- a/ui/src/hooks/__tests__/useAuth.test.ts
+++ b/ui/src/hooks/__tests__/useAuth.test.ts
@@ -123,6 +123,17 @@ describe("useAuth", () => {
       expect(result.current.isEscalationTeam).toBe(false);
     });
 
+    it("fails closed when session roles are not an array", () => {
+      const user = createTestUser({ roles: "LEADERSHIP,SUPPORT_ENGINEER" as unknown as string[] });
+      mockUseSession.mockReturnValue(mockAuthenticatedSession(user));
+
+      const { result } = renderHook(() => useAuth());
+
+      expect(result.current.isLeadership).toBe(false);
+      expect(result.current.isSupportEngineer).toBe(false);
+      expect(result.current.isEscalationTeam).toBe(false);
+    });
+
     it("sets all role flags to false when user is null", () => {
       mockUseSession.mockReturnValue(mockUnauthenticatedSession());
 

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AuthTeam, AuthUser } from "@/auth.config";
+import { BACKEND_ROLES } from "@/lib/auth/capabilities";
 import { signOut, useSession } from "next-auth/react";
 import { useMemo } from "react";
 
@@ -22,9 +23,9 @@ export function useAuth(): UseAuthReturn {
   const isAuthenticated = status === "authenticated" && !!session?.user;
   const user = session?.user ?? null;
 
-  const isLeadership = user?.roles?.includes("LEADERSHIP") ?? false;
-  const isSupportEngineer = user?.roles?.includes("SUPPORT_ENGINEER") ?? false;
-  const isEscalationTeam = user?.roles?.includes("ESCALATION") ?? false;
+  const isLeadership = user?.roles?.includes(BACKEND_ROLES.LEADERSHIP) ?? false;
+  const isSupportEngineer = user?.roles?.includes(BACKEND_ROLES.SUPPORT_ENGINEER) ?? false;
+  const isEscalationTeam = user?.roles?.includes(BACKEND_ROLES.ESCALATION) ?? false;
 
   const actualEscalationTeams = useMemo(() => {
     if (!user || !isEscalationTeam) return [];

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { AuthTeam, AuthUser } from "@/auth.config";
-import { BACKEND_ROLES } from "@/lib/auth/capabilities";
+import { BACKEND_ROLES, normalizeBackendRoles } from "@/lib/auth/capabilities";
 import { signOut, useSession } from "next-auth/react";
 import { useMemo } from "react";
 
@@ -22,10 +22,11 @@ export function useAuth(): UseAuthReturn {
   const isLoading = status === "loading";
   const isAuthenticated = status === "authenticated" && !!session?.user;
   const user = session?.user ?? null;
+  const roles = normalizeBackendRoles(user?.roles);
 
-  const isLeadership = user?.roles?.includes(BACKEND_ROLES.LEADERSHIP) ?? false;
-  const isSupportEngineer = user?.roles?.includes(BACKEND_ROLES.SUPPORT_ENGINEER) ?? false;
-  const isEscalationTeam = user?.roles?.includes(BACKEND_ROLES.ESCALATION) ?? false;
+  const isLeadership = roles.includes(BACKEND_ROLES.LEADERSHIP);
+  const isSupportEngineer = roles.includes(BACKEND_ROLES.SUPPORT_ENGINEER);
+  const isEscalationTeam = roles.includes(BACKEND_ROLES.ESCALATION);
 
   const actualEscalationTeams = useMemo(() => {
     if (!user || !isEscalationTeam) return [];

--- a/ui/src/lib/auth/__tests__/capabilities.test.ts
+++ b/ui/src/lib/auth/__tests__/capabilities.test.ts
@@ -1,0 +1,20 @@
+import { hasUiCapability, UI_CAPABILITIES } from "../capabilities";
+
+describe("hasUiCapability", () => {
+  const capability = UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS;
+
+  it.each(["LEADERSHIP", "SUPPORT_ENGINEER"])("grants restricted dashboards to the %s role", (role) => {
+    expect(hasUiCapability(["USER", role], capability)).toBe(true);
+  });
+
+  it.each([["USER"], ["ESCALATION"], ["USER", "ESCALATION"], [], undefined, null])(
+    "denies restricted dashboards without a permitted backend role",
+    (roles) => {
+      expect(hasUiCapability(roles, capability)).toBe(false);
+    }
+  );
+
+  it("fails closed for unknown or differently-cased roles", () => {
+    expect(hasUiCapability(["leadership", "supportEngineer", "ADMIN"], capability)).toBe(false);
+  });
+});

--- a/ui/src/lib/auth/__tests__/capabilities.test.ts
+++ b/ui/src/lib/auth/__tests__/capabilities.test.ts
@@ -17,4 +17,17 @@ describe("hasUiCapability", () => {
   it("fails closed for unknown or differently-cased roles", () => {
     expect(hasUiCapability(["leadership", "supportEngineer", "ADMIN"], capability)).toBe(false);
   });
+
+  it.each([
+    ["a comma-delimited string", "USER,SUPPORT_ENGINEER"],
+    ["an object", { role: "SUPPORT_ENGINEER" }],
+    ["a number", 42],
+  ])("fails closed when roles is %s", (_description, roles) => {
+    expect(hasUiCapability(roles, capability)).toBe(false);
+  });
+
+  it("ignores non-string entries in a roles array", () => {
+    expect(hasUiCapability(["USER", 42, null, { role: "LEADERSHIP" }], capability)).toBe(false);
+    expect(hasUiCapability(["USER", 42, "SUPPORT_ENGINEER"], capability)).toBe(true);
+  });
 });

--- a/ui/src/lib/auth/capabilities.ts
+++ b/ui/src/lib/auth/capabilities.ts
@@ -1,0 +1,34 @@
+export const BACKEND_ROLES = {
+  USER: "USER",
+  LEADERSHIP: "LEADERSHIP",
+  SUPPORT_ENGINEER: "SUPPORT_ENGINEER",
+  ESCALATION: "ESCALATION",
+} as const;
+
+export type BackendRole = (typeof BACKEND_ROLES)[keyof typeof BACKEND_ROLES];
+
+export const UI_CAPABILITIES = {
+  VIEW_RESTRICTED_DASHBOARDS: "view-restricted-dashboards",
+} as const;
+
+export type UiCapability = (typeof UI_CAPABILITIES)[keyof typeof UI_CAPABILITIES];
+
+const KNOWN_BACKEND_ROLES: ReadonlySet<string> = new Set(Object.values(BACKEND_ROLES));
+
+const ROLES_BY_CAPABILITY: Readonly<Record<UiCapability, ReadonlySet<BackendRole>>> = {
+  [UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS]: new Set([BACKEND_ROLES.LEADERSHIP, BACKEND_ROLES.SUPPORT_ENGINEER]),
+};
+
+function isBackendRole(role: string): role is BackendRole {
+  return KNOWN_BACKEND_ROLES.has(role);
+}
+
+/**
+ * Derives a UI capability from the roles issued by the backend in the session.
+ * Unknown and differently-cased roles deliberately fail closed.
+ */
+export function hasUiCapability(roles: readonly string[] | null | undefined, capability: UiCapability): boolean {
+  if (!roles) return false;
+  const permittedRoles = ROLES_BY_CAPABILITY[capability];
+  return roles.some((role) => isBackendRole(role) && permittedRoles.has(role));
+}

--- a/ui/src/lib/auth/capabilities.ts
+++ b/ui/src/lib/auth/capabilities.ts
@@ -24,11 +24,21 @@ function isBackendRole(role: string): role is BackendRole {
 }
 
 /**
+ * Converts untrusted session/backend role data into the string-array shape
+ * consumed by the UI. Malformed values fail closed instead of reaching array
+ * operations in render paths.
+ */
+export function normalizeBackendRoles(roles: unknown): string[] {
+  if (!Array.isArray(roles)) return [];
+  return roles.filter((role): role is string => typeof role === "string");
+}
+
+/**
  * Derives a UI capability from the roles issued by the backend in the session.
  * Unknown and differently-cased roles deliberately fail closed.
  */
-export function hasUiCapability(roles: readonly string[] | null | undefined, capability: UiCapability): boolean {
-  if (!roles) return false;
+export function hasUiCapability(roles: unknown, capability: UiCapability): boolean {
+  const normalizedRoles = normalizeBackendRoles(roles);
   const permittedRoles = ROLES_BY_CAPABILITY[capability];
-  return roles.some((role) => isBackendRole(role) && permittedRoles.has(role));
+  return normalizedRoles.some((role) => isBackendRole(role) && permittedRoles.has(role));
 }


### PR DESCRIPTION
## Changes

- Derive restricted-dashboard visibility from backend-issued session roles through one shared UI capability policy.
- Keep selected-team state as data scope only and rename the context signal accordingly.
- Use the same capability for sidebar visibility, direct page guards, and restricted dashboard fragments.
- Keep Next.js BFF routes role-agnostic while preserving backend authorization responses.

## Why

Leadership and support engineers should retain authorized navigation when they narrow the data view to a tenant or escalation team. Keeping UI presentation capabilities separate from data scope also leaves Spring as the definitive authorization boundary.