### PR TITLE
fix(ui): base Products View percentages on all tickets in range

### DIFF
--- a/ui/src/components/products/__tests__/products.test.tsx
+++ b/ui/src/components/products/__tests__/products.test.tsx
@@ -106,16 +106,17 @@ describe("Products Component", () => {
     expect(screen.queryByText("Product - Alpha")).not.toBeInTheDocument();
   });
 
-  it("excludes untagged tickets from rows, Totals, and the percentage denominator", () => {
+  it("excludes untagged tickets from rows and Totals, but keeps them in the percentage denominator", () => {
     renderProducts();
 
-    // Ticket 3 only has the non-product "bug" tag: no None row, and it doesn't
-    // count — Totals is 3 (tickets 1, 2, 4) and Alpha's share is 3/3
+    // Ticket 3 only has the non-product "bug" tag: no None row and it's not in
+    // Total Product Tickets (3: tickets 1, 2, 4), but it still counts toward
+    // the denominator — Alpha's share is 3 of all 4 tickets in range
     expect(screen.queryByText("None")).not.toBeInTheDocument();
-    const totalsRow = screen.getByText("Totals").closest("tr")!;
+    const totalsRow = screen.getByText("Total Product Tickets").closest("tr")!;
     expect(within(totalsRow).getByText("3")).toBeInTheDocument();
     const alphaRow = screen.getByText("Alpha").closest("tr")!;
-    expect(within(alphaRow).getByText("100.0%")).toBeInTheDocument();
+    expect(within(alphaRow).getByText("75.0%")).toBeInTheDocument();
   });
 
   it("does not render a hide-untagged control", () => {
@@ -125,29 +126,30 @@ describe("Products Component", () => {
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 
-  it("shows each product's percentage of product-tagged tickets", () => {
+  it("shows each product's percentage of all tickets in range, untagged included", () => {
     renderProducts();
 
-    // 3 tickets carry product tags; Alpha appears on all 3, Beta on 1
+    // 4 tickets in range; Alpha appears on 3, Beta on 1
     const alphaRow = screen.getByText("Alpha").closest("tr")!;
-    expect(within(alphaRow).getByText("100.0%")).toBeInTheDocument();
+    expect(within(alphaRow).getByText("75.0%")).toBeInTheDocument();
 
     const betaRow = screen.getByText("Beta").closest("tr")!;
-    expect(within(betaRow).getByText("33.3%")).toBeInTheDocument();
+    expect(within(betaRow).getByText("25.0%")).toBeInTheDocument();
   });
 
-  it("renders a Totals row counting distinct product-tagged tickets, always last regardless of sorting", () => {
+  it("renders a Total Product Tickets row counting distinct tagged tickets, always last regardless of sorting", () => {
     renderProducts();
 
-    // Ticket 4 carries two product tags but counts once: 3 tagged tickets, not the column sum of 4
-    const totalsRow = screen.getByText("Totals").closest("tr")!;
+    // Ticket 4 carries two product tags but counts once: 3 tagged tickets (not
+    // the column sum of 4), which is 75% of the 4 tickets in range
+    const totalsRow = screen.getByText("Total Product Tickets").closest("tr")!;
     expect(within(totalsRow).getByText("3")).toBeInTheDocument();
-    expect(within(totalsRow).getByText("100.0%")).toBeInTheDocument();
+    expect(within(totalsRow).getByText("75.0%")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Product"));
     fireEvent.click(screen.getByText("Product"));
     const rows = screen.getAllByRole("row");
-    expect(within(rows[rows.length - 1]).getByText("Totals")).toBeInTheDocument();
+    expect(within(rows[rows.length - 1]).getByText("Total Product Tickets")).toBeInTheDocument();
   });
 
   it("does not list non-product tags", () => {
@@ -176,7 +178,7 @@ describe("Products Component", () => {
 
     const rows = screen.getAllByRole("row").slice(1); // skip header row
     const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Alpha", "Beta", "Totals"]);
+    expect(products).toEqual(["Alpha", "Beta", "Total Product Tickets"]);
   });
 
   it("sorts by product name when the Product header is clicked and flips direction on second click", () => {
@@ -185,12 +187,12 @@ describe("Products Component", () => {
     fireEvent.click(screen.getByText("Product"));
     let rows = screen.getAllByRole("row").slice(1);
     let products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Alpha", "Beta", "Totals"]);
+    expect(products).toEqual(["Alpha", "Beta", "Total Product Tickets"]);
 
     fireEvent.click(screen.getByText("Product"));
     rows = screen.getAllByRole("row").slice(1);
     products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Beta", "Alpha", "Totals"]);
+    expect(products).toEqual(["Beta", "Alpha", "Total Product Tickets"]);
   });
 
   it("flips count sort direction when the Tickets header is clicked", () => {
@@ -199,7 +201,7 @@ describe("Products Component", () => {
     fireEvent.click(screen.getByText("Tickets"));
     const rows = screen.getAllByRole("row").slice(1);
     const products = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(products).toEqual(["Beta", "Alpha", "Totals"]);
+    expect(products).toEqual(["Beta", "Alpha", "Total Product Tickets"]);
   });
 
   it("counts tickets tagged with a retired product under its own row", () => {
@@ -265,7 +267,7 @@ describe("Products Component", () => {
     // The prefix-only tag seeds no blank row; its ticket counts as untagged
     // and is excluded entirely, leaving only the seeded Alpha row at zero
     expect(screen.queryByText("None")).not.toBeInTheDocument();
-    const totalsRow = screen.getByText("Totals").closest("tr")!;
+    const totalsRow = screen.getByText("Total Product Tickets").closest("tr")!;
     expect(within(totalsRow).getByText("0")).toBeInTheDocument();
   });
 
@@ -294,7 +296,7 @@ describe("Products Component", () => {
 
     expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
     // No final-looking data while the code→label map is unavailable
-    expect(screen.queryByText("Totals")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total Product Tickets")).not.toBeInTheDocument();
   });
 
   it("shows an error message when the registry fails to load", () => {
@@ -307,7 +309,7 @@ describe("Products Component", () => {
     renderProducts();
 
     expect(screen.getByText("Error loading products")).toBeInTheDocument();
-    expect(screen.queryByText("Totals")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total Product Tickets")).not.toBeInTheDocument();
   });
 
   it("shows an error message when tickets fail to load", () => {

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -253,7 +253,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
               <TableRow>
                 <SortableHeader col="product" label="Product" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
                 <SortableHeader col="count" label="Tickets" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <TableHead>% of Tickets</TableHead>
+                <TableHead>% of total Tickets</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/ui/src/components/products/products.tsx
+++ b/ui/src/components/products/products.tsx
@@ -118,10 +118,14 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
   const isLoading = ticketsQuery.isLoading || registryQuery.isLoading;
   const loadError = ticketsQuery.error || registryQuery.error;
 
-  // Tickets without a product tag are excluded before counting: they get no
-  // row, and they don't feed the Totals count or the percentage denominator —
-  // so percentages are shares of product-tagged tickets (and only sum to 100%
-  // exactly when no ticket carries more than one product tag).
+  // All tickets in range (untagged included) — the percentage denominator, so
+  // each row reads as "share of all tickets in the selected period".
+  const totalTickets = visibleTickets.length;
+
+  // Tickets without a product tag get no row and don't count toward Total
+  // Product Tickets, but they stay in the percentage denominator above — with
+  // mostly-untagged data the percentages are deliberately small and don't sum
+  // to 100%.
   const { productCounts, taggedTicketCount } = useMemo(() => {
     const labelByCode = new Map<string, string>();
     (registryData?.tags ?? []).forEach((tag: TicketTag) => labelByCode.set(tag.code, tag.label));
@@ -222,7 +226,7 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
                   labelStyle={{ color: "var(--popover-foreground)" }}
                   itemStyle={{ color: "var(--popover-foreground)" }}
                   cursor={{ fill: "var(--accent)" }}
-                  formatter={(value: number) => [`${value} (${formatPercentage(value, taggedTicketCount)})`, "Tickets"]}
+                  formatter={(value: number) => [`${value} (${formatPercentage(value, totalTickets)})`, "Tickets"]}
                 />
                 <Bar dataKey="count" fill="var(--chart-1)" barSize={20} radius={[0, 4, 4, 0]}>
                   {chartData.map((entry) => (
@@ -265,16 +269,14 @@ export default function ProductsPage({ dateRange }: { dateRange?: { from?: strin
                     <TableRow key={product}>
                       <TableCell>{product}</TableCell>
                       <TableCell className="font-mono text-sm tabular-nums">{count}</TableCell>
-                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, taggedTicketCount)}</TableCell>
+                      <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(count, totalTickets)}</TableCell>
                     </TableRow>
                   ))}
                   {/* Distinct product-tagged tickets in scope — can be below the column sum since a ticket may carry several product tags. */}
                   <TableRow className="bg-muted/50 border-t font-semibold">
-                    <TableCell>Totals</TableCell>
+                    <TableCell>Total Product Tickets</TableCell>
                     <TableCell className="font-mono text-sm tabular-nums">{taggedTicketCount}</TableCell>
-                    <TableCell className="font-mono text-sm tabular-nums">
-                      {formatPercentage(taggedTicketCount, taggedTicketCount)}
-                    </TableCell>
+                    <TableCell className="font-mono text-sm tabular-nums">{formatPercentage(taggedTicketCount, totalTickets)}</TableCell>
                   </TableRow>
                 </>
               )}


### PR DESCRIPTION
## Summary

Follow-up to #302. The **% of Tickets** column in Products View used product-tagged tickets as the denominator, which inflated shares when most tickets in the period are untagged. This changes the denominator to **all tickets in the selected period, untagged included**:

- Each product row now reads as its share of every ticket in range — 100 tickets with 3 tagged gives "Product A, 2, 2.0%", "Product B, 1, 1.0%"
- The totals row is relabelled **Total Product Tickets** and shows its own share of the range (3, 3.0% in the example above)
- The column is renamed **% of total Tickets** to say what the denominator now is
- The chart tooltip percentage uses the same denominator so chart and table always agree
- Untagged tickets still get no row and don't count toward Total Product Tickets; they only widen the denominator

<img width="1786" height="913" alt="image" src="https://github.com/user-attachments/assets/bb7bef41-fbe8-4d64-80a1-37e001531fac" />

## Test plan

- [x] `yarn test src/components/products src/components/health` — 20 + 35 tests passing (percentage expectations updated to the all-tickets denominator, totals-row label assertions updated)
- [x] `yarn lint` / prettier clean
- [x] Browser check against local seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)