### PR TITLE
feat(ui): add Products View tab to Analytics & Operations

### DIFF
--- a/ui/src/components/health/__tests__/health.test.tsx
+++ b/ui/src/components/health/__tests__/health.test.tsx
@@ -2,7 +2,7 @@
  * Health Dashboard Unit Tests
  *
  * Tests the Health dashboard rendering, tabs, and filtering:
- * - Tab navigation (Activity Trends, Ratings, Ticket Workbench)
+ * - Tab navigation (Activity Trends, Ratings, Ticket Workbench, Products View)
  * - Status, Rated, and Assignee filters in Ticket Workbench tab
  * - Loading and error states
  */
@@ -143,12 +143,13 @@ describe("HealthPage", () => {
       } as unknown as ReturnType<typeof hooks.useTickets>);
     });
 
-    it("renders all three tabs", () => {
+    it("renders all four tabs", () => {
       render(<HealthPage />, { wrapper: Wrapper });
 
       expect(screen.getByText("Activity Trends")).toBeInTheDocument();
       expect(screen.getByText("Ratings")).toBeInTheDocument();
       expect(screen.getByText("Ticket Workbench")).toBeInTheDocument();
+      expect(screen.getByText("Products View")).toBeInTheDocument();
     });
 
     it("defaults to Activity Trends tab", () => {

--- a/ui/src/components/health/__tests__/health.test.tsx
+++ b/ui/src/components/health/__tests__/health.test.tsx
@@ -7,7 +7,7 @@
  * - Loading and error states
  */
 
-import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
+import { clearMockUrlParamsInitial, useMockUrlParams as mockUseUrlParams, setMockUrlParamsInitial } from "@/test-utils/mock-url-params";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
@@ -39,6 +39,7 @@ jest.mock("../../../lib/hooks/useUrlParams", () => ({
 }));
 
 const mockUseTickets = hooks.useTickets as jest.MockedFunction<typeof hooks.useTickets>;
+const mockUseAllTickets = hooks.useAllTickets as jest.MockedFunction<typeof hooks.useAllTickets>;
 const mockUseRatings = hooks.useRatings as jest.MockedFunction<typeof hooks.useRatings>;
 const mockUseRegistry = hooks.useRegistry as jest.MockedFunction<typeof hooks.useRegistry>;
 const mockUseSupportMembers = hooks.useSupportMembers as jest.MockedFunction<typeof hooks.useSupportMembers>;
@@ -70,6 +71,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
 describe("HealthPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearMockUrlParamsInitial();
 
     mockUseRegistry.mockReturnValue({
       data: {
@@ -206,6 +208,52 @@ describe("HealthPage", () => {
 
       // Should show activity trends tab content (has date filter picklist with "Last Week")
       expect(screen.getByText(/Last Week/i)).toBeInTheDocument();
+    });
+
+    it("falls back to Activity Trends when deep-linked to Products View with no product tags", () => {
+      setMockUrlParamsInitial({ tab: "products" });
+      mockUseRegistry.mockReturnValue({
+        data: {
+          impacts: [],
+          tags: [{ code: "bug", label: "Bug" }],
+        },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+      render(<HealthPage />, { wrapper: Wrapper });
+
+      // The hidden view must not mount, and Activity Trends renders instead
+      expect(screen.queryByText("Products View")).not.toBeInTheDocument();
+      expect(screen.queryByText("Ticket counts per product tag")).not.toBeInTheDocument();
+      expect(screen.getByText(/Last Week/i)).toBeInTheDocument();
+    });
+
+    it("falls back to Activity Trends when deep-linked to Products View and the registry fails", () => {
+      setMockUrlParamsInitial({ tab: "products" });
+      mockUseRegistry.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error("registry down"),
+      } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+      render(<HealthPage />, { wrapper: Wrapper });
+
+      expect(screen.queryByText("Ticket counts per product tag")).not.toBeInTheDocument();
+      expect(screen.getByText(/Last Week/i)).toBeInTheDocument();
+    });
+
+    it("opens Products View from a deep link when product tags are configured", () => {
+      setMockUrlParamsInitial({ tab: "products" });
+      mockUseAllTickets.mockReturnValue({
+        data: { content: [], page: 0, totalPages: 1, totalElements: 0 },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+      render(<HealthPage />, { wrapper: Wrapper });
+
+      expect(screen.getByText("Ticket counts per product tag")).toBeInTheDocument();
     });
   });
 

--- a/ui/src/components/health/__tests__/health.test.tsx
+++ b/ui/src/components/health/__tests__/health.test.tsx
@@ -74,7 +74,10 @@ describe("HealthPage", () => {
     mockUseRegistry.mockReturnValue({
       data: {
         impacts: [{ code: "high", label: "High" }],
-        tags: [{ code: "bug", label: "Bug" }],
+        tags: [
+          { code: "bug", label: "Bug" },
+          { code: "product-alpha", label: "Product - Alpha" },
+        ],
       },
       isLoading: false,
       error: null,
@@ -150,6 +153,52 @@ describe("HealthPage", () => {
       expect(screen.getByText("Ratings")).toBeInTheDocument();
       expect(screen.getByText("Ticket Workbench")).toBeInTheDocument();
       expect(screen.getByText("Products View")).toBeInTheDocument();
+    });
+
+    it("hides the Products View tab when no product tags are configured", () => {
+      mockUseRegistry.mockReturnValue({
+        data: {
+          impacts: [{ code: "high", label: "High" }],
+          tags: [{ code: "bug", label: "Bug" }],
+        },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+      render(<HealthPage />, { wrapper: Wrapper });
+
+      expect(screen.queryByText("Products View")).not.toBeInTheDocument();
+      expect(screen.getByText("Activity Trends")).toBeInTheDocument();
+      expect(screen.getByText("Ratings")).toBeInTheDocument();
+      expect(screen.getByText("Ticket Workbench")).toBeInTheDocument();
+    });
+
+    it("hides the Products View tab when the only product tags are inactive", () => {
+      mockUseRegistry.mockReturnValue({
+        data: {
+          impacts: [],
+          tags: [{ code: "product-retired", label: "Product - Retired", active: false }],
+        },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+      render(<HealthPage />, { wrapper: Wrapper });
+
+      expect(screen.queryByText("Products View")).not.toBeInTheDocument();
+    });
+
+    it("hides the Products View tab while the registry is still loading", () => {
+      mockUseRegistry.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+      render(<HealthPage />, { wrapper: Wrapper });
+
+      expect(screen.queryByText("Products View")).not.toBeInTheDocument();
+      expect(screen.getByText("Activity Trends")).toBeInTheDocument();
     });
 
     it("defaults to Activity Trends tab", () => {

--- a/ui/src/components/health/health.tsx
+++ b/ui/src/components/health/health.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import LoadingSkeleton from "@/components/LoadingSkeleton";
+import ProductsPage from "@/components/products/products";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,7 +24,7 @@ import {
   TicketWithLogs,
 } from "@/lib/types";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ChevronDown, ClipboardList, Headphones, Star } from "lucide-react";
+import { AlertTriangle, ChevronDown, ClipboardList, Headphones, Package, Star } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
@@ -37,6 +38,7 @@ export default function HealthPage() {
     { key: "tickets" as const, label: "Activity Trends", icon: ClipboardList, color: "blue" },
     { key: "ratings" as const, label: "Ratings", icon: Star, color: "yellow" },
     { key: "workbench" as const, label: "Ticket Workbench", icon: Headphones, color: "purple" },
+    { key: "products" as const, label: "Products View", icon: Package, color: "green" },
   ];
 
   // Persist date filter mode, custom date range, and active tab in the URL.
@@ -47,12 +49,12 @@ export default function HealthPage() {
       dateFilter: enumValidator(["lastWeek", "last2Weeks", "lastMonth", "lastYear", "custom"] as const, "lastWeek"),
       dateFrom: isoDateValidator,
       dateTo: isoDateValidator,
-      tab: enumValidator(["tickets", "ratings", "workbench"] as const, "tickets"),
+      tab: enumValidator(["tickets", "ratings", "workbench", "products"] as const, "tickets"),
     }
   );
   // Safe to cast: validators guarantee these are valid enum values.
   const dateFilter = params.dateFilter as "lastWeek" | "last2Weeks" | "lastMonth" | "lastYear" | "custom";
-  const activeTab = params.tab as "tickets" | "ratings" | "workbench";
+  const activeTab = params.tab as "tickets" | "ratings" | "workbench" | "products";
 
   // Correct the URL when custom date range is in an invalid order (dateFrom > dateTo).
   useEffect(() => {
@@ -1636,6 +1638,8 @@ export default function HealthPage() {
               </div>
             </>
           )}
+
+          {activeTab === "products" && <ProductsPage dateRange={dateRange} />}
         </TabsContent>
       </Tabs>
     </div>

--- a/ui/src/components/health/health.tsx
+++ b/ui/src/components/health/health.tsx
@@ -58,15 +58,14 @@ export default function HealthPage() {
   );
   // Safe to cast: validators guarantee these are valid enum values.
   const dateFilter = params.dateFilter as "lastWeek" | "last2Weeks" | "lastMonth" | "lastYear" | "custom";
-  const activeTab = params.tab as "tickets" | "ratings" | "workbench" | "products";
+  const urlTab = params.tab as "tickets" | "ratings" | "workbench" | "products";
 
-  // A deep link or stale bookmark can still point at the hidden Products View
-  // tab; fall back to the default tab once the registry confirms no product tags.
-  useEffect(() => {
-    if (activeTab === "products" && registryData !== undefined && !productTagsConfigured) {
-      setParams({ tab: "tickets" });
-    }
-  }, [activeTab, registryData, productTagsConfigured, setParams]);
+  // A deep link or stale bookmark can point at the Products View tab while the
+  // registry is loading, errored, or has no product tags configured. Deriving
+  // the active tab (instead of correcting the URL from an effect) means the
+  // hidden view never mounts or fetches, and the URL's intent still wins if
+  // the registry later confirms product tags exist.
+  const activeTab = urlTab === "products" && !productTagsConfigured ? "tickets" : urlTab;
 
   // Correct the URL when custom date range is in an invalid order (dateFrom > dateTo).
   useEffect(() => {

--- a/ui/src/components/health/health.tsx
+++ b/ui/src/components/health/health.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import LoadingSkeleton from "@/components/LoadingSkeleton";
-import ProductsPage from "@/components/products/products";
+import ProductsPage, { hasActiveProductTags } from "@/components/products/products";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -34,11 +34,15 @@ export default function HealthPage() {
   const { data: isAssignmentEnabled } = useAssignmentEnabled();
   const queryClient = useQueryClient();
 
+  // The Products View tab only exists when the registry has active product tags,
+  // so it stays hidden while the registry loads and never flashes in and out.
+  const productTagsConfigured = hasActiveProductTags(registryData);
+
   const tabs = [
     { key: "tickets" as const, label: "Activity Trends", icon: ClipboardList, color: "blue" },
     { key: "ratings" as const, label: "Ratings", icon: Star, color: "yellow" },
     { key: "workbench" as const, label: "Ticket Workbench", icon: Headphones, color: "purple" },
-    { key: "products" as const, label: "Products View", icon: Package, color: "green" },
+    ...(productTagsConfigured ? [{ key: "products" as const, label: "Products View", icon: Package, color: "green" }] : []),
   ];
 
   // Persist date filter mode, custom date range, and active tab in the URL.
@@ -55,6 +59,14 @@ export default function HealthPage() {
   // Safe to cast: validators guarantee these are valid enum values.
   const dateFilter = params.dateFilter as "lastWeek" | "last2Weeks" | "lastMonth" | "lastYear" | "custom";
   const activeTab = params.tab as "tickets" | "ratings" | "workbench" | "products";
+
+  // A deep link or stale bookmark can still point at the hidden Products View
+  // tab; fall back to the default tab once the registry confirms no product tags.
+  useEffect(() => {
+    if (activeTab === "products" && registryData !== undefined && !productTagsConfigured) {
+      setParams({ tab: "tickets" });
+    }
+  }, [activeTab, registryData, productTagsConfigured, setParams]);
 
   // Correct the URL when custom date range is in an invalid order (dateFrom > dateTo).
   useEffect(() => {

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -1,0 +1,281 @@
+import { useMockUrlParams as mockUseUrlParams } from "@/test-utils/mock-url-params";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import React from "react";
+import * as hooks from "../../../lib/hooks";
+import Products from "../products";
+
+// Mock recharts to avoid rendering errors in tests
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+}));
+
+// Mock the hooks
+jest.mock("../../../lib/hooks");
+
+// Mock useUrlParams with a useState-based implementation so filter changes
+// re-render the component correctly.
+jest.mock("../../../lib/hooks/useUrlParams", () => ({
+  ...jest.requireActual("../../../lib/hooks/useUrlParams"),
+  useUrlParams: mockUseUrlParams,
+}));
+
+const mockUseAllTickets = hooks.useAllTickets as jest.MockedFunction<typeof hooks.useAllTickets>;
+const mockUseRegistry = hooks.useRegistry as jest.MockedFunction<typeof hooks.useRegistry>;
+
+// Mock team filter context
+jest.mock("../../../contexts/TeamFilterContext", () => ({
+  TeamFilterProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTeamFilter: jest.fn(),
+}));
+const mockUseTeamFilter = jest.requireMock("../../../contexts/TeamFilterContext").useTeamFilter as jest.MockedFunction<
+  () => {
+    effectiveTeams: string[];
+    hasNoTeamScope: boolean;
+  }
+>;
+
+const mockRegistry = {
+  impacts: [],
+  tags: [
+    { code: "product-alpha", label: "Product - Alpha" },
+    { code: "product-beta", label: "Product - Beta" },
+    { code: "product-retired", label: "Product - Retired", active: false },
+    { code: "bug", label: "Bug" },
+  ],
+};
+
+const createMockTicket = (id: string, tags: string[]): any => ({
+  id,
+  status: "opened",
+  team: { name: "Team A" },
+  tags,
+  escalations: [],
+  logs: [{ event: "opened", date: new Date().toISOString() }],
+});
+
+const getMockPaginatedTickets = (tickets: ReturnType<typeof createMockTicket>[]) => ({
+  content: tickets,
+  page: 0,
+  totalPages: 1,
+  totalElements: tickets.length,
+});
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+const renderProducts = () => render(<Products />, { wrapper: Wrapper });
+
+describe("Products Component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseTeamFilter.mockReturnValue({
+      effectiveTeams: [],
+      hasNoTeamScope: false,
+    });
+
+    mockUseRegistry.mockReturnValue({
+      data: mockRegistry,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+    mockUseAllTickets.mockReturnValue({
+      data: getMockPaginatedTickets([
+        createMockTicket("1", ["product-alpha", "bug"]),
+        createMockTicket("2", ["product-alpha"]),
+        createMockTicket("3", ["bug"]),
+        createMockTicket("4", ["product-alpha", "product-beta"]),
+      ]),
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+  });
+
+  it("renders the tab description", () => {
+    renderProducts();
+
+    expect(screen.getByText("Ticket counts per product tag")).toBeInTheDocument();
+  });
+
+  it("counts tickets per product tag with the prefix stripped", () => {
+    renderProducts();
+
+    const alphaRow = screen.getByText("Alpha").closest("tr")!;
+    expect(within(alphaRow).getByText("3")).toBeInTheDocument();
+
+    const betaRow = screen.getByText("Beta").closest("tr")!;
+    expect(within(betaRow).getByText("1")).toBeInTheDocument();
+
+    // Prefix is removed in the table
+    expect(screen.queryByText("Product - Alpha")).not.toBeInTheDocument();
+  });
+
+  it("counts tickets without a product tag under None", () => {
+    renderProducts();
+
+    // Ticket 3 only has the non-product "bug" tag
+    const noneRow = screen.getByText("None").closest("tr")!;
+    expect(within(noneRow).getByText("1")).toBeInTheDocument();
+  });
+
+  it("hides untagged tickets from the table and totals when the checkbox is checked", () => {
+    renderProducts();
+
+    fireEvent.click(screen.getByLabelText("Hide tickets without a product tag"));
+
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+    // Ticket 3 (untagged) is excluded entirely: 3 tickets remain and percentages rebase
+    const totalsRow = screen.getByText("Totals").closest("tr")!;
+    expect(within(totalsRow).getByText("3")).toBeInTheDocument();
+    const alphaRow = screen.getByText("Alpha").closest("tr")!;
+    expect(within(alphaRow).getByText("100.0%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Hide tickets without a product tag"));
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
+  it("shows each product's percentage of all tickets", () => {
+    renderProducts();
+
+    // Alpha appears on 3 of the 4 tickets
+    const alphaRow = screen.getByText("Alpha").closest("tr")!;
+    expect(within(alphaRow).getByText("75.0%")).toBeInTheDocument();
+
+    const betaRow = screen.getByText("Beta").closest("tr")!;
+    expect(within(betaRow).getByText("25.0%")).toBeInTheDocument();
+  });
+
+  it("renders a Totals row counting distinct tickets, always last regardless of sorting", () => {
+    renderProducts();
+
+    // Ticket 4 carries two product tags but counts once: 4 tickets, not the column sum of 5
+    const totalsRow = screen.getByText("Totals").closest("tr")!;
+    expect(within(totalsRow).getByText("4")).toBeInTheDocument();
+    expect(within(totalsRow).getByText("100.0%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Product"));
+    fireEvent.click(screen.getByText("Product"));
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[rows.length - 1]).getByText("Totals")).toBeInTheDocument();
+  });
+
+  it("does not list non-product tags", () => {
+    renderProducts();
+
+    expect(screen.queryByText("Bug")).not.toBeInTheDocument();
+  });
+
+  it("shows zero counts for active product tags with no tickets in range", () => {
+    mockUseAllTickets.mockReturnValue({
+      data: getMockPaginatedTickets([createMockTicket("1", ["bug"])]),
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+    renderProducts();
+
+    const alphaRow = screen.getByText("Alpha").closest("tr")!;
+    expect(within(alphaRow).getByText("0")).toBeInTheDocument();
+    // Retired product tags are not seeded
+    expect(screen.queryByText("Retired")).not.toBeInTheDocument();
+  });
+
+  it("scopes counts to the effective teams", () => {
+    mockUseTeamFilter.mockReturnValue({
+      effectiveTeams: ["Team B"],
+      hasNoTeamScope: false,
+    });
+
+    renderProducts();
+
+    // All mock tickets belong to Team A, so Alpha keeps its seeded zero count
+    const alphaRow = screen.getByText("Alpha").closest("tr")!;
+    expect(within(alphaRow).getByText("0")).toBeInTheDocument();
+  });
+
+  it("shows the no-team-access warning when the user has no team scope", () => {
+    mockUseTeamFilter.mockReturnValue({
+      effectiveTeams: [],
+      hasNoTeamScope: true,
+    });
+
+    renderProducts();
+
+    expect(screen.getByText("No Team Access")).toBeInTheDocument();
+  });
+
+  it("shows only the None row when there are no product tags", () => {
+    mockUseRegistry.mockReturnValue({
+      data: { impacts: [], tags: [{ code: "bug", label: "Bug" }] },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+    mockUseAllTickets.mockReturnValue({
+      data: getMockPaginatedTickets([createMockTicket("1", ["bug"])]),
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+    renderProducts();
+
+    const noneRow = screen.getByText("None").closest("tr")!;
+    expect(within(noneRow).getByText("1")).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(3); // header + None + Totals
+  });
+
+  it("sorts by count descending by default", () => {
+    renderProducts();
+
+    const rows = screen.getAllByRole("row").slice(1); // skip header row
+    const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
+    expect(products).toEqual(["Alpha", "Beta", "None", "Totals"]);
+  });
+
+  it("sorts by product name when the Product header is clicked and flips direction on second click", () => {
+    renderProducts();
+
+    fireEvent.click(screen.getByText("Product"));
+    let rows = screen.getAllByRole("row").slice(1);
+    let products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
+    expect(products).toEqual(["Alpha", "Beta", "None", "Totals"]);
+
+    fireEvent.click(screen.getByText("Product"));
+    rows = screen.getAllByRole("row").slice(1);
+    products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
+    expect(products).toEqual(["None", "Beta", "Alpha", "Totals"]);
+  });
+
+  it("flips count sort direction when the Tickets header is clicked", () => {
+    renderProducts();
+
+    fireEvent.click(screen.getByText("Tickets"));
+    const rows = screen.getAllByRole("row").slice(1);
+    const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
+    expect(products).toEqual(["Beta", "None", "Alpha", "Totals"]);
+  });
+
+  it("shows an error message when tickets fail to load", () => {
+    mockUseAllTickets.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("boom"),
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+    renderProducts();
+
+    expect(screen.getByText("Error loading products")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -217,7 +217,7 @@ describe("Products Component", () => {
     expect(screen.getByText("No Team Access")).toBeInTheDocument();
   });
 
-  it("shows only the None row when there are no product tags", () => {
+  it("shows an operator message instead of the chart and table when no product tags are configured", () => {
     mockUseRegistry.mockReturnValue({
       data: { impacts: [], tags: [{ code: "bug", label: "Bug" }] },
       isLoading: false,
@@ -231,9 +231,22 @@ describe("Products Component", () => {
 
     renderProducts();
 
-    const noneRow = screen.getByText("None").closest("tr")!;
-    expect(within(noneRow).getByText("1")).toBeInTheDocument();
-    expect(screen.getAllByRole("row")).toHaveLength(3); // header + None + Totals
+    expect(screen.getByText("No product tags configured yet")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Hide tickets without a product tag")).not.toBeInTheDocument();
+  });
+
+  it("treats a registry with only inactive product tags as not configured", () => {
+    mockUseRegistry.mockReturnValue({
+      data: { impacts: [], tags: [{ code: "product-retired", label: "Product - Retired", active: false }] },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+    renderProducts();
+
+    expect(screen.getByText("No product tags configured yet")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
   it("sorts by count descending by default", () => {

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -217,38 +217,6 @@ describe("Products Component", () => {
     expect(screen.getByText("No Team Access")).toBeInTheDocument();
   });
 
-  it("shows an operator message instead of the chart and table when no product tags are configured", () => {
-    mockUseRegistry.mockReturnValue({
-      data: { impacts: [], tags: [{ code: "bug", label: "Bug" }] },
-      isLoading: false,
-      error: null,
-    } as unknown as ReturnType<typeof hooks.useRegistry>);
-    mockUseAllTickets.mockReturnValue({
-      data: getMockPaginatedTickets([createMockTicket("1", ["bug"])]),
-      isLoading: false,
-      error: null,
-    } as unknown as ReturnType<typeof hooks.useAllTickets>);
-
-    renderProducts();
-
-    expect(screen.getByText("No product tags configured yet")).toBeInTheDocument();
-    expect(screen.queryByRole("table")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Hide tickets without a product tag")).not.toBeInTheDocument();
-  });
-
-  it("treats a registry with only inactive product tags as not configured", () => {
-    mockUseRegistry.mockReturnValue({
-      data: { impacts: [], tags: [{ code: "product-retired", label: "Product - Retired", active: false }] },
-      isLoading: false,
-      error: null,
-    } as unknown as ReturnType<typeof hooks.useRegistry>);
-
-    renderProducts();
-
-    expect(screen.getByText("No product tags configured yet")).toBeInTheDocument();
-    expect(screen.queryByRole("table")).not.toBeInTheDocument();
-  });
-
   it("sorts by count descending by default", () => {
     renderProducts();
 

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -207,6 +207,33 @@ describe("Products Component", () => {
     expect(products).toEqual(["Beta", "None", "Alpha", "Totals"]);
   });
 
+  it("shows the loading skeleton while the registry is still loading", () => {
+    mockUseRegistry.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+    const { container } = renderProducts();
+
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+    // No final-looking data while the code→label map is unavailable
+    expect(screen.queryByText("Totals")).not.toBeInTheDocument();
+  });
+
+  it("shows an error message when the registry fails to load", () => {
+    mockUseRegistry.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("registry down"),
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+
+    renderProducts();
+
+    expect(screen.getByText("Error loading products")).toBeInTheDocument();
+    expect(screen.queryByText("Totals")).not.toBeInTheDocument();
+  });
+
   it("shows an error message when tickets fail to load", () => {
     mockUseAllTickets.mockReturnValue({
       data: undefined,

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -106,47 +106,42 @@ describe("Products Component", () => {
     expect(screen.queryByText("Product - Alpha")).not.toBeInTheDocument();
   });
 
-  it("counts tickets without a product tag under None", () => {
+  it("excludes untagged tickets from rows, Totals, and the percentage denominator", () => {
     renderProducts();
 
-    // Ticket 3 only has the non-product "bug" tag
-    const noneRow = screen.getByText("None").closest("tr")!;
-    expect(within(noneRow).getByText("1")).toBeInTheDocument();
-  });
-
-  it("hides untagged tickets from the table and totals when the checkbox is checked", () => {
-    renderProducts();
-
-    fireEvent.click(screen.getByLabelText("Hide tickets without a product tag"));
-
+    // Ticket 3 only has the non-product "bug" tag: no None row, and it doesn't
+    // count — Totals is 3 (tickets 1, 2, 4) and Alpha's share is 3/3
     expect(screen.queryByText("None")).not.toBeInTheDocument();
-    // Ticket 3 (untagged) is excluded entirely: 3 tickets remain and percentages rebase
     const totalsRow = screen.getByText("Totals").closest("tr")!;
     expect(within(totalsRow).getByText("3")).toBeInTheDocument();
     const alphaRow = screen.getByText("Alpha").closest("tr")!;
     expect(within(alphaRow).getByText("100.0%")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText("Hide tickets without a product tag"));
-    expect(screen.getByText("None")).toBeInTheDocument();
   });
 
-  it("shows each product's percentage of all tickets", () => {
+  it("does not render a hide-untagged control", () => {
     renderProducts();
 
-    // Alpha appears on 3 of the 4 tickets
+    expect(screen.queryByLabelText("Hide tickets without a product tag")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("shows each product's percentage of product-tagged tickets", () => {
+    renderProducts();
+
+    // 3 tickets carry product tags; Alpha appears on all 3, Beta on 1
     const alphaRow = screen.getByText("Alpha").closest("tr")!;
-    expect(within(alphaRow).getByText("75.0%")).toBeInTheDocument();
+    expect(within(alphaRow).getByText("100.0%")).toBeInTheDocument();
 
     const betaRow = screen.getByText("Beta").closest("tr")!;
-    expect(within(betaRow).getByText("25.0%")).toBeInTheDocument();
+    expect(within(betaRow).getByText("33.3%")).toBeInTheDocument();
   });
 
-  it("renders a Totals row counting distinct tickets, always last regardless of sorting", () => {
+  it("renders a Totals row counting distinct product-tagged tickets, always last regardless of sorting", () => {
     renderProducts();
 
-    // Ticket 4 carries two product tags but counts once: 4 tickets, not the column sum of 5
+    // Ticket 4 carries two product tags but counts once: 3 tagged tickets, not the column sum of 4
     const totalsRow = screen.getByText("Totals").closest("tr")!;
-    expect(within(totalsRow).getByText("4")).toBeInTheDocument();
+    expect(within(totalsRow).getByText("3")).toBeInTheDocument();
     expect(within(totalsRow).getByText("100.0%")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Product"));
@@ -181,7 +176,7 @@ describe("Products Component", () => {
 
     const rows = screen.getAllByRole("row").slice(1); // skip header row
     const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Alpha", "Beta", "None", "Totals"]);
+    expect(products).toEqual(["Alpha", "Beta", "Totals"]);
   });
 
   it("sorts by product name when the Product header is clicked and flips direction on second click", () => {
@@ -190,12 +185,12 @@ describe("Products Component", () => {
     fireEvent.click(screen.getByText("Product"));
     let rows = screen.getAllByRole("row").slice(1);
     let products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Alpha", "Beta", "None", "Totals"]);
+    expect(products).toEqual(["Alpha", "Beta", "Totals"]);
 
     fireEvent.click(screen.getByText("Product"));
     rows = screen.getAllByRole("row").slice(1);
     products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["None", "Beta", "Alpha", "Totals"]);
+    expect(products).toEqual(["Beta", "Alpha", "Totals"]);
   });
 
   it("flips count sort direction when the Tickets header is clicked", () => {
@@ -204,7 +199,7 @@ describe("Products Component", () => {
     fireEvent.click(screen.getByText("Tickets"));
     const rows = screen.getAllByRole("row").slice(1);
     const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Beta", "None", "Alpha", "Totals"]);
+    expect(products).toEqual(["Beta", "Alpha", "Totals"]);
   });
 
   it("counts tickets tagged with a retired product under its own row", () => {
@@ -268,8 +263,10 @@ describe("Products Component", () => {
     renderProducts();
 
     // The prefix-only tag seeds no blank row; its ticket counts as untagged
-    const noneRow = screen.getByText("None").closest("tr")!;
-    expect(within(noneRow).getByText("1")).toBeInTheDocument();
+    // and is excluded entirely, leaving only the seeded Alpha row at zero
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+    const totalsRow = screen.getByText("Totals").closest("tr")!;
+    expect(within(totalsRow).getByText("0")).toBeInTheDocument();
   });
 
   describe("hasActiveProductTags", () => {

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -30,18 +30,6 @@ jest.mock("../../../lib/hooks/useUrlParams", () => ({
 const mockUseAllTickets = hooks.useAllTickets as jest.MockedFunction<typeof hooks.useAllTickets>;
 const mockUseRegistry = hooks.useRegistry as jest.MockedFunction<typeof hooks.useRegistry>;
 
-// Mock team filter context
-jest.mock("../../../contexts/TeamFilterContext", () => ({
-  TeamFilterProvider: ({ children }: { children: React.ReactNode }) => children,
-  useTeamFilter: jest.fn(),
-}));
-const mockUseTeamFilter = jest.requireMock("../../../contexts/TeamFilterContext").useTeamFilter as jest.MockedFunction<
-  () => {
-    effectiveTeams: string[];
-    hasNoTeamScope: boolean;
-  }
->;
-
 const mockRegistry = {
   impacts: [],
   tags: [
@@ -80,11 +68,6 @@ const renderProducts = () => render(<Products />, { wrapper: Wrapper });
 describe("Products Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockUseTeamFilter.mockReturnValue({
-      effectiveTeams: [],
-      hasNoTeamScope: false,
-    });
 
     mockUseRegistry.mockReturnValue({
       data: mockRegistry,
@@ -191,30 +174,6 @@ describe("Products Component", () => {
     expect(within(alphaRow).getByText("0")).toBeInTheDocument();
     // Retired product tags are not seeded
     expect(screen.queryByText("Retired")).not.toBeInTheDocument();
-  });
-
-  it("scopes counts to the effective teams", () => {
-    mockUseTeamFilter.mockReturnValue({
-      effectiveTeams: ["Team B"],
-      hasNoTeamScope: false,
-    });
-
-    renderProducts();
-
-    // All mock tickets belong to Team A, so Alpha keeps its seeded zero count
-    const alphaRow = screen.getByText("Alpha").closest("tr")!;
-    expect(within(alphaRow).getByText("0")).toBeInTheDocument();
-  });
-
-  it("shows the no-team-access warning when the user has no team scope", () => {
-    mockUseTeamFilter.mockReturnValue({
-      effectiveTeams: [],
-      hasNoTeamScope: true,
-    });
-
-    renderProducts();
-
-    expect(screen.getByText("No Team Access")).toBeInTheDocument();
   });
 
   it("sorts by count descending by default", () => {

--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
 import * as hooks from "../../../lib/hooks";
-import Products from "../products";
+import Products, { hasActiveProductTags } from "../products";
 
 // Mock recharts to avoid rendering errors in tests
 jest.mock("recharts", () => ({
@@ -205,6 +205,85 @@ describe("Products Component", () => {
     const rows = screen.getAllByRole("row").slice(1);
     const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
     expect(products).toEqual(["Beta", "None", "Alpha", "Totals"]);
+  });
+
+  it("counts tickets tagged with a retired product under its own row", () => {
+    mockUseAllTickets.mockReturnValue({
+      data: getMockPaginatedTickets([createMockTicket("1", ["product-retired"]), createMockTicket("2", ["product-alpha"])]),
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+    renderProducts();
+
+    // Retired products are not seeded, but their tickets still count when in range
+    const retiredRow = screen.getByText("Retired").closest("tr")!;
+    expect(within(retiredRow).getByText("1")).toBeInTheDocument();
+  });
+
+  it("tolerates case and dash variants in product tag labels", () => {
+    mockUseRegistry.mockReturnValue({
+      data: {
+        impacts: [],
+        tags: [
+          { code: "product-gamma", label: "Product – Gamma" }, // en dash
+          { code: "product-delta", label: "product - delta" }, // lowercase
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+    mockUseAllTickets.mockReturnValue({
+      data: getMockPaginatedTickets([createMockTicket("1", ["product-gamma"]), createMockTicket("2", ["product-delta"])]),
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+    renderProducts();
+
+    const gammaRow = screen.getByText("Gamma").closest("tr")!;
+    expect(within(gammaRow).getByText("1")).toBeInTheDocument();
+    const deltaRow = screen.getByText("delta").closest("tr")!;
+    expect(within(deltaRow).getByText("1")).toBeInTheDocument();
+  });
+
+  it("treats prefix-only labels as non-product tags", () => {
+    mockUseRegistry.mockReturnValue({
+      data: {
+        impacts: [],
+        tags: [
+          { code: "product-alpha", label: "Product - Alpha" },
+          { code: "product-empty", label: "Product -" },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useRegistry>);
+    mockUseAllTickets.mockReturnValue({
+      data: getMockPaginatedTickets([createMockTicket("1", ["product-empty"])]),
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof hooks.useAllTickets>);
+
+    renderProducts();
+
+    // The prefix-only tag seeds no blank row; its ticket counts as untagged
+    const noneRow = screen.getByText("None").closest("tr")!;
+    expect(within(noneRow).getByText("1")).toBeInTheDocument();
+  });
+
+  describe("hasActiveProductTags", () => {
+    it("ignores prefix-only labels", () => {
+      expect(hasActiveProductTags({ tags: [{ code: "p", label: "Product -" }] })).toBe(false);
+    });
+
+    it("accepts case and dash variants", () => {
+      expect(hasActiveProductTags({ tags: [{ code: "p", label: "product – alpha" }] })).toBe(true);
+    });
+
+    it("ignores inactive product tags", () => {
+      expect(hasActiveProductTags({ tags: [{ code: "p", label: "Product - Alpha", active: false }] })).toBe(false);
+    });
   });
 
   it("shows the loading skeleton while the registry is still loading", () => {

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -59,6 +59,11 @@ function SortableHeader({
   );
 }
 
+// Used by the Analytics & Operations page to hide the Products View tab
+// entirely when the registry has no active product tags.
+export const hasActiveProductTags = (registryData?: { tags?: TicketTag[] }): boolean =>
+  (registryData?.tags ?? []).some((tag) => tag.active !== false && tag.label.startsWith(PRODUCT_TAG_PREFIX));
+
 const stripProductPrefix = (label: string): string => label.slice(PRODUCT_TAG_PREFIX.length).trim();
 
 const formatPercentage = (count: number, total: number): string => (total > 0 ? `${((count / total) * 100).toFixed(1)}%` : "0.0%");
@@ -120,12 +125,6 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
   }, [ticketsContent, hasNoTeamScope, effectiveTeams]);
 
   const totalTickets = visibleTickets.length;
-
-  // Distinguish "no product tags configured" (registry has none) from "no tickets tagged".
-  // Only asserted once the registry has loaded, to avoid flashing the message.
-  const noProductTagsConfigured =
-    registryData !== undefined &&
-    !(registryData.tags ?? []).some((tag: TicketTag) => tag.active !== false && tag.label.startsWith(PRODUCT_TAG_PREFIX));
 
   const productCounts = useMemo(() => {
     const labelByCode = new Map<string, string>();
@@ -203,17 +202,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {noProductTagsConfigured && (
-        <div className="bg-card rounded-lg border p-8 text-center">
-          <p className="text-foreground font-semibold">No product tags configured yet</p>
-          <p className="text-muted-foreground mt-1 text-sm">
-            This view is powered by ticket tags labelled <code className="bg-muted rounded px-1 py-0.5">Product - &lt;name&gt;</code>.
-            Contact your support-bot operator to add some.
-          </p>
-        </div>
-      )}
-
-      {!noProductTagsConfigured && !ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && (
+      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && (
         <div className="flex items-center gap-2">
           <input
             id="hide-untagged"
@@ -228,7 +217,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {!noProductTagsConfigured && !ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && chartData.length > 0 && (
+      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && chartData.length > 0 && (
         <div className="bg-card rounded-lg border p-4">
           <h2 className="text-foreground mb-2 text-center font-semibold">Tickets by Product</h2>
           <div style={{ width: "100%", height: Math.max(200, chartData.length * 36 + 60) }}>
@@ -279,53 +268,51 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {!noProductTagsConfigured && (
-        <div className="overflow-hidden rounded-lg border">
-          {ticketsQuery.isLoading ? (
-            <LoadingSkeleton />
-          ) : ticketsQuery.error ? (
-            <div className="border-destructive/30 bg-destructive/10 text-destructive m-6 rounded-lg border p-4">
-              <p className="font-semibold">Error loading products</p>
-              <p className="mt-1 text-sm">Unable to load ticket data. Please try refreshing the page.</p>
-            </div>
-          ) : (
-            <Table>
-              <TableHeader className="bg-muted z-10">
+      <div className="overflow-hidden rounded-lg border">
+        {ticketsQuery.isLoading ? (
+          <LoadingSkeleton />
+        ) : ticketsQuery.error ? (
+          <div className="border-destructive/30 bg-destructive/10 text-destructive m-6 rounded-lg border p-4">
+            <p className="font-semibold">Error loading products</p>
+            <p className="mt-1 text-sm">Unable to load ticket data. Please try refreshing the page.</p>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader className="bg-muted z-10">
+              <TableRow>
+                <SortableHeader col="product" label="Product" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                <SortableHeader col="count" label="Tickets" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                <TableHead>% of Tickets</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedProducts.length === 0 ? (
                 <TableRow>
-                  <SortableHeader col="product" label="Product" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                  <SortableHeader col="count" label="Tickets" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                  <TableHead>% of Tickets</TableHead>
+                  <TableCell colSpan={3} className="text-muted-foreground py-8 text-center">
+                    No product tags found
+                  </TableCell>
                 </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sortedProducts.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={3} className="text-muted-foreground py-8 text-center">
-                      No product tags found
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  <>
-                    {sortedProducts.map(({ product, count }) => (
-                      <TableRow key={product}>
-                        <TableCell>{product}</TableCell>
-                        <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
-                        <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, displayedTotal)}</TableCell>
-                      </TableRow>
-                    ))}
-                    {/* Distinct tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
-                    <TableRow className="bg-muted/50 border-t font-semibold">
-                      <TableCell>Totals</TableCell>
-                      <TableCell className="font-mono text-sm tabular-nums">{displayedTotal}</TableCell>
-                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(displayedTotal, displayedTotal)}</TableCell>
+              ) : (
+                <>
+                  {sortedProducts.map(({ product, count }) => (
+                    <TableRow key={product}>
+                      <TableCell>{product}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, displayedTotal)}</TableCell>
                     </TableRow>
-                  </>
-                )}
-              </TableBody>
-            </Table>
-          )}
-        </div>
-      )}
+                  ))}
+                  {/* Distinct tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
+                  <TableRow className="bg-muted/50 border-t font-semibold">
+                    <TableCell>Totals</TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">{displayedTotal}</TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(displayedTotal, displayedTotal)}</TableCell>
+                  </TableRow>
+                </>
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import LoadingSkeleton from "@/components/LoadingSkeleton";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useTeamFilter } from "@/contexts/TeamFilterContext";
+import { TEAM_SCOPE } from "@/lib/constants";
+import { useAllTickets, useRegistry } from "@/lib/hooks";
+import { enumValidator, useUrlParams } from "@/lib/hooks/useUrlParams";
+import { normalizeTeamKey } from "@/lib/teamUtils";
+import { PaginatedTickets, TicketTag, TicketWithLogs } from "@/lib/types";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { useMemo } from "react";
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+const PRODUCT_TAG_PREFIX = "Product -";
+const NO_PRODUCT_LABEL = "None";
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-9)",
+  "var(--chart-10)",
+  "var(--chart-8)",
+];
+
+type SortColumn = "product" | "count";
+
+function SortableHeader({
+  col,
+  label,
+  sortColumn,
+  sortDirection,
+  onSort,
+}: {
+  col: SortColumn;
+  label: string;
+  sortColumn: SortColumn;
+  sortDirection: "asc" | "desc";
+  onSort: (column: SortColumn) => void;
+}) {
+  return (
+    <TableHead className="hover:bg-muted cursor-pointer transition-colors select-none" onClick={() => onSort(col)}>
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {sortColumn === col ? (
+          sortDirection === "asc" ? (
+            <ArrowUp className="h-3.5 w-3.5" />
+          ) : (
+            <ArrowDown className="h-3.5 w-3.5" />
+          )
+        ) : (
+          <ArrowUpDown className="text-muted-foreground h-3.5 w-3.5" />
+        )}
+      </span>
+    </TableHead>
+  );
+}
+
+const stripProductPrefix = (label: string): string => label.slice(PRODUCT_TAG_PREFIX.length).trim();
+
+const formatPercentage = (count: number, total: number): string => (total > 0 ? `${((count / total) * 100).toFixed(1)}%` : "0.0%");
+
+const getTagLabel = (tag: unknown): string => {
+  if (typeof tag === "string") return tag;
+  if (tag && typeof tag === "object") {
+    const obj = tag as { label?: string; code?: string };
+    return obj.label || obj.code || "";
+  }
+  return "";
+};
+
+export default function ProductsPage({ dateRange }: { dateRange?: { from?: string; to?: string } }) {
+  const { effectiveTeams, hasNoTeamScope: contextHasNoTeamScope } = useTeamFilter();
+  const hasNoTeamScope = contextHasNoTeamScope ?? effectiveTeams.includes(TEAM_SCOPE.NO_TEAMS);
+
+  const { data: registryData } = useRegistry();
+
+  const [params, setParams] = useUrlParams(
+    {
+      sortBy: "count",
+      sortDir: "desc",
+      hideUntagged: "false",
+    },
+    {
+      sortBy: enumValidator(["product", "count"] as const, "count"),
+      sortDir: enumValidator(["asc", "desc"] as const, "desc"),
+      hideUntagged: enumValidator(["true", "false"] as const, "false"),
+    }
+  );
+
+  // Casts are safe: sortBy and sortDir are guarded by enumValidators above.
+  const sortColumn = params.sortBy as SortColumn;
+  const sortDirection = params.sortDir as "asc" | "desc";
+  const hideUntagged = params.hideUntagged === "true";
+
+  const handleSort = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setParams({ sortDir: sortDirection === "asc" ? "desc" : "asc" });
+    } else {
+      setParams({ sortBy: column, sortDir: column === "count" ? "desc" : "asc" });
+    }
+  };
+
+  const ticketsQuery = useAllTickets(200, dateRange?.from, dateRange?.to, !hasNoTeamScope);
+  const ticketsData = ticketsQuery.data as PaginatedTickets | undefined;
+  const ticketsContent = useMemo(() => (ticketsData?.content as TicketWithLogs[] | undefined) ?? [], [ticketsData]);
+
+  // Scope tickets to the teams the user is viewing, mirroring the tickets page.
+  const visibleTickets = useMemo(() => {
+    if (hasNoTeamScope) return [];
+    if (effectiveTeams.length === 0) return ticketsContent;
+    return ticketsContent.filter((t: TicketWithLogs) => {
+      if (!t.team?.name) return false;
+      const ticketTeam = normalizeTeamKey(t.team.name);
+      return effectiveTeams.some((team) => normalizeTeamKey(team) === ticketTeam);
+    });
+  }, [ticketsContent, hasNoTeamScope, effectiveTeams]);
+
+  const totalTickets = visibleTickets.length;
+
+  const productCounts = useMemo(() => {
+    const labelByCode = new Map<string, string>();
+    (registryData?.tags ?? []).forEach((tag: TicketTag) => labelByCode.set(tag.code, tag.label));
+
+    const counts = new Map<string, number>();
+    // Seed with active registry product tags so products with no tickets in range still appear.
+    (registryData?.tags ?? []).forEach((tag: TicketTag) => {
+      if (tag.active !== false && tag.label.startsWith(PRODUCT_TAG_PREFIX)) {
+        counts.set(stripProductPrefix(tag.label), 0);
+      }
+    });
+    counts.set(NO_PRODUCT_LABEL, 0);
+
+    visibleTickets.forEach((t: TicketWithLogs) => {
+      // A ticket counts once per distinct product, even if tagged twice.
+      const products = new Set<string>();
+      (t.tags ?? []).forEach((code) => {
+        const label = labelByCode.get(code as string) || getTagLabel(code);
+        if (label.startsWith(PRODUCT_TAG_PREFIX)) products.add(stripProductPrefix(label));
+      });
+      if (products.size === 0) products.add(NO_PRODUCT_LABEL);
+      products.forEach((product) => counts.set(product, (counts.get(product) ?? 0) + 1));
+    });
+
+    return Array.from(counts, ([product, count]) => ({ product, count }));
+  }, [visibleTickets, registryData]);
+
+  // Hiding untagged tickets removes them entirely: no None row, and they leave
+  // the Totals count and percentage denominator too.
+  const noneCount = productCounts.find((p) => p.product === NO_PRODUCT_LABEL)?.count ?? 0;
+  const displayedCounts = useMemo(
+    () => (hideUntagged ? productCounts.filter((p) => p.product !== NO_PRODUCT_LABEL) : productCounts),
+    [productCounts, hideUntagged]
+  );
+  const displayedTotal = hideUntagged ? totalTickets - noneCount : totalTickets;
+
+  // The chart is a fixed magnitude ranking (largest first), independent of the table's sort.
+  const chartData = useMemo(
+    () => [...displayedCounts].sort((a, b) => b.count - a.count || a.product.localeCompare(b.product)),
+    [displayedCounts]
+  );
+
+  // Hues are assigned by alphabetical position, not rank, so a product keeps its
+  // color when counts shift between date ranges. "None" stays gray (catch-all).
+  const colorByProduct = useMemo(() => {
+    const products = productCounts
+      .map((p) => p.product)
+      .filter((p) => p !== NO_PRODUCT_LABEL)
+      .sort((a, b) => a.localeCompare(b));
+    return new Map(products.map((p, idx) => [p, CHART_COLORS[idx % CHART_COLORS.length]]));
+  }, [productCounts]);
+
+  const sortedProducts = useMemo(() => {
+    return [...displayedCounts].sort((a, b) => {
+      if (sortColumn === "count") {
+        const cmp = a.count - b.count;
+        // Ties stay alphabetical regardless of sort direction
+        if (cmp === 0) return a.product.localeCompare(b.product);
+        return sortDirection === "asc" ? cmp : -cmp;
+      }
+      const cmp = a.product.localeCompare(b.product);
+      return sortDirection === "asc" ? cmp : -cmp;
+    });
+  }, [displayedCounts, sortColumn, sortDirection]);
+
+  return (
+    <div className="space-y-6">
+      <p className="text-muted-foreground text-sm">Ticket counts per product tag</p>
+
+      {hasNoTeamScope && (
+        <div className="border-warning/30 bg-warning/10 text-warning rounded-lg border p-4">
+          <p className="font-semibold">No Team Access</p>
+          <p className="mt-1 text-sm">You are not assigned to any teams, so product ticket counts cannot be displayed.</p>
+        </div>
+      )}
+
+      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && (
+        <div className="flex items-center gap-2">
+          <input
+            id="hide-untagged"
+            type="checkbox"
+            checked={hideUntagged}
+            onChange={(e) => setParams({ hideUntagged: e.target.checked ? "true" : "false" })}
+            className="accent-primary h-4 w-4 cursor-pointer"
+          />
+          <Label htmlFor="hide-untagged" className="cursor-pointer font-normal">
+            Hide tickets without a product tag
+          </Label>
+        </div>
+      )}
+
+      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && chartData.length > 0 && (
+        <div className="bg-card rounded-lg border p-4">
+          <h2 className="text-foreground mb-2 text-center font-semibold">Tickets by Product</h2>
+          <div style={{ width: "100%", height: Math.max(200, chartData.length * 36 + 60) }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} layout="vertical" margin={{ left: 16, right: 24 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+                <XAxis
+                  type="number"
+                  allowDecimals={false}
+                  stroke="var(--border)"
+                  tick={{ fill: "var(--muted-foreground)", fontSize: 11 }}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="product"
+                  width={120}
+                  stroke="var(--border)"
+                  tick={{ fill: "var(--muted-foreground)", fontSize: 11 }}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: "var(--popover)",
+                    color: "var(--popover-foreground)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "8px",
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                  }}
+                  labelStyle={{ color: "var(--popover-foreground)" }}
+                  itemStyle={{ color: "var(--popover-foreground)" }}
+                  cursor={{ fill: "var(--accent)" }}
+                  formatter={(value: number) => [`${value} (${formatPercentage(value, displayedTotal)})`, "Tickets"]}
+                />
+                <Bar dataKey="count" fill="var(--chart-1)" barSize={20} radius={[0, 4, 4, 0]}>
+                  {chartData.map((entry) => (
+                    <Cell
+                      key={entry.product}
+                      fill={
+                        entry.product === NO_PRODUCT_LABEL
+                          ? "var(--muted-foreground)"
+                          : (colorByProduct.get(entry.product) ?? "var(--chart-1)")
+                      }
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-lg border">
+        {ticketsQuery.isLoading ? (
+          <LoadingSkeleton />
+        ) : ticketsQuery.error ? (
+          <div className="border-destructive/30 bg-destructive/10 text-destructive m-6 rounded-lg border p-4">
+            <p className="font-semibold">Error loading products</p>
+            <p className="mt-1 text-sm">Unable to load ticket data. Please try refreshing the page.</p>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader className="bg-muted z-10">
+              <TableRow>
+                <SortableHeader col="product" label="Product" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                <SortableHeader col="count" label="Tickets" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                <TableHead>% of Tickets</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedProducts.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-muted-foreground py-8 text-center">
+                    No product tags found
+                  </TableCell>
+                </TableRow>
+              ) : (
+                <>
+                  {sortedProducts.map(({ product, count }) => (
+                    <TableRow key={product}>
+                      <TableCell>{product}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, displayedTotal)}</TableCell>
+                    </TableRow>
+                  ))}
+                  {/* Distinct tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
+                  <TableRow className="bg-muted/50 border-t font-semibold">
+                    <TableCell>Totals</TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">{displayedTotal}</TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(displayedTotal, displayedTotal)}</TableCell>
+                  </TableRow>
+                </>
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import LoadingSkeleton from "@/components/LoadingSkeleton";
-import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useAllTickets, useRegistry } from "@/lib/hooks";
 import { enumValidator, useUrlParams } from "@/lib/hooks/useUrlParams";
@@ -9,8 +8,6 @@ import { PaginatedTickets, TicketTag, TicketWithLogs } from "@/lib/types";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-
-const NO_PRODUCT_LABEL = "None";
 
 const CHART_COLORS = [
   "var(--chart-1)",
@@ -90,19 +87,16 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
     {
       sortBy: "count",
       sortDir: "desc",
-      hideUntagged: "false",
     },
     {
       sortBy: enumValidator(["product", "count"] as const, "count"),
       sortDir: enumValidator(["asc", "desc"] as const, "desc"),
-      hideUntagged: enumValidator(["true", "false"] as const, "false"),
     }
   );
 
   // Casts are safe: sortBy and sortDir are guarded by enumValidators above.
   const sortColumn = params.sortBy as SortColumn;
   const sortDirection = params.sortDir as "asc" | "desc";
-  const hideUntagged = params.hideUntagged === "true";
 
   const handleSort = (column: SortColumn) => {
     if (sortColumn === column) {
@@ -124,9 +118,11 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
   const isLoading = ticketsQuery.isLoading || registryQuery.isLoading;
   const loadError = ticketsQuery.error || registryQuery.error;
 
-  const totalTickets = visibleTickets.length;
-
-  const productCounts = useMemo(() => {
+  // Tickets without a product tag are excluded before counting: they get no
+  // row, and they don't feed the Totals count or the percentage denominator —
+  // so percentages are shares of product-tagged tickets (and only sum to 100%
+  // exactly when no ticket carries more than one product tag).
+  const { productCounts, taggedTicketCount } = useMemo(() => {
     const labelByCode = new Map<string, string>();
     (registryData?.tags ?? []).forEach((tag: TicketTag) => labelByCode.set(tag.code, tag.label));
 
@@ -140,8 +136,8 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         counts.set(stripProductPrefix(tag.label), 0);
       }
     });
-    counts.set(NO_PRODUCT_LABEL, 0);
 
+    let taggedTicketCount = 0;
     visibleTickets.forEach((t: TicketWithLogs) => {
       // A ticket counts once per distinct product, even if tagged twice.
       const products = new Set<string>();
@@ -149,33 +145,24 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         const label = labelByCode.get(code as string) || getTagLabel(code);
         if (isProductLabel(label)) products.add(stripProductPrefix(label));
       });
-      if (products.size === 0) products.add(NO_PRODUCT_LABEL);
+      if (products.size === 0) return;
+      taggedTicketCount++;
       products.forEach((product) => counts.set(product, (counts.get(product) ?? 0) + 1));
     });
 
-    return Array.from(counts, ([product, count]) => ({ product, count }));
+    return { productCounts: Array.from(counts, ([product, count]) => ({ product, count })), taggedTicketCount };
   }, [visibleTickets, registryData]);
-
-  // Hiding untagged tickets removes them entirely: no None row, and they leave
-  // the Totals count and percentage denominator too.
-  const noneCount = productCounts.find((p) => p.product === NO_PRODUCT_LABEL)?.count ?? 0;
-  const displayedCounts = useMemo(
-    () => (hideUntagged ? productCounts.filter((p) => p.product !== NO_PRODUCT_LABEL) : productCounts),
-    [productCounts, hideUntagged]
-  );
-  const displayedTotal = hideUntagged ? totalTickets - noneCount : totalTickets;
 
   // The chart is a fixed magnitude ranking (largest first), independent of the table's sort.
   const chartData = useMemo(
-    () => [...displayedCounts].sort((a, b) => b.count - a.count || a.product.localeCompare(b.product)),
-    [displayedCounts]
+    () => [...productCounts].sort((a, b) => b.count - a.count || a.product.localeCompare(b.product)),
+    [productCounts]
   );
 
   // Hues are assigned by alphabetical position over every registry product tag
   // (retired included), not by rank or by which rows currently have tickets —
   // so a product keeps its color when counts shift between date ranges, even
-  // when a retired product's row only exists for some ranges. "None" stays
-  // gray (catch-all).
+  // when a retired product's row only exists for some ranges.
   const colorByProduct = useMemo(() => {
     const products = Array.from(
       new Set(
@@ -188,7 +175,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
   }, [registryData]);
 
   const sortedProducts = useMemo(() => {
-    return [...displayedCounts].sort((a, b) => {
+    return [...productCounts].sort((a, b) => {
       if (sortColumn === "count") {
         const cmp = a.count - b.count;
         // Ties stay alphabetical regardless of sort direction
@@ -198,26 +185,11 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
       const cmp = a.product.localeCompare(b.product);
       return sortDirection === "asc" ? cmp : -cmp;
     });
-  }, [displayedCounts, sortColumn, sortDirection]);
+  }, [productCounts, sortColumn, sortDirection]);
 
   return (
     <div className="space-y-6">
       <p className="text-muted-foreground text-sm">Ticket counts per product tag</p>
-
-      {!isLoading && !loadError && (
-        <div className="flex items-center gap-2">
-          <input
-            id="hide-untagged"
-            type="checkbox"
-            checked={hideUntagged}
-            onChange={(e) => setParams({ hideUntagged: e.target.checked ? "true" : "false" })}
-            className="accent-primary h-4 w-4 cursor-pointer"
-          />
-          <Label htmlFor="hide-untagged" className="cursor-pointer font-normal">
-            Hide tickets without a product tag
-          </Label>
-        </div>
-      )}
 
       {!isLoading && !loadError && chartData.length > 0 && (
         <div className="bg-card rounded-lg border p-4">
@@ -250,18 +222,11 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
                   labelStyle={{ color: "var(--popover-foreground)" }}
                   itemStyle={{ color: "var(--popover-foreground)" }}
                   cursor={{ fill: "var(--accent)" }}
-                  formatter={(value: number) => [`${value} (${formatPercentage(value, displayedTotal)})`, "Tickets"]}
+                  formatter={(value: number) => [`${value} (${formatPercentage(value, taggedTicketCount)})`, "Tickets"]}
                 />
                 <Bar dataKey="count" fill="var(--chart-1)" barSize={20} radius={[0, 4, 4, 0]}>
                   {chartData.map((entry) => (
-                    <Cell
-                      key={entry.product}
-                      fill={
-                        entry.product === NO_PRODUCT_LABEL
-                          ? "var(--muted-foreground)"
-                          : (colorByProduct.get(entry.product) ?? "var(--chart-1)")
-                      }
-                    />
+                    <Cell key={entry.product} fill={colorByProduct.get(entry.product) ?? "var(--chart-1)"} />
                   ))}
                 </Bar>
               </BarChart>
@@ -300,14 +265,16 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
                     <TableRow key={product}>
                       <TableCell>{product}</TableCell>
                       <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
-                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, displayedTotal)}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, taggedTicketCount)}</TableCell>
                     </TableRow>
                   ))}
-                  {/* Distinct tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
+                  {/* Distinct product-tagged tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
                   <TableRow className="bg-muted/50 border-t font-semibold">
                     <TableCell>Totals</TableCell>
-                    <TableCell className="font-mono text-sm tabular-nums">{displayedTotal}</TableCell>
-                    <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(displayedTotal, displayedTotal)}</TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">{taggedTicketCount}</TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">
+                      {formatPercentage(taggedTicketCount, taggedTicketCount)}
+                    </TableCell>
                   </TableRow>
                 </>
               )}

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -10,7 +10,6 @@ import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
-const PRODUCT_TAG_PREFIX = "Product -";
 const NO_PRODUCT_LABEL = "None";
 
 const CHART_COLORS = [
@@ -56,12 +55,21 @@ function SortableHeader({
   );
 }
 
+// Product tags are detected by their label prefix ("Product - <name>") — a UI
+// convention until the registry can declare a tag category. Matching tolerates
+// case, spacing, and hyphen/en/em dash variants so a slightly different label
+// doesn't silently drop a product; a label that is only the prefix (empty
+// product name) is not a product tag.
+const PRODUCT_TAG_PREFIX_RE = /^\s*product\s*[-–—]\s*/i;
+
+const stripProductPrefix = (label: string): string => label.replace(PRODUCT_TAG_PREFIX_RE, "").trim();
+
+const isProductLabel = (label: string): boolean => PRODUCT_TAG_PREFIX_RE.test(label) && stripProductPrefix(label) !== "";
+
 // Used by the Analytics & Operations page to hide the Products View tab
 // entirely when the registry has no active product tags.
 export const hasActiveProductTags = (registryData?: { tags?: TicketTag[] }): boolean =>
-  (registryData?.tags ?? []).some((tag) => tag.active !== false && tag.label.startsWith(PRODUCT_TAG_PREFIX));
-
-const stripProductPrefix = (label: string): string => label.slice(PRODUCT_TAG_PREFIX.length).trim();
+  (registryData?.tags ?? []).some((tag) => tag.active !== false && isProductLabel(tag.label));
 
 const formatPercentage = (count: number, total: number): string => (total > 0 ? `${((count / total) * 100).toFixed(1)}%` : "0.0%");
 
@@ -123,9 +131,12 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
     (registryData?.tags ?? []).forEach((tag: TicketTag) => labelByCode.set(tag.code, tag.label));
 
     const counts = new Map<string, number>();
-    // Seed with active registry product tags so products with no tickets in range still appear.
+    // Seed with active registry product tags so products with no tickets in
+    // range still appear. Retired (inactive) product tags are deliberately not
+    // seeded, but tickets carrying them still count below — a retired product
+    // surfaces only for date ranges that contain its tickets.
     (registryData?.tags ?? []).forEach((tag: TicketTag) => {
-      if (tag.active !== false && tag.label.startsWith(PRODUCT_TAG_PREFIX)) {
+      if (tag.active !== false && isProductLabel(tag.label)) {
         counts.set(stripProductPrefix(tag.label), 0);
       }
     });
@@ -136,7 +147,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
       const products = new Set<string>();
       (t.tags ?? []).forEach((code) => {
         const label = labelByCode.get(code as string) || getTagLabel(code);
-        if (label.startsWith(PRODUCT_TAG_PREFIX)) products.add(stripProductPrefix(label));
+        if (isProductLabel(label)) products.add(stripProductPrefix(label));
       });
       if (products.size === 0) products.add(NO_PRODUCT_LABEL);
       products.forEach((product) => counts.set(product, (counts.get(product) ?? 0) + 1));
@@ -160,15 +171,21 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
     [displayedCounts]
   );
 
-  // Hues are assigned by alphabetical position, not rank, so a product keeps its
-  // color when counts shift between date ranges. "None" stays gray (catch-all).
+  // Hues are assigned by alphabetical position over every registry product tag
+  // (retired included), not by rank or by which rows currently have tickets —
+  // so a product keeps its color when counts shift between date ranges, even
+  // when a retired product's row only exists for some ranges. "None" stays
+  // gray (catch-all).
   const colorByProduct = useMemo(() => {
-    const products = productCounts
-      .map((p) => p.product)
-      .filter((p) => p !== NO_PRODUCT_LABEL)
-      .sort((a, b) => a.localeCompare(b));
+    const products = Array.from(
+      new Set(
+        (registryData?.tags ?? [])
+          .filter((tag: TicketTag) => isProductLabel(tag.label))
+          .map((tag: TicketTag) => stripProductPrefix(tag.label))
+      )
+    ).sort((a, b) => a.localeCompare(b));
     return new Map(products.map((p, idx) => [p, CHART_COLORS[idx % CHART_COLORS.length]]));
-  }, [productCounts]);
+  }, [registryData]);
 
   const sortedProducts = useMemo(() => {
     return [...displayedCounts].sort((a, b) => {

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -75,7 +75,8 @@ const getTagLabel = (tag: unknown): string => {
 };
 
 export default function ProductsPage({ dateRange }: { dateRange?: { from?: string; to?: string } }) {
-  const { data: registryData } = useRegistry();
+  const registryQuery = useRegistry();
+  const registryData = registryQuery.data;
 
   const [params, setParams] = useUrlParams(
     {
@@ -108,6 +109,12 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
   const ticketsQuery = useAllTickets(200, dateRange?.from, dateRange?.to);
   const ticketsData = ticketsQuery.data as PaginatedTickets | undefined;
   const visibleTickets = useMemo(() => (ticketsData?.content as TicketWithLogs[] | undefined) ?? [], [ticketsData]);
+
+  // Product bucketing needs the registry's code→label map, so the view is not
+  // ready until BOTH queries resolve — rendering on tickets alone would bucket
+  // every ticket under "None" and present it as final data.
+  const isLoading = ticketsQuery.isLoading || registryQuery.isLoading;
+  const loadError = ticketsQuery.error || registryQuery.error;
 
   const totalTickets = visibleTickets.length;
 
@@ -180,7 +187,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
     <div className="space-y-6">
       <p className="text-muted-foreground text-sm">Ticket counts per product tag</p>
 
-      {!ticketsQuery.isLoading && !ticketsQuery.error && (
+      {!isLoading && !loadError && (
         <div className="flex items-center gap-2">
           <input
             id="hide-untagged"
@@ -195,7 +202,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {!ticketsQuery.isLoading && !ticketsQuery.error && chartData.length > 0 && (
+      {!isLoading && !loadError && chartData.length > 0 && (
         <div className="bg-card rounded-lg border p-4">
           <h2 className="text-foreground mb-2 text-center font-semibold">Tickets by Product</h2>
           <div style={{ width: "100%", height: Math.max(200, chartData.length * 36 + 60) }}>
@@ -247,12 +254,12 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
       )}
 
       <div className="overflow-hidden rounded-lg border">
-        {ticketsQuery.isLoading ? (
+        {isLoading ? (
           <LoadingSkeleton />
-        ) : ticketsQuery.error ? (
+        ) : loadError ? (
           <div className="border-destructive/30 bg-destructive/10 text-destructive m-6 rounded-lg border p-4">
             <p className="font-semibold">Error loading products</p>
-            <p className="mt-1 text-sm">Unable to load ticket data. Please try refreshing the page.</p>
+            <p className="mt-1 text-sm">Unable to load data. Please try refreshing the page.</p>
           </div>
         ) : (
           <Table>

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -3,11 +3,8 @@
 import LoadingSkeleton from "@/components/LoadingSkeleton";
 import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useTeamFilter } from "@/contexts/TeamFilterContext";
-import { TEAM_SCOPE } from "@/lib/constants";
 import { useAllTickets, useRegistry } from "@/lib/hooks";
 import { enumValidator, useUrlParams } from "@/lib/hooks/useUrlParams";
-import { normalizeTeamKey } from "@/lib/teamUtils";
 import { PaginatedTickets, TicketTag, TicketWithLogs } from "@/lib/types";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useMemo } from "react";
@@ -78,9 +75,6 @@ const getTagLabel = (tag: unknown): string => {
 };
 
 export default function ProductsPage({ dateRange }: { dateRange?: { from?: string; to?: string } }) {
-  const { effectiveTeams, hasNoTeamScope: contextHasNoTeamScope } = useTeamFilter();
-  const hasNoTeamScope = contextHasNoTeamScope ?? effectiveTeams.includes(TEAM_SCOPE.NO_TEAMS);
-
   const { data: registryData } = useRegistry();
 
   const [params, setParams] = useUrlParams(
@@ -109,20 +103,11 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
     }
   };
 
-  const ticketsQuery = useAllTickets(200, dateRange?.from, dateRange?.to, !hasNoTeamScope);
+  // Deliberately unscoped by the sidebar team filter: like the other analytics
+  // tabs on this page, Products View reports across all teams.
+  const ticketsQuery = useAllTickets(200, dateRange?.from, dateRange?.to);
   const ticketsData = ticketsQuery.data as PaginatedTickets | undefined;
-  const ticketsContent = useMemo(() => (ticketsData?.content as TicketWithLogs[] | undefined) ?? [], [ticketsData]);
-
-  // Scope tickets to the teams the user is viewing, mirroring the tickets page.
-  const visibleTickets = useMemo(() => {
-    if (hasNoTeamScope) return [];
-    if (effectiveTeams.length === 0) return ticketsContent;
-    return ticketsContent.filter((t: TicketWithLogs) => {
-      if (!t.team?.name) return false;
-      const ticketTeam = normalizeTeamKey(t.team.name);
-      return effectiveTeams.some((team) => normalizeTeamKey(team) === ticketTeam);
-    });
-  }, [ticketsContent, hasNoTeamScope, effectiveTeams]);
+  const visibleTickets = useMemo(() => (ticketsData?.content as TicketWithLogs[] | undefined) ?? [], [ticketsData]);
 
   const totalTickets = visibleTickets.length;
 
@@ -195,14 +180,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
     <div className="space-y-6">
       <p className="text-muted-foreground text-sm">Ticket counts per product tag</p>
 
-      {hasNoTeamScope && (
-        <div className="border-warning/30 bg-warning/10 text-warning rounded-lg border p-4">
-          <p className="font-semibold">No Team Access</p>
-          <p className="mt-1 text-sm">You are not assigned to any teams, so product ticket counts cannot be displayed.</p>
-        </div>
-      )}
-
-      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && (
+      {!ticketsQuery.isLoading && !ticketsQuery.error && (
         <div className="flex items-center gap-2">
           <input
             id="hide-untagged"
@@ -217,7 +195,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && chartData.length > 0 && (
+      {!ticketsQuery.isLoading && !ticketsQuery.error && chartData.length > 0 && (
         <div className="bg-card rounded-lg border p-4">
           <h2 className="text-foreground mb-2 text-center font-semibold">Tickets by Product</h2>
           <div style={{ width: "100%", height: Math.max(200, chartData.length * 36 + 60) }}>

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -121,6 +121,12 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
 
   const totalTickets = visibleTickets.length;
 
+  // Distinguish "no product tags configured" (registry has none) from "no tickets tagged".
+  // Only asserted once the registry has loaded, to avoid flashing the message.
+  const noProductTagsConfigured =
+    registryData !== undefined &&
+    !(registryData.tags ?? []).some((tag: TicketTag) => tag.active !== false && tag.label.startsWith(PRODUCT_TAG_PREFIX));
+
   const productCounts = useMemo(() => {
     const labelByCode = new Map<string, string>();
     (registryData?.tags ?? []).forEach((tag: TicketTag) => labelByCode.set(tag.code, tag.label));
@@ -197,7 +203,17 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && (
+      {noProductTagsConfigured && (
+        <div className="bg-card rounded-lg border p-8 text-center">
+          <p className="text-foreground font-semibold">No product tags configured yet</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            This view is powered by ticket tags labelled <code className="bg-muted rounded px-1 py-0.5">Product - &lt;name&gt;</code>.
+            Contact your support-bot operator to add some.
+          </p>
+        </div>
+      )}
+
+      {!noProductTagsConfigured && !ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && (
         <div className="flex items-center gap-2">
           <input
             id="hide-untagged"
@@ -212,7 +228,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      {!ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && chartData.length > 0 && (
+      {!noProductTagsConfigured && !ticketsQuery.isLoading && !ticketsQuery.error && !hasNoTeamScope && chartData.length > 0 && (
         <div className="bg-card rounded-lg border p-4">
           <h2 className="text-foreground mb-2 text-center font-semibold">Tickets by Product</h2>
           <div style={{ width: "100%", height: Math.max(200, chartData.length * 36 + 60) }}>
@@ -263,51 +279,53 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
         </div>
       )}
 
-      <div className="overflow-hidden rounded-lg border">
-        {ticketsQuery.isLoading ? (
-          <LoadingSkeleton />
-        ) : ticketsQuery.error ? (
-          <div className="border-destructive/30 bg-destructive/10 text-destructive m-6 rounded-lg border p-4">
-            <p className="font-semibold">Error loading products</p>
-            <p className="mt-1 text-sm">Unable to load ticket data. Please try refreshing the page.</p>
-          </div>
-        ) : (
-          <Table>
-            <TableHeader className="bg-muted z-10">
-              <TableRow>
-                <SortableHeader col="product" label="Product" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader col="count" label="Tickets" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <TableHead>% of Tickets</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sortedProducts.length === 0 ? (
+      {!noProductTagsConfigured && (
+        <div className="overflow-hidden rounded-lg border">
+          {ticketsQuery.isLoading ? (
+            <LoadingSkeleton />
+          ) : ticketsQuery.error ? (
+            <div className="border-destructive/30 bg-destructive/10 text-destructive m-6 rounded-lg border p-4">
+              <p className="font-semibold">Error loading products</p>
+              <p className="mt-1 text-sm">Unable to load ticket data. Please try refreshing the page.</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader className="bg-muted z-10">
                 <TableRow>
-                  <TableCell colSpan={3} className="text-muted-foreground py-8 text-center">
-                    No product tags found
-                  </TableCell>
+                  <SortableHeader col="product" label="Product" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                  <SortableHeader col="count" label="Tickets" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                  <TableHead>% of Tickets</TableHead>
                 </TableRow>
-              ) : (
-                <>
-                  {sortedProducts.map(({ product, count }) => (
-                    <TableRow key={product}>
-                      <TableCell>{product}</TableCell>
-                      <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
-                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, displayedTotal)}</TableCell>
-                    </TableRow>
-                  ))}
-                  {/* Distinct tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
-                  <TableRow className="bg-muted/50 border-t font-semibold">
-                    <TableCell>Totals</TableCell>
-                    <TableCell className="font-mono text-sm tabular-nums">{displayedTotal}</TableCell>
-                    <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(displayedTotal, displayedTotal)}</TableCell>
+              </TableHeader>
+              <TableBody>
+                {sortedProducts.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-muted-foreground py-8 text-center">
+                      No product tags found
+                    </TableCell>
                   </TableRow>
-                </>
-              )}
-            </TableBody>
-          </Table>
-        )}
-      </div>
+                ) : (
+                  <>
+                    {sortedProducts.map(({ product, count }) => (
+                      <TableRow key={product}>
+                        <TableCell>{product}</TableCell>
+                        <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
+                        <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, displayedTotal)}</TableCell>
+                      </TableRow>
+                    ))}
+                    {/* Distinct tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
+                    <TableRow className="bg-muted/50 border-t font-semibold">
+                      <TableCell>Totals</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{displayedTotal}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(displayedTotal, displayedTotal)}</TableCell>
+                    </TableRow>
+                  </>
+                )}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/test-utils/mock-url-params.ts
+++ b/ui/src/test-utils/mock-url-params.ts
@@ -23,8 +23,31 @@ import { useState } from "react";
 
 type StringRecord = Record<string, string>;
 
+let initialParams: StringRecord | null = null;
+
+/**
+ * Seed the next `useMockUrlParams` mounts with URL params, simulating a deep
+ * link (e.g. `?tab=products`). Only keys present in a hook call's defaults are
+ * applied, so unrelated `useUrlParams` consumers are unaffected. Call
+ * `clearMockUrlParamsInitial` in `beforeEach` to avoid leaking across tests.
+ */
+export function setMockUrlParamsInitial(params: StringRecord): void {
+  initialParams = params;
+}
+
+export function clearMockUrlParamsInitial(): void {
+  initialParams = null;
+}
+
 export function useMockUrlParams<T extends StringRecord>(defaults: T): [T, (updates: Partial<T>) => void] {
-  const [params, setParamsState] = useState<T>(defaults);
+  const [params, setParamsState] = useState<T>(() => {
+    if (!initialParams) return defaults;
+    const seeded: StringRecord = { ...defaults };
+    for (const key of Object.keys(defaults)) {
+      if (initialParams[key] !== undefined) seeded[key] = initialParams[key];
+    }
+    return seeded as T;
+  });
   const setParams = (updates: Partial<T>) => {
     setParamsState((prev) => {
       const next: StringRecord = { ...prev };


### PR DESCRIPTION
## Summary

Adds a **Products View** tab to the Analytics & Operations dashboard (`/health`), showing ticket counts per product tag. The view is driven by the page's shared date filter.

- Horizontal bar chart ranking products by ticket count — stable per-product colors from the theme chart palette
- Sortable table with ticket counts, a % of Tickets column, and a pinned **Totals** row counting distinct product-tagged tickets (a ticket with several product tags counts once in Totals but appears in each of its rows)
- Tickets without a product tag are excluded before counting: no "None" row, and totals/percentages are shares of product-tagged tickets only, so percentages sum to 100% (modulo multi-tagged tickets)
- The tab only appears when the registry has active `Product - <name>` tags: it stays hidden while the registry loads (no flash in/out), and a deep link to `?tab=products` renders Activity Trends unless the registry confirms product tags exist — the hidden view never mounts, including when the registry request fails
- Like the sibling analytics tabs, the view is **not** scoped by the sidebar team filter: it reports across all teams
- Product tag matching tolerates case, spacing, and hyphen/en/em-dash label variants; prefix-only labels (`Product -`) are treated as non-product tags

Note: as a tab of Analytics & Operations, the view sits behind the same `VIEW_RESTRICTED_DASHBOARDS` capability as the rest of the page.

<img width="1808" height="904" alt="image" src="https://github.com/user-attachments/assets/ded20acb-df9b-4128-8b08-00dd66cfd57d" />

## Test plan

- [x] `yarn test src/components/products src/components/health` — 20 + 35 tests passing (incl. untagged tickets excluded from rows/Totals/percentages, no hide-untagged control, tab hidden for no/inactive-only product tags and while the registry loads, deep-link fallback on missing tags and registry failure, retired-tag counting, label-variant matching)
- [x] `yarn lint` / prettier clean
- [x] Verified manually against local seeded data (sorting, Totals, dark mode) — on an earlier revision that still had the None row/checkbox
- [x] Browser re-check after the None/checkbox removal (`c5e648c0`)

## Follow-ups (out of scope for this PR)

From the code review of this branch, in rough priority order:

- **Registry-declared tag category** — product detection rides on the `Product - <name>` label convention (now tolerantly matched, but still a UI-invented contract operators must guess; it is documented nowhere and the registry model has no field to carry it). Add a `category`/`type: product` field to the tag config chain (`Tag` record → `enums.tags` in `application.yaml` → `TagUI` in `RegistryController` → `/registry/tag`) and switch the UI to match on it, demoting the prefix to a display-only concern.
- **Server-side tickets-by-tag aggregation** — the view downloads every ticket in range (`useAllTickets`: `ceil(N/200)` parallel requests of full `TicketWithLogs` payloads) to compute a handful of counts. Add a `/dashboard` endpoint mirroring `escalation-percentage-by-tag` (the SQL `unnest(tags)` group-by pattern already exists in `JdbcDashboardRepository`). Best done after the category field lands so the endpoint doesn't encode the label convention in SQL.
- **1000-ticket cap on the sibling tabs** — Activity Trends / Ratings / Workbench compute from `useTickets(0, 1000, …)`, so date ranges with more than 1000 tickets are silently truncated and those tabs can disagree with Products View (which fetches all pages). Quick win: a "showing first 1000 of N" notice; proper fix: the aggregation endpoint above.
- **Extract duplicated helpers** — this PR added local copies of things that exist elsewhere: `SortableHeader` (3rd copy, see `escalations.tsx`), `getTagLabel` (verbatim from `tickets.tsx`), the chart color array (duplicates the `COLORS` array in `health.tsx` and collides in name with `CHART_COLORS` in `lib/constants`), and the recharts tooltip style block. Extract into shared modules and converge the existing copies.
- **Chart tooltip style** — the chart tooltip is missing `cursor.stroke: 'var(--border)'` per `ui/AGENTS.md` §9.
- **Known edge cases (product decisions)** — a registry tag literally labeled `Product - None` renders as a normal product row named "None" (there is no untagged bucket anymore, but the name could still read as one); when *all* product tags are inactive, the tab stays hidden even if retired-tagged tickets exist in range (kept deliberately, matching the tab-visibility rule from 9b4ca09a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)