### PR TITLE
[El-131] langchain4j upgrade for being able to eventually integrate with client endpoints

### DIFF
--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -118,13 +118,13 @@ dependencies {
 
     implementation("com.google.cloud:spring-cloud-gcp-starter:5.10.0")
     implementation("com.google.apis:google-api-services-cloudidentity:v1-rev20241208-2.0.0")
-    implementation("com.google.cloud:google-cloud-vertexai:1.52.0")
 
     implementation("com.microsoft.graph:microsoft-graph:6.36.0")
     implementation("com.azure.spring:spring-cloud-azure-starter:5.22.0")
 
-    implementation("dev.langchain4j:langchain4j-vertex-ai-gemini:0.36.2")
-    implementation("dev.langchain4j:langchain4j:0.36.2")
+    implementation(platform("dev.langchain4j:langchain4j-bom:1.18.0"))
+    implementation("dev.langchain4j:langchain4j")
+    implementation("dev.langchain4j:langchain4j-vertex-ai-gemini")
 
     implementation("net.logstash.logback:logstash-logback-encoder:8.0")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/api/service/src/main/java/com/coreeng/supportbot/analysis/llm/FakeChatModel.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/analysis/llm/FakeChatModel.java
@@ -1,10 +1,9 @@
 package com.coreeng.supportbot.analysis.llm;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.output.Response;
-import java.util.List;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -16,7 +15,7 @@ import org.springframework.stereotype.Component;
 @Profile("functionaltests")
 @Primary
 @Component
-public class FakeChatLanguageModel implements ChatLanguageModel {
+public class FakeChatModel implements ChatModel {
 
     private static final String STUB_ANALYSIS_RESPONSE = """
             Ticket: 0
@@ -27,7 +26,9 @@ public class FakeChatLanguageModel implements ChatLanguageModel {
             """;
 
     @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages) {
-        return Response.from(AiMessage.from(STUB_ANALYSIS_RESPONSE));
+    public ChatResponse doChat(ChatRequest chatRequest) {
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(STUB_ANALYSIS_RESPONSE))
+                .build();
     }
 }

--- a/api/service/src/main/java/com/coreeng/supportbot/analysis/llm/LlmAnalysisService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/analysis/llm/LlmAnalysisService.java
@@ -2,7 +2,7 @@ package com.coreeng.supportbot.analysis.llm;
 
 import com.coreeng.supportbot.analysis.AnalysisRecord;
 import com.coreeng.supportbot.summarydata.ThreadService;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
  * <ul>
  *   <li>Fetches thread content from Slack via {@link ThreadService}</li>
  *   <li>Combines the thread with a prompt template</li>
- *   <li>Calls the LLM (configured via {@link dev.langchain4j.model.chat.ChatLanguageModel})</li>
+ *   <li>Calls the LLM (configured via {@link dev.langchain4j.model.chat.ChatModel})</li>
  *   <li>Parses the LLM response into structured {@link AnalysisRecord} data</li>
  * </ul>
  *
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class LlmAnalysisService {
 
-    private final ChatLanguageModel chatLanguageModel;
+    private final ChatModel chatModel;
     private final ThreadService threadService;
 
     /**
@@ -57,7 +57,7 @@ public class LlmAnalysisService {
 
             // Call LLM
             log.debug("Calling LLM for thread {}", threadTs);
-            String response = chatLanguageModel.generate(threadWithPrompt);
+            String response = chatModel.chat(threadWithPrompt);
 
             // Parse response into structured data
             return parseResponse(response, ticketId);

--- a/api/service/src/main/java/com/coreeng/supportbot/analysis/llm/LlmConfig.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/analysis/llm/LlmConfig.java
@@ -1,8 +1,8 @@
 package com.coreeng.supportbot.analysis.llm;
 
 import com.coreeng.supportbot.config.AnalysisProps;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.vertexai.VertexAiGeminiChatModel;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +14,7 @@ public class LlmConfig {
 
     @Bean
     @ConditionalOnProperty(name = "analysis.prompt.enabled", havingValue = "true")
-    public ChatLanguageModel chatLanguageModel(AnalysisProps analysisProps) {
+    public ChatModel chatModel(AnalysisProps analysisProps) {
         log.info(
                 "Configuring Vertex AI Gemini model: project={}, location={}, model={}",
                 analysisProps.vertex().projectId(),

--- a/api/service/src/test/java/com/coreeng/supportbot/analysis/llm/LlmAnalysisServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/analysis/llm/LlmAnalysisServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 
 import com.coreeng.supportbot.analysis.AnalysisRecord;
 import com.coreeng.supportbot.summarydata.ThreadService;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LlmAnalysisServiceTest {
 
     @Mock
-    private ChatLanguageModel chatLanguageModel;
+    private ChatModel chatModel;
 
     @Mock
     private ThreadService threadService;
@@ -26,7 +26,7 @@ class LlmAnalysisServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new LlmAnalysisService(chatLanguageModel, threadService);
+        service = new LlmAnalysisService(chatModel, threadService);
     }
 
     @Test
@@ -47,7 +47,7 @@ class LlmAnalysisServiceTest {
                 """;
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenReturn(llmResponse);
+        when(chatModel.chat(anyString())).thenReturn(llmResponse);
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);
@@ -63,7 +63,7 @@ class LlmAnalysisServiceTest {
         assertThat(result.promptId()).isNull(); // promptId is set by caller
 
         verify(threadService).getThreadAsText(channelId, threadTs);
-        verify(chatLanguageModel).generate(anyString());
+        verify(chatModel).chat(anyString());
     }
 
     @Test
@@ -83,7 +83,7 @@ class LlmAnalysisServiceTest {
                 """;
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenReturn(llmResponse);
+        when(chatModel.chat(anyString())).thenReturn(llmResponse);
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);
@@ -113,7 +113,7 @@ class LlmAnalysisServiceTest {
         // then
         assertThat(result).isNull();
         verify(threadService).getThreadAsText(channelId, threadTs);
-        verifyNoInteractions(chatLanguageModel);
+        verifyNoInteractions(chatModel);
     }
 
     @Test
@@ -126,7 +126,7 @@ class LlmAnalysisServiceTest {
         String threadText = "Some thread content";
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenThrow(new RuntimeException("LLM API error"));
+        when(chatModel.chat(anyString())).thenThrow(new RuntimeException("LLM API error"));
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);
@@ -134,7 +134,7 @@ class LlmAnalysisServiceTest {
         // then
         assertThat(result).isNull();
         verify(threadService).getThreadAsText(channelId, threadTs);
-        verify(chatLanguageModel).generate(anyString());
+        verify(chatModel).chat(anyString());
     }
 
     @Test
@@ -154,7 +154,7 @@ class LlmAnalysisServiceTest {
                 """;
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenReturn(llmResponse);
+        when(chatModel.chat(anyString())).thenReturn(llmResponse);
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);
@@ -185,7 +185,7 @@ class LlmAnalysisServiceTest {
                 """;
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenReturn(llmResponse);
+        when(chatModel.chat(anyString())).thenReturn(llmResponse);
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);
@@ -207,7 +207,7 @@ class LlmAnalysisServiceTest {
         String llmResponse = "Primary Driver: Bug\r\nCategory: Config\r\nPlatform Feature: storage\r\nReason: Issue";
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenReturn(llmResponse);
+        when(chatModel.chat(anyString())).thenReturn(llmResponse);
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);
@@ -235,7 +235,7 @@ class LlmAnalysisServiceTest {
                 """;
 
         when(threadService.getThreadAsText(channelId, threadTs)).thenReturn(threadText);
-        when(chatLanguageModel.generate(anyString())).thenReturn(llmResponse);
+        when(chatModel.chat(anyString())).thenReturn(llmResponse);
 
         // when
         AnalysisRecord result = service.analyzeThread(channelId, threadTs, ticketId, prompt);


### PR DESCRIPTION
Prep for EL-131 (swappable AI provider): 1.18.x supports the endpoint override and custom auth headers the AI-gateway mode will need. Versions now come from the langchain4j-bom; the google-cloud-vertexai pin is dropped (the new Vertex module manages its own SDK). Migrates the breaking 1.x API: ChatLanguageModel → ChatModel, generate() → chat(), fake reimplements doChat(). No behavior change — Vertex remains the only provider, config untouched.