### PR TITLE
[El-142] add elevate-review skill to support bot but tailored to support bot

### DIFF
--- a/.agents/skills/support-bot-review/SKILL.md
+++ b/.agents/skills/support-bot-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: elevate-review
-description: Use when reviewing an Elevate change, local branch, or GitHub PR before merge, especially when focused security, ADR, frontend, backend, or high-risk-surface feedback is needed.
+name: support-bot-review
+description: Use when reviewing a support-bot change, local branch, or GitHub PR before merge, especially when focused security, ADR, frontend, backend, or high-risk-surface feedback is needed.
 ---
 
-# Elevate Review
+# Support Bot Review
 
 ## Overview
 
@@ -14,7 +14,7 @@ Run five independent, focused reviews against either the current branch or a Git
 - Shared review context built by this skill
 - Review rubrics in `docs/reviews/`
 - Root `AGENTS.md`
-- Touched component `AGENTS.md` files
+- Touched module `AGENTS.md` files (`api/AGENTS.md`, `ui/AGENTS.md`)
 - Relevant `docs/adr/*.md`, plans, and issue documents
 - Jira ticket context when a Jira key is supplied or inferred, or the user's explicit reason when there is no Jira ticket
 
@@ -29,7 +29,7 @@ Run five independent, focused reviews against either the current branch or a Git
 
 1. Identify the current branch.
 2. Compare with `origin/main` using the merge-base diff, not local `main` and not only uncommitted changes.
-3. Capture changed files, changed delivery units, and a diff summary for the shared review context.
+3. Capture changed files, changed modules, and a diff summary for the shared review context.
 
 Useful commands:
 
@@ -74,7 +74,7 @@ git diff --stat origin/<baseRefName>...HEAD
 git diff origin/<baseRefName>...HEAD
 ```
 
-6. Capture PR number, worktree path, head branch, base branch, changed files, changed delivery units, and a diff summary for the shared review context.
+6. Capture PR number, worktree path, head branch, base branch, changed files, changed modules, and a diff summary for the shared review context.
 
 If `gh` is unavailable, authentication fails, PR metadata cannot be read, or PR checkout fails, stop with a clear blocker. Do not fall back to reviewing the current checkout.
 
@@ -82,7 +82,7 @@ If `gh` is unavailable, authentication fails, PR metadata cannot be read, or PR 
 
 Gather Jira ticket context once and include it in the shared review context.
 
-1. If the user supplies a Jira key such as `PT-456`, use it.
+1. If the user supplies a Jira key such as `EL-456`, use it.
 2. If no key is supplied, infer one from PR title/body, branch name, or commits in the reviewed range.
 3. If no key can be inferred, prompt the user before dispatching review workers. The user must either provide the Jira key or state that there is no Jira ticket and give a short reason.
 4. If the user provides a Jira key, use it. If the user states there is no Jira ticket, set `Jira: none - <user reason>` in the shared review context.
@@ -112,7 +112,7 @@ Missing Jira context is not automatically a `fix now`. Treat it as unknown inten
 
 ## Shared Review Context
 
-Build this once before running any focused review. Each review must use this as the single source of truth for what changed and why.
+Build this once before running any focused review. Each review must use this as the single source of truth for what changed and why. Changed modules are the touched top-level directories: `api/`, `ui/`, `dex/`, `ldap/`, `helm-chart/`, and `docs/`.
 
 ```text
 Review Target: local branch | PR <number>
@@ -122,7 +122,7 @@ Base: <base branch>
 Diff Range: <base>...HEAD
 Diff Commands: <commands used>
 Changed Files: <name-status summary>
-Changed Delivery Units: <list>
+Changed Modules: <list>
 Diff Summary: <stat and concise behavioral summary>
 Jira: <key, summary, status, relevant description/requirements; key with fetch failure; or none - user reason>
 Guidance Read: <root/component AGENTS.md files>
@@ -161,7 +161,7 @@ Worker instructions:
 Prompt template for each review worker:
 
 ```text
-You are running the <Review Name> for an Elevate change. Do not modify files.
+You are running the <Review Name> for a support-bot change. Do not modify files.
 
 Use exactly these inputs:
 1. Shared review context:
@@ -170,7 +170,7 @@ Use exactly these inputs:
 2. Rubric:
 <paste docs/reviews/<rubric>.md>
 
-Return one GitHub-flavored Markdown review section using the Elevate Review summary format. Use only these finding classifications: fix now, defer, reject with reason. Do not emit an overall verdict. Do not choose a different diff range, base branch, Jira ticket, or rubric.
+Return one GitHub-flavored Markdown review section using the Support Bot Review summary format. Use only these finding classifications: fix now, defer, reject with reason. Do not emit an overall verdict. Do not choose a different diff range, base branch, Jira ticket, or rubric.
 ```
 
 ## Finding Classifications
@@ -201,7 +201,7 @@ After all review workers return and before printing the final review, moderate t
    - the earliest review in this order: Security, ADR, Frontend, Backend, High-Risk Surface.
 6. Preserve useful evidence from duplicates by merging it into the canonical finding if it adds materially different context.
 
-Example duplicate group: if Backend Review and High-Risk Surface Review both report that exported YAML omits DB identifiers required for import update-vs-create semantics, keep one canonical finding and suppress the duplicate in the later section.
+Example duplicate group: if Security Review and Backend Review both report that a new `api/` endpoint is missing an authorization check, keep one canonical finding and suppress the duplicate in the later section.
 
 ### User Classification Gates
 
@@ -347,10 +347,6 @@ Do not save a file or post a PR comment before the user chooses one of these opt
 - Reviews remain independent during worker execution. Deduplication happens only in the coordinating worker's moderation step after all reviews have returned.
 - If evidence is insufficient, classify the uncertainty as `fix now` only when merge would be unsafe without resolving it; otherwise use `defer` with the missing evidence.
 
-## Test Recommendations
-
-This review skill does not run functional, integration, Extended, or Kind tests. When the change warrants one of those workflows, recommend the applicable repository testing skill after the moderated review. Do not invoke that skill or execute its commands automatically; any later run must follow that skill's separate preview and explicit-confirmation contract.
-
 ## Common Mistakes
 
 | Mistake | Correction |
@@ -371,7 +367,7 @@ This review skill does not run functional, integration, Extended, or Kind tests.
 | Using severity labels | Use only `fix now`, `defer`, or `reject with reason`. |
 | Treating deferred findings as blocking | Defer-only reviews are `approved`. |
 | Skipping ADR lookup | ADR review must identify and include selected accepted ADRs in the review output. |
-| Treating `elevate-frontend/AGENTS.md` as background only | Frontend Review must validate frontend PRs against every applicable instruction in `elevate-frontend/AGENTS.md`. |
+| Treating `ui/AGENTS.md` as background only | Frontend Review must validate frontend PRs against every applicable instruction in `ui/AGENTS.md`. |
 | Printing raw worker output directly | First dedupe findings and run the fix-now and defer classification gates. |
 | Repeating the same fix-now issue in multiple sections | Keep the canonical finding and replace duplicates with compact suppression findings. |
 
@@ -380,7 +376,7 @@ This review skill does not run functional, integration, Extended, or Kind tests.
 - "This is just a quick review" means still run all five review sections.
 - "PR 123" means PR number mode; do not review the current checkout.
 - "main...HEAD is close enough" means stop; use `origin/<baseRefName>...HEAD` for PR number mode or `origin/main...HEAD` for local branch mode.
-- "PT-456" means include Jira ticket context in every focused review.
+- "EL-456" means include Jira ticket context in every focused review.
 - "The rubric says diff" means use the shared context; rubrics do not own diff selection.
 - "I'll just do the reviews myself" means stop and dispatch one separate general-purpose worker per review.
 - "Frontend/backend did not change" means emit `not applicable`, not skip the section silently.

--- a/.agents/skills/support-bot-review/SKILL.md
+++ b/.agents/skills/support-bot-review/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: elevate-review
+description: Use when reviewing an Elevate change, local branch, or GitHub PR before merge, especially when focused security, ADR, frontend, backend, or high-risk-surface feedback is needed.
+---
+
+# Elevate Review
+
+## Overview
+
+Run five independent, focused reviews against either the current branch or a GitHub PR number. PR-number reviews must happen in an isolated git worktree. The skill builds one shared review context, including Jira ticket context from the Atlassian MCP server, dispatches one separate general-purpose worker per review, then deduplicates and moderates findings before printing PR-ready output.
+
+## Required Inputs
+
+- Shared review context built by this skill
+- Review rubrics in `docs/reviews/`
+- Root `AGENTS.md`
+- Touched component `AGENTS.md` files
+- Relevant `docs/adr/*.md`, plans, and issue documents
+- Jira ticket context when a Jira key is supplied or inferred, or the user's explicit reason when there is no Jira ticket
+
+## Entry Modes
+
+| User Request | Mode | Review Location |
+|--------------|------|-----------------|
+| Review the current branch, local change, local PR, or current work | Local branch mode | Current checkout |
+| Review PR `<number>` | PR number mode | `.worktrees/pr-<number>-review` |
+
+## Local Branch Mode Preflight
+
+1. Identify the current branch.
+2. Compare with `origin/main` using the merge-base diff, not local `main` and not only uncommitted changes.
+3. Capture changed files, changed delivery units, and a diff summary for the shared review context.
+
+Useful commands:
+
+```bash
+git diff --name-status origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+If `origin/main` may be stale, say so in the console summary. Do not use local `main` as a fallback.
+
+## PR Number Mode Preflight
+
+Use this mode when the user supplies a PR number. Do not check out the PR in the current workspace.
+
+1. Verify `gh` is available and authenticated.
+2. Read PR metadata:
+
+```bash
+gh pr view <number> --json number,headRefName,baseRefName,headRepositoryOwner,headRepository
+```
+
+3. Create or reuse an isolated worktree at `.worktrees/pr-<number>-review`:
+   - If the path does not exist, create the `.worktrees` parent and add a worktree for the PR branch.
+   - If the path exists, reuse it only if it is already a git worktree for the same PR branch.
+   - If the path exists for anything else, stop and ask before overwriting or deleting it.
+4. Check out the PR in that worktree, not in the original checkout. Create the worktree from the remote-tracking base branch, not local `main`:
+
+```bash
+mkdir -p .worktrees
+git worktree add --detach .worktrees/pr-<number>-review origin/<baseRefName>
+gh pr checkout <number>
+```
+
+Run `gh pr checkout <number>` with the worktree as the working directory.
+
+5. In the worktree, fetch or update the PR base branch if needed, then compare against the remote-tracking PR base branch from metadata. Never compare a PR against local `main`:
+
+```bash
+git diff --name-status origin/<baseRefName>...HEAD
+git diff --stat origin/<baseRefName>...HEAD
+git diff origin/<baseRefName>...HEAD
+```
+
+6. Capture PR number, worktree path, head branch, base branch, changed files, changed delivery units, and a diff summary for the shared review context.
+
+If `gh` is unavailable, authentication fails, PR metadata cannot be read, or PR checkout fails, stop with a clear blocker. Do not fall back to reviewing the current checkout.
+
+## Jira Context
+
+Gather Jira ticket context once and include it in the shared review context.
+
+1. If the user supplies a Jira key such as `PT-456`, use it.
+2. If no key is supplied, infer one from PR title/body, branch name, or commits in the reviewed range.
+3. If no key can be inferred, prompt the user before dispatching review workers. The user must either provide the Jira key or state that there is no Jira ticket and give a short reason.
+4. If the user provides a Jira key, use it. If the user states there is no Jira ticket, set `Jira: none - <user reason>` in the shared review context.
+5. If a key is found or provided, read the issue context with the Atlassian MCP Jira issue-read tool, such as `getJiraIssue` or `mcp__atlassian__getJiraIssue`. Use cloud ID `33d26043-7c2e-4336-9417-5b2f478506e7` and request these fields:
+   - `summary`
+   - `status`
+   - `assignee`
+   - `description`
+   - `parent`
+   - `customfield_10093` (Motivation)
+   - `customfield_10094` (Requirements)
+   - `customfield_10097` (Wireframe)
+6. If no Atlassian MCP Jira issue-read tool is available, authentication fails, the configured token lacks Jira read access, or the Jira issue cannot be fetched, stop before dispatching review workers. Tell the user to configure Atlassian MCP with a read-only Jira API token as described in `CONTRIBUTING.md`, then rerun the review.
+7. Extract useful review context from the returned issue:
+    - key
+    - summary
+    - status
+    - assignee
+    - description
+    - parent or epic when available
+    - motivation, requirements, and wireframe fields when available for epics
+8. Jira descriptions and custom fields may be Atlassian Document Format JSON; recursively extract text from `content` nodes and preserve headings, list items, and links where useful.
+
+Do not use `Jira: not provided` merely because inference failed. The shared review context must contain either fetched Jira context or `none - <user reason>`. A known Jira key without fetched Jira context is a blocker, not review context.
+
+Missing Jira context is not automatically a `fix now`. Treat it as unknown intent unless the implementation appears to solve the wrong problem or the missing ticket context makes merge unsafe.
+
+## Shared Review Context
+
+Build this once before running any focused review. Each review must use this as the single source of truth for what changed and why.
+
+```text
+Review Target: local branch | PR <number>
+Worktree: <path or N/A>
+Head: <branch or SHA>
+Base: <base branch>
+Diff Range: <base>...HEAD
+Diff Commands: <commands used>
+Changed Files: <name-status summary>
+Changed Delivery Units: <list>
+Diff Summary: <stat and concise behavioral summary>
+Jira: <key, summary, status, relevant description/requirements; key with fetch failure; or none - user reason>
+Guidance Read: <root/component AGENTS.md files>
+Relevant Repo Context: <ADRs, plans, issue docs, tests, or N/A>
+```
+
+Do not let individual reviews choose a different base branch, diff range, or Jira ticket. If a reviewer believes the shared context is wrong, it must report that as a finding instead of silently changing inputs.
+
+## Review Workers
+
+Run these independently. Dispatch one separate general-purpose worker for each review:
+
+| Review | Rubric |
+|--------|--------|
+| Security Review | `docs/reviews/security-review.md` |
+| ADR Review | `docs/reviews/adr-review.md` |
+| Frontend Review | `docs/reviews/frontend-review.md` |
+| Backend Review | `docs/reviews/backend-review.md` |
+| High-Risk Surface Review | `docs/reviews/high-risk-surface-review.md` |
+
+Each review worker gets exactly two inputs:
+
+- The shared review context from this skill
+- That review's rubric
+
+Worker instructions:
+
+- Use a host-provided general-purpose worker.
+- Workers are read-only: they must not edit files, run formatters, apply fixes, commit, or create report files.
+- Each worker returns one Markdown review section using the required summary format.
+- Each worker must decide only its own review outcome: `approved`, `request changes`, or `not applicable`.
+- Run the five workers concurrently when possible; otherwise run them sequentially without changing their prompts or shared context.
+- The coordinating worker must not print the returned sections immediately. It must first run finding moderation, then print the moderated five-section output and compact index.
+- If a worker fails, do not synthesize its approval. Mark that review as `request changes` with a `fix now` finding explaining that the review could not be completed.
+
+Prompt template for each review worker:
+
+```text
+You are running the <Review Name> for an Elevate change. Do not modify files.
+
+Use exactly these inputs:
+1. Shared review context:
+<paste shared review context>
+
+2. Rubric:
+<paste docs/reviews/<rubric>.md>
+
+Return one GitHub-flavored Markdown review section using the Elevate Review summary format. Use only these finding classifications: fix now, defer, reject with reason. Do not emit an overall verdict. Do not choose a different diff range, base branch, Jira ticket, or rubric.
+```
+
+## Finding Classifications
+
+Every finding must use exactly one classification:
+
+| Classification | Meaning |
+|----------------|---------|
+| `fix now` | Must be fixed before merge. Any `fix now` makes that review `request changes`. |
+| `defer` | Valid concern, but not blocking this change. Defer-only reviews are `approved`. |
+| `reject with reason` | Considered and explicitly not a problem. Include the rationale. |
+
+Do not use severity-only labels such as blocker, major, minor, or nit. Do not emit `approved with comments`.
+
+## Finding Moderation
+
+After all review workers return and before printing the final review, moderate the findings.
+
+### Deduplicate Findings
+
+1. Parse every finding from every review section.
+2. Group findings that describe the same underlying issue, even when they cite different rubrics, files, wording, or impacts.
+3. Treat findings as duplicates when fixing one code or contract problem would resolve all of them.
+4. Do not group findings merely because they touch the same file, endpoint, or feature.
+5. Pick one canonical finding per duplicate group. Prefer, in order:
+   - the finding with the clearest root-cause statement and action;
+   - the finding from the most directly owning review area;
+   - the earliest review in this order: Security, ADR, Frontend, Backend, High-Risk Surface.
+6. Preserve useful evidence from duplicates by merging it into the canonical finding if it adds materially different context.
+
+Example duplicate group: if Backend Review and High-Risk Surface Review both report that exported YAML omits DB identifiers required for import update-vs-create semantics, keep one canonical finding and suppress the duplicate in the later section.
+
+### User Classification Gates
+
+Before printing the final review, prompt the user to confirm moderated finding classifications. Run the `fix now` gate first, then the `defer` gate.
+
+#### Fix-Now Gate
+
+Prompt the user with the full canonical YAML for all unique findings currently classified as `fix now`, followed by a concise classification checklist.
+
+Prompt format:
+
+````text
+Review the unique fix-now findings before I print the PR-ready review. Mark each as fix now, defer, or reject with reason.
+
+```yaml
+- id: 1
+  current_classification: fix now
+  canonical_review: <Review Name>
+  summary: <short issue summary>
+  file: <path:line or N/A>
+  issue: <full issue>
+  evidence: <full evidence>
+  impact: <full impact>
+  action: <full action>
+```
+
+1. [fix now/defer/reject with reason] <short issue> (<canonical review>, <file>)
+2. [fix now/defer/reject with reason] <short issue> (<canonical review>, <file>)
+````
+
+Rules:
+
+- Ask once for all unique `fix now` findings.
+- Include a short summary and the full canonical finding fields before the checklist: file, issue, evidence, impact, and action. Do not require the user to ask for more detail before classifying.
+- Do not print the final review until the user has classified every unique `fix now` finding.
+- If the user keeps a finding as `fix now`, the canonical review remains `request changes`.
+- If the user marks a finding as `defer`, change the canonical finding and every duplicate in that group to `defer`.
+- If the user marks a finding as `defer` and gives a reason, include that reason in the finding action.
+- If the user marks a finding as `defer` and gives no reason, keep the reviewer-provided action as the deferred follow-up.
+- If the user marks a finding as `reject with reason`, require or ask for the reason before continuing. Change the canonical finding and every duplicate in that group to `reject with reason`, and include the reason in the action.
+- If there are no unique `fix now` findings, skip this gate.
+
+#### Defer Gate
+
+After the fix-now gate, prompt the user with the full canonical YAML for all unique findings currently classified as `defer`, including findings that were originally `defer` and findings reclassified to `defer` during the fix-now gate, followed by a concise classification checklist.
+
+Prompt format:
+
+````text
+Review the unique defer findings before I print the PR-ready review. Confirm each as defer, optionally add a reason, or reject with reason.
+
+```yaml
+- id: 1
+  current_classification: defer
+  canonical_review: <Review Name>
+  summary: <short issue summary>
+  file: <path:line or N/A>
+  issue: <full issue>
+  evidence: <full evidence>
+  impact: <full impact>
+  action: <full action>
+```
+
+1. [defer/reject with reason] <short issue> (<canonical review>, <file>) reason: <optional>
+2. [defer/reject with reason] <short issue> (<canonical review>, <file>) reason: <optional>
+````
+
+Rules:
+
+- Ask once for all unique `defer` findings after fix-now reclassification is complete.
+- Include a short summary and the full canonical finding fields before the checklist: file, issue, evidence, impact, and action. Do not require the user to ask for more detail before classifying.
+- Do not print the final review until the user has confirmed every unique `defer` finding.
+- If the user confirms `defer` and gives a reason, include that reason in the finding action.
+- If the user confirms `defer` and gives no reason, keep the reviewer-provided action as the deferred follow-up.
+- If the user marks a finding as `reject with reason`, require or ask for the reason before continuing. Change the canonical finding and every duplicate in that group to `reject with reason`, and include the reason in the action.
+- If there are no unique `defer` findings, skip this gate.
+
+### Suppress Duplicates In Final Output
+
+Keep all five review sections in the final output, but avoid repeating the full text of duplicate findings.
+
+For the canonical review section, print the full canonical finding with the user-approved classification.
+
+For later duplicate sections, replace the full duplicate with a compact suppression finding:
+
+```text
+- classification: reject with reason | defer
+  file: <duplicate file or N/A>
+  issue: Duplicate finding: <short issue>.
+  evidence: Same underlying issue as <Canonical Review> finding.
+  impact: Already represented once in the PR-ready review output.
+  action: See <Canonical Review> finding.
+```
+
+Use `reject with reason` for duplicate suppression when the canonical finding remains `fix now` or is reclassified as `reject with reason`. Use `defer` when the canonical finding is classified as `defer`.
+
+## Markdown Summary Format
+
+Print the final moderated review as GitHub-flavored Markdown. Use a compact metadata table, second-level review headings, bold field labels, and fenced `yaml` blocks for findings so the output can be pasted directly into GitHub or Jira.
+
+````markdown
+| Field | Value |
+|---|---|
+| Review Target | local branch \| PR <number> |
+| Worktree | <path or N/A> |
+| Head | <branch or SHA> |
+| Base | <base branch> |
+| Jira | <key and summary, fetch failure, or not provided> |
+
+## <Review Name>
+**Outcome:** approved | request changes | not applicable  
+**Rubric:** `docs/reviews/<file>.md`  
+**Scope:** <why this review applies, or why it is not applicable>
+
+**Findings:**
+```yaml
+- classification: fix now | defer | reject with reason
+  file: path:line or N/A
+  issue: concise statement
+  evidence: diff, ADR, AGENTS.md, or repo evidence
+  impact: concrete consequence
+  action: required fix, deferred follow-up, or rejection rationale
+```
+
+If no findings:
+**Findings:** none
+````
+
+After all five moderated sections, print only a compact Markdown table of outcomes. Do not collapse them into a single overall verdict.
+
+After printing the final moderated review and compact outcomes table to the console, ask the user which delivery action to take next:
+
+1. Save the printed review to a file.
+2. Add the printed review as a comment on the PR.
+
+Do not save a file or post a PR comment before the user chooses one of these options. If the review target has no known PR number, say that PR commenting needs a PR number before offering the file option.
+
+## Lifecycle Rules
+
+- A review with any `fix now` finding is `request changes`.
+- A review with no findings is `approved`, unless its rubric says `not applicable`.
+- A review with only `defer`, `reject with reason`, and/or duplicate-suppression findings is `approved`.
+- Reviews remain independent during worker execution. Deduplication happens only in the coordinating worker's moderation step after all reviews have returned.
+- If evidence is insufficient, classify the uncertainty as `fix now` only when merge would be unsafe without resolving it; otherwise use `defer` with the missing evidence.
+
+## Test Recommendations
+
+This review skill does not run functional, integration, Extended, or Kind tests. When the change warrants one of those workflows, recommend the applicable repository testing skill after the moderated review. Do not invoke that skill or execute its commands automatically; any later run must follow that skill's separate preview and explicit-confirmation contract.
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---------|------------|
+| Reviewing only the working tree | Review `origin/main...HEAD` for local branch mode, including committed branch changes. |
+| Comparing against local `main` | Use `origin/main...HEAD` for local branch mode and `origin/<baseRefName>...HEAD` for PR number mode. Local `main` can be stale or unrelated to the PR base. |
+| Checking out a PR in the current workspace | For PR numbers, create and review inside `.worktrees/pr-<number>-review`. |
+| Falling back to the current branch after PR checkout fails | Stop with a clear blocker instead. |
+| Letting each review decide what to diff | Build one shared review context and pass it to every review. |
+| Ignoring a supplied Jira key | Include Jira context in the shared review context. |
+| Setting Jira to not provided after inference fails | Ask the user for the Jira key or a no-ticket reason before dispatching review workers. |
+| Fetching Jira ad hoc in each review worker | Fetch Jira once with Atlassian MCP before dispatching workers. |
+| Continuing after Atlassian MCP fails for a known Jira key | Stop early and tell the user to configure Atlassian MCP with a read-only Jira API token. |
+| Running all reviews in the coordinating worker | Dispatch one separate general-purpose worker per review. |
+| Creating report files before the user chooses file output | Print the review to the console first, then offer file output or PR comment as the next action. |
+| Printing plain-text output | Print the final moderated review as GitHub-flavored Markdown using the Markdown Summary Format. |
+| Producing one combined verdict | Keep outcomes independent per review. |
+| Using severity labels | Use only `fix now`, `defer`, or `reject with reason`. |
+| Treating deferred findings as blocking | Defer-only reviews are `approved`. |
+| Skipping ADR lookup | ADR review must identify and include selected accepted ADRs in the review output. |
+| Treating `elevate-frontend/AGENTS.md` as background only | Frontend Review must validate frontend PRs against every applicable instruction in `elevate-frontend/AGENTS.md`. |
+| Printing raw worker output directly | First dedupe findings and run the fix-now and defer classification gates. |
+| Repeating the same fix-now issue in multiple sections | Keep the canonical finding and replace duplicates with compact suppression findings. |
+
+## Red Flags
+
+- "This is just a quick review" means still run all five review sections.
+- "PR 123" means PR number mode; do not review the current checkout.
+- "main...HEAD is close enough" means stop; use `origin/<baseRefName>...HEAD` for PR number mode or `origin/main...HEAD` for local branch mode.
+- "PT-456" means include Jira ticket context in every focused review.
+- "The rubric says diff" means use the shared context; rubrics do not own diff selection.
+- "I'll just do the reviews myself" means stop and dispatch one separate general-purpose worker per review.
+- "Frontend/backend did not change" means emit `not applicable`, not skip the section silently.
+- "No findings" still requires an explicit outcome and scope note.
+- "One review already caught it" does not remove another review worker's independent responsibility; it only affects final moderated output.
+- "The workers are done" does not mean print final output; first dedupe and run the user classification gates.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -599,8 +599,9 @@ ui/.next/
 
 # Gas Town (added by gt)
 .runtime/
-# Claude Code — local agents/prompts under .claude/agents/ (not committed)
-.claude/
+# Claude Code — local-only state
+**/.claude/worktrees/
+**/.claude/settings.local.json
 .beads/
 .logs/
 

--- a/.gitignore
+++ b/.gitignore
@@ -599,7 +599,7 @@ ui/.next/
 
 # Gas Town (added by gt)
 .runtime/
-# Claude Code — local-only state
+# Claude Code — local worktrees and settings (not committed)
 **/.claude/worktrees/
 **/.claude/settings.local.json
 .beads/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,37 @@ Make sure to update the `README.md` if necessary.
 * Maintainers will review your submission, provide feedback if needed, and merge it once it meets the project’s requirements. We commit
 to review the PR within 3 working days.
 
+## Review Skill Beta
+
+Use the `support-bot-review` skill when reviewing support-bot PRs or local branches. The skill is in beta: treat its output as reviewer support, not as an automated decision. Reviewers are expected to understand every finding, validate it against the codebase, and make their own judgement before requesting changes or approving a PR.
+
+The review skill requires Atlassian MCP access when a Jira ticket is supplied or inferred. Configure Atlassian MCP with a Jira read-only personal API token before using the skill for ticket-backed work. If the Atlassian MCP server is unavailable, the skill exits early and asks you to set it up rather than reviewing without ticket context.
+
+To configure Atlassian MCP in your MCP client:
+
+1. Create an Atlassian personal API token with only Jira read scopes.
+2. Base64-encode `<email>:<api-token>`.
+3. Add the Atlassian MCP server using this endpoint and authorization header:
+
+   ```json
+   {
+     "atlassian": {
+       "type": "remote",
+       "url": "https://mcp.atlassian.com/v1/mcp",
+       "headers": {
+         "Authorization": "Basic <base64-email-colon-token>"
+       }
+     }
+   }
+   ```
+
+4. Restart your MCP client if it does not hot-reload MCP configuration.
+5. Verify read access by asking your agent to read a known EL issue.
+
+The Jira cloud ID used by the review skill is `33d26043-7c2e-4336-9417-5b2f478506e7`. Do not grant write scopes for review-skill usage.
+
+During beta, improve the review system when it produces an invalid, unclear, duplicated, or missing finding. Depending on where the issue came from, update the relevant guidance in `AGENTS.md`, `.agents/skills/support-bot-review`, or `docs/reviews/`. The goal is to iterate until the review process is reliable enough to become automated.
+
 ## Coding standards/style
 
 * We use [PMD](https://pmd.github.io/) for linting

--- a/docs/reviews/adr-review.md
+++ b/docs/reviews/adr-review.md
@@ -1,0 +1,35 @@
+# ADR Review
+
+## Purpose
+
+Identify which accepted ADRs are relevant to a change and check whether the implementation conforms to those decisions.
+
+## Change Context
+
+Review the supplied change context: changed files, changed modules, Jira ticket context, module guidance, relevant repository documents, and the selected ADRs. Use Jira context to understand the intended architectural scope and whether the work introduces a new decision that should be documented.
+
+## Scope Detection
+
+Run this review for every change. Treat it as higher risk when the change includes:
+
+- Architecture, cross-service contracts, authentication, RBAC, APIs, or infrastructure
+- Database migrations, testing strategy, deployment strategy, external integrations, or model/provider choices
+- Behavior that appears to update, replace, or bypass a documented decision
+
+## Review Checklist
+
+- Identify the accepted ADRs under `docs/adr/` relevant to the changed files and behavior.
+- Include the selected ADRs in the review output, even when no conformance findings are raised.
+- For each selected ADR, state why it is relevant to the change.
+- Check whether the implementation follows each selected ADR's decision and consequences.
+- Check whether any ADR-described limitation has changed and needs documentation updates.
+- Check whether a new architectural decision is being introduced without an ADR.
+- Use repo evidence, not assumptions; cite ADR numbers and paths in findings.
+
+## Approval Rules
+
+Approve when selected ADRs have been included in the review output and no blocking conformance issue remains.
+
+## Request Changes Rules
+
+Request changes when the change contradicts an accepted ADR, bypasses an ADR-mandated path, introduces a material architectural decision without documentation, leaves directly relevant ADR text misleading, or omits selected ADRs from the ADR review output.

--- a/docs/reviews/backend-review.md
+++ b/docs/reviews/backend-review.md
@@ -1,0 +1,49 @@
+# Backend Review
+
+## Purpose
+
+Find backend regressions in the Spring Boot service under `api/` — controllers, services, repositories, entities, migrations, transactions, validation, Slack integration, tests, and backend implementation quality.
+
+## Change Context
+
+Review the supplied change context: changed files, changed modules, Jira ticket context, module guidance, relevant ADRs, and other repository evidence. Use Jira context to check that backend behavior, data model changes, auth behavior, and API semantics match the intended workflow and acceptance criteria.
+
+## Scope Detection
+
+Run this review when the change includes files under `api/`. If no backend files changed, report `not applicable` using the review summary format.
+
+## Common Backend Guidance
+
+- Read root `AGENTS.md` and `api/AGENTS.md`; module guidance overrides root guidance.
+- Follow existing Lombok usage patterns in `api/` rather than introducing manual boilerplate.
+- Use constructor injection, `@RestController` for APIs, `@Service` for business logic, `@Repository` for data access, and `@ControllerAdvice` for global exception handling.
+- Prefer maintained Spring or Spring Boot functionality over custom framework-style code for lifecycle hooks, configuration binding, validation, scheduling, transactions, conditionals, web/error handling, and resource management. If custom logic appears to solve a framework concern, check current Spring/Spring Boot documentation or another reliable current source before raising a finding.
+- Use Flyway migrations named `V{version}__{description}.sql` under `api/service/src/main/resources/db/migration`, proper JPA annotations, and `@Transactional` for data modifications.
+- Run or require `./gradlew spotlessApply` after Java changes; ErrorProne warnings are errors (`-Werror`), NullAway applies to `com.coreeng.supportbot`, and Checkstyle enforces `UPPER_SNAKE_CASE` enum constants.
+- When adding or changing enum codes, follow `docs/enum-codes.md` and avoid orphaned enum references (see `docs/runbooks/orphaned-enum-references.md`).
+- Keep Slack integration changes consistent with the established Slack gateway and handler patterns in `api/`.
+- Cover every module and function with unit tests; add functional tests (`api/functional/`) for new features and bug fixes, and integration tests (`api/integration-tests/`) when introducing or modifying a third-party service or external dependency, per `CONTRIBUTING.md`.
+- Apply SOLID: cohesive responsibilities, narrow interfaces, injected dependencies, and strategy/composition for extension rather than broad branching.
+- Keep payloads intentional, distinguish absent/unknown from empty, add size guardrails for unbounded data, encode boundary values, and authorize every endpoint.
+
+## Review Checklist
+
+- Controllers and auth entry points use established current-user, role, and authorization patterns.
+- Services keep business logic cohesive and use constructor-injected dependencies.
+- Changes avoid custom framework-style logic when Spring or Spring Boot already provides a simpler supported feature; reviewers verify current Spring/Spring Boot functionality before making this a finding.
+- Data access respects transaction boundaries and existing repository patterns.
+- Migrations, JPA entities, DTOs, and database constraints stay consistent.
+- Validation and error mapping produce safe, intentional API behavior.
+- Async, scheduled, startup, and external-provider work is durable or coordinated where required by ADRs.
+- Implementation is simple, cohesive, and consistent with established naming and module patterns.
+- Tests cover external behavior, including functional tests when new functionality warrants it.
+- Public and internal backend contracts preserve expected compatibility unless the change intentionally updates them.
+- No debug flags, local URLs, secrets, stale comments, dead code, or unrelated cleanup are introduced.
+
+## Approval Rules
+
+Approve when backend behavior is correct, authorized, maintainable, consistent with module and ADR guidance, and aligned with the Jira ticket's intended behavior.
+
+## Request Changes Rules
+
+Request changes for missing authorization, unsafe migrations, broken transaction semantics, incorrect API/auth behavior, implementation that does not satisfy the Jira ticket's intended backend behavior, missing required behavioral tests, confusing backend design that materially increases maintenance risk, or a `fix now` finding for custom logic that duplicates likely built-in Spring functionality after the reviewer verifies the current Spring/Spring Boot feature and the built-in would reduce maintenance risk without violating repo requirements.

--- a/docs/reviews/frontend-review.md
+++ b/docs/reviews/frontend-review.md
@@ -1,0 +1,37 @@
+# Frontend Review
+
+## Purpose
+
+Find frontend regressions in Next.js, React, TypeScript, UI behavior, API usage, auth gating, user-facing error handling, and frontend implementation quality.
+
+## Change Context
+
+Review the supplied change context: changed files, changed modules, Jira ticket context, module guidance, relevant ADRs, and other repository evidence. Use Jira context to check that the changed UI and frontend behavior match the intended user workflow and acceptance criteria.
+
+## Scope Detection
+
+Run this review when the change includes files under `ui/`. If no frontend files changed, report `not applicable` using the review summary format.
+
+When the diff includes files under `ui/`, the shared review context must include `ui/AGENTS.md`, and the Frontend Review agent must validate the PR against every applicable rule, convention, anti-pattern, and testing expectation in that file. Treat `ui/AGENTS.md` as a checklist covering package-manager and formatting rules, design-system tokens, shadcn primitives, page/section/card anatomy, numeric formatting, tables and pagination, filters, charts, dialogs, spacing rhythm, animations, theming, cursor affordances, and the pre-PR checklist. Cite `ui/AGENTS.md` as repo evidence for any violation.
+
+## Review Checklist
+
+- Routes, layouts, components, and API calls preserve expected behavior.
+- Auth/session checks happen at the right boundary and do not rely only on hidden UI controls.
+- Frontend RBAC or feature gating is consistent with backend authorization and ADRs.
+- API calls use the intended contracts, error mapping, caching, and revalidation behavior.
+- Loading, empty, error, and permission-denied states are handled.
+- User input is validated or safely encoded before reaching APIs or structured formats.
+- Changed UI remains usable on desktop and mobile and follows the `ui/AGENTS.md` design system.
+- Implementation is simple, cohesive, and consistent with established naming and component patterns.
+- Tests cover changed user-visible behavior where the repo has a test pattern for it.
+- Public and internal frontend contracts preserve expected compatibility unless the change intentionally updates them.
+- Dead code, stale comments, debug UI, local URLs, secrets, and accidental test data are absent.
+
+## Approval Rules
+
+Approve when changed frontend behavior is correct, authorized, maintainable, and covered by appropriate verification or clear repo evidence.
+
+## Request Changes Rules
+
+Request changes for broken user flows, missing auth boundary checks, unsafe data exposure, contract mismatches, unhandled critical states, implementation that does not satisfy the Jira ticket's intended user workflow, missing required tests for changed behavior, or confusing frontend design that materially increases maintenance risk.

--- a/docs/reviews/high-risk-surface-review.md
+++ b/docs/reviews/high-risk-surface-review.md
@@ -1,0 +1,50 @@
+# High-Risk Surface Review
+
+## Purpose
+
+Find risks on high-blast-radius surfaces: database schema, APIs, new modules, dependencies, external integrations, async work, and deployment behavior.
+
+## Change Context
+
+Review the supplied change context: changed files, changed modules, Jira ticket context, module guidance, relevant ADRs, and other repository evidence. Use Jira context to check whether high-risk changes are necessary for the requested work and whether the ticket's scope justifies their blast radius.
+
+## Scope Detection
+
+Run this review for every change. Treat the review as especially important when the change includes:
+
+- Flyway migrations, JPA entities, indexes, constraints, or data backfills
+- Public or cross-service APIs, DTOs, wire formats, API clients, or generated contracts
+- New modules, services, packages, routes, jobs, or schedulers
+- Library, plugin, container, chart, or build dependencies
+- External provider integrations (Slack, GitHub, LLM providers), retries, idempotency, queues, scheduled work, startup work, or long-running jobs
+- Helm, Kubernetes, secrets, resource limits, autoscaling, or deployment config
+- Integration, end-to-end, or functional tests that create persistent data, users, external-provider objects, files, browser state, cloud resources, or other shared-environment resources
+
+## Review Checklist
+
+- Database changes are backward-compatible where required; migrations live in `api/service/src/main/resources/db/migration` and are safe for existing data, repeatable environments, and multi-replica deployments.
+- API changes have explicit contracts, auth behavior, validation, pagination/size limits, and error semantics.
+- New modules or services have ownership, tests, configuration, deployment, monitoring, and security boundaries.
+- New dependencies are necessary, maintained, licensed appropriately, and do not duplicate existing capabilities.
+- Async, scheduled, startup, and external-provider work follows idempotency, durable claiming, or coordination patterns required by ADRs.
+- Deployment changes do not introduce single-replica assumptions, secret exposure, or resource regressions.
+- High-risk behavior has suitable tests or documented verification evidence.
+
+## Integration Test Resource Cleanup
+
+When reviewing integration, end-to-end, or functional tests, explicitly check whether the test creates persistent resources and how those resources are cleaned up.
+
+- Test data cleanup is registered before or at the same time as the resource is created, not only after post-create assertions succeed.
+- Cleanup runs on failure paths, timeouts, skipped assertions, and partial setup wherever the test framework supports hooks or finally blocks.
+- Cleanup covers all persistent resources the test can create, including application records, users, external-provider objects, files, browser storage, and cloud resources.
+- Cleanup is isolated to the resources owned by the current test run and cannot delete shared fixtures or another run's resources.
+- Failures in best-effort cleanup are visible enough to diagnose leaked resources.
+- Tests that intentionally leave resources behind document why that is safe for repeatable CI and shared environments.
+
+## Approval Rules
+
+Approve when changed high-risk surfaces are intentional, bounded, tested or verifiable, consistent with ADRs, and justified by the Jira ticket or change context.
+
+## Request Changes Rules
+
+Request changes for unsafe migrations, under-specified API changes, unjustified dependencies, unowned modules, uncoordinated async/scheduled work, deployment regressions, high-risk changes outside the Jira ticket's intended scope, high-risk changes without adequate verification, or integration tests that can leak persistent resources in shared environments when setup or post-create assertions fail.

--- a/docs/reviews/security-review.md
+++ b/docs/reviews/security-review.md
@@ -1,0 +1,47 @@
+# Security Review
+
+## Purpose
+
+Find security regressions in a change, especially around APIs, authentication, authorization, view permissions, secrets, and sensitive support-thread data handling.
+
+## Change Context
+
+Review the supplied change context: changed files, changed modules, Jira ticket context, module guidance, relevant ADRs, and other repository evidence. Use that context to decide whether the security posture matches the intended users, permissions, and scope.
+
+## Auth, Permissions, And Data ADRs
+
+When the change touches authentication, authorization, view permissions, or export/exposure of support-thread data, explicitly check the relevant ADRs from this list:
+
+- `docs/adr/adr-003-rework-view-permissions.md` — view permissions for tickets and escalations.
+- `docs/adr/adr-008-single-oauth2-oidc-provider.md` — single OAuth2/OIDC provider for authentication.
+- `docs/adr/adr-005-configurable-thread-sanitisation.md` — configurable thread sanitisation for data export.
+- `docs/adr/adr-001-support-area-summary.md` — summary data export/import for knowledge gap analysis.
+
+## Scope Detection
+
+Run this review for every change. Treat it as higher risk when the change includes:
+
+- Controllers, route handlers, middleware, filters, or API clients
+- Dex, LDAP, OAuth, OIDC, JWT, session, cookie, token, role, or permission code
+- Database access paths or queries that enforce view permissions
+- Logs, errors, exports, reports, Slack messages, or payloads that may expose sensitive data
+- Dependencies, container images, Helm values, secrets, or deployment configuration
+
+## Review Checklist
+
+- New or changed APIs enforce authentication and authorization at every entry point.
+- New or changed APIs have explicit RBAC where user roles matter.
+- Auth, permission, and data-export changes conform to the relevant ADRs above.
+- Responses, exports, and Slack-facing output do not expose thread content the requesting user cannot view, and exported data respects the configured sanitisation rules.
+- Inputs are validated and encoded for their transport and storage boundary.
+- Responses, logs, errors, and frontend-visible state do not expose secrets or unrelated user data.
+- Secrets and credentials remain in environment/configuration stores, not source code or logs.
+- Security-relevant dependency changes are intentional and justified.
+
+## Approval Rules
+
+Approve when the change does not show a blocking security concern, even if deferred follow-up is worth tracking separately.
+
+## Request Changes Rules
+
+Request changes for missing auth/RBAC on new APIs, view-permission bypass, unsanitised or over-broad data export, sensitive data exposure, hard-coded secrets, unsafe token/session handling, or auth behavior that conflicts with accepted ADRs or the Jira ticket's intended access model.


### PR DESCRIPTION

Ports core-elevate's elevate-review skill into this repo as support-bot-review: five focused reviews (security, ADR, frontend, backend, high-risk surface) with moderation and PR-ready output.

- Adds the skill under .agents/skills/ plus the .claude/skills symlink
- Adapts it to support-bot: modules instead of delivery units, ui/AGENTS.md as the frontend checklist, EL Jira keys, support-bot ADRs
- Ports the five rubrics to docs/reviews/, rewriting backend/security for the api/ Spring Boot service
- Adds a Review Skill Beta section to CONTRIBUTING.md (Atlassian MCP setup)
- Narrows the .claude/ gitignore to worktrees/ + settings.local.json so shared skill files commit normally