### PR TITLE
Fix Codeowner gate bugs

### DIFF
--- a/api/functional/src/test/java/com/coreeng/supportbot/GitHubCodeownerLifecycleFunctionalTests.java
+++ b/api/functional/src/test/java/com/coreeng/supportbot/GitHubCodeownerLifecycleFunctionalTests.java
@@ -313,11 +313,9 @@ public class GitHubCodeownerLifecycleFunctionalTests {
                         .build());
 
         // Seed straight into AWAITING_MERGE with a live merge deadline, so the transition under test is the
-        // "no longer approved/mergeable" exit, not a merge-SLA breach. codeownerReviewRequested(true) models
-        // a genuine prior code-owner approval that's since been revoked: without it, the poller can't tell
-        // this apart from "code-owner review never applied to this PR's paths" (a repo that also has a
-        // minimum-approval-count rule reports the identical REVIEW_REQUIRED + empty reviewRequests signature
-        // either way — see PrLifecyclePoller#codeownerApproved) and would wrongly stay in AWAITING_MERGE.
+        // "no longer approved/mergeable" exit, not a merge-SLA breach. A revoked code-owner approval reads
+        // as a definite `false` aggregate (reviewDecision REVIEW_REQUIRED, no changes-requested verdict) —
+        // codeownerApproved() fails closed on that unconditionally, so the record must pause back to OPEN.
         var record = supportBotClient
                 .test()
                 .createPrTrackingRecord(SupportBotClient.PrTrackingToCreate.builder()
@@ -329,7 +327,6 @@ public class GitHubCodeownerLifecycleFunctionalTests {
                         .slaDeadline(Instant.now().plus(Duration.ofHours(23)))
                         .owningTeam("wow")
                         .canAutoCloseTicket(false)
-                        .codeownerReviewRequested(true)
                         .build());
 
         // Poll: the PR is still open and mergeable, but the code-owner approval was revoked (GraphQL

--- a/api/service/src/main/java/com/coreeng/supportbot/elevate/ElevateEnabledController.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/elevate/ElevateEnabledController.java
@@ -1,0 +1,27 @@
+package com.coreeng.supportbot.elevate;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes whether the Elevate integration is configured. Deliberately unrestricted by role (unlike
+ * {@link ElevateStatusController}'s {@code @PreAuthorize}) — still requires authentication — so the
+ * UI sidebar can check this for every user to decide whether to show the Elevate nav item, without a
+ * 403 for users lacking the restricted-dashboards role.
+ */
+@RestController
+@RequestMapping("/elevate")
+@RequiredArgsConstructor
+public class ElevateEnabledController {
+
+    private final ElevateQueryService elevateQueryService;
+
+    @GetMapping("/enabled")
+    public FeatureStatus enabled() {
+        return new FeatureStatus(elevateQueryService.configured());
+    }
+
+    public record FeatureStatus(boolean enabled) {}
+}

--- a/api/service/src/main/java/com/coreeng/supportbot/elevate/ElevateQueryService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/elevate/ElevateQueryService.java
@@ -14,6 +14,10 @@ public class ElevateQueryService {
     private final ElevateProps props;
     private final ElevateRepository repository;
 
+    public boolean configured() {
+        return props.configured();
+    }
+
     public ElevateStatusResponse status() {
         ElevateStoredStatus storedStatus = repository.getStoredStatus();
         ElevateSyncState state = storedStatus.state();

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -704,10 +704,14 @@ public class PrDetectionService {
      * message, never review-escalates — unchanged from before this class had any code-owner awareness.
      *
      * <p>One carve-out (an exception to that default): if the pending code owners ARE the repo's own
-     * maintaining team ({@link #pendingCodeOwnersAreMaintainingTeam}), chasing them makes no sense — that
-     * case gets a real review deadline instead (when {@code sla} is configured) and the normal
-     * tracked-with-a-deadline message, and can review-escalate on breach like any repo. Everything else
-     * keeps the default.
+     * maintaining team ({@link #pendingCodeOwnersAreMaintainingTeam}), chasing them makes no sense — the
+     * message never names them as something to chase, regardless of {@code sla}. The repo's configured
+     * override always wins first if present (same precedence as everywhere else in this file); failing
+     * that, {@code sla} configured gets a real review deadline and the normal tracked-with-a-deadline
+     * message and can review-escalate on breach like any repo, while no {@code sla} gets the standard
+     * no-SLA-tracked message. Everything else (a genuinely external pending code owner) keeps the
+     * default chase message even if an override is configured — the override applies to the
+     * normal/no-codeowner flow, not to a real chase.
      *
      * <p>Path filtering still applies with no {@code sla} block: like any no-SLA repo, only PRs touching
      * the configured {@code paths} are tracked.
@@ -764,9 +768,9 @@ public class PrDetectionService {
         // Mark the code-owner-request flag at insert time too, not just from the poller: the pending
         // window can close (approved then dismissed by a push) before the first poll ever runs — overnight
         // or over a weekend under the default business-hours cron — and it never reopens (GitHub does not
-        // restore a dismissed reviewer to reviewRequests). Missing it here would permanently misread the
-        // record as "code-owner review never applied to this PR's paths" (see
-        // PrLifecyclePoller#codeownerApproved).
+        // restore a dismissed reviewer to reviewRequests). Purely observability today (see
+        // PrTrackingRecord#codeownerReviewRequested), but the audit trail should reflect reality even for
+        // a PR that closes before it's ever polled.
         if (!prMetadata.codeOwnerReviewers().isEmpty()) {
             tracking = prTrackingRepository.markCodeownerReviewRequested(tracking.id());
         }
@@ -798,27 +802,35 @@ public class PrDetectionService {
                 // "tracked" message with a deadline that's already in the past.
                 handleCodeownerAlreadyOverdue(detectedPr, ticket, tracking, repoConfig, prMetadata, slaDeadline);
             } else {
-                Duration reviewSlaDuration =
-                        slaDeadline != null ? Duration.between(prMetadata.createdAt(), slaDeadline) : null;
-                PrMessageContext ctx = new PrMessageContext(
-                        detectedPr.provider(),
-                        detectedPr.repositoryName(),
-                        detectedPr.pullNumber(),
-                        resolveTeamLabel(repoConfig.owningTeam()),
-                        reviewSlaDuration,
-                        slaDeadline);
-                String override = messageRenderer.render(detectedPr.repositoryName(), MessageEvent.DETECTED, ctx);
                 String text;
-                if (override != null) {
-                    text = override;
-                } else if (slaDeadline != null) {
-                    text = formatTrackedText(
+                if (codeOwnerIsMaintainingTeam) {
+                    // See the maintaining-team carve-out paragraph in this method's class-level Javadoc.
+                    Duration reviewSlaDuration =
+                            slaDeadline != null ? Duration.between(prMetadata.createdAt(), slaDeadline) : null;
+                    PrMessageContext ctx = new PrMessageContext(
                             detectedPr.provider(),
                             detectedPr.repositoryName(),
                             detectedPr.pullNumber(),
-                            checkNotNull(ctx.sla()),
-                            checkNotNull(ctx.slaDeadline()),
-                            ctx.owningTeam());
+                            resolveTeamLabel(repoConfig.owningTeam()),
+                            reviewSlaDuration,
+                            slaDeadline);
+                    String override = messageRenderer.render(detectedPr.repositoryName(), MessageEvent.DETECTED, ctx);
+                    if (override != null) {
+                        text = override;
+                    } else if (slaDeadline != null) {
+                        text = formatTrackedText(
+                                detectedPr.provider(),
+                                detectedPr.repositoryName(),
+                                detectedPr.pullNumber(),
+                                checkNotNull(ctx.sla()),
+                                checkNotNull(ctx.slaDeadline()),
+                                ctx.owningTeam());
+                    } else {
+                        text = formatNoSlaTrackedText(
+                                detectedPr.provider(),
+                                detectedPr.repositoryName(),
+                                resolveTeamLabel(repoConfig.owningTeam()));
+                    }
                 } else {
                     text = formatCodeownerDetectedText(
                             detectedPr.provider(),
@@ -1084,7 +1096,6 @@ public class PrDetectionService {
         Provider p = pendingNotification.provider();
         String noun = PrTerminology.noun(p);
         String sep = PrTerminology.separator(p);
-        String plural = PrTerminology.plural(p);
         String text = override != null
                 ? override
                 : switch (pendingNotification.type()) {
@@ -1097,11 +1108,8 @@ public class PrDetectionService {
                                 checkNotNull(pendingNotification.slaDeadline()),
                                 checkNotNull(pendingNotification.teamLabel()));
                     case NO_SLA_TRACKED ->
-                        "%s to %s have no automated SLAs, they are monitored by %s team. I'll still keep an eye on this one and let you know when it moves."
-                                .formatted(
-                                        plural,
-                                        pendingNotification.repo(),
-                                        checkNotNull(pendingNotification.teamLabel()));
+                        formatNoSlaTrackedText(
+                                p, pendingNotification.repo(), checkNotNull(pendingNotification.teamLabel()));
                     case CHANGES_REQUESTED ->
                         formatChangesRequestedText(p, pendingNotification.repo(), pendingNotification.prNumber());
                     case APPROVED ->
@@ -1294,6 +1302,11 @@ public class PrDetectionService {
                         PrTerminology.separator(provider),
                         prNumber,
                         repo);
+    }
+
+    private String formatNoSlaTrackedText(Provider provider, String repo, String teamLabel) {
+        return "%s to %s have no automated SLAs, they are monitored by %s team. I'll still keep an eye on this one and let you know when it moves."
+                .formatted(PrTerminology.plural(provider), repo, teamLabel);
     }
 
     private String formatEscalatedText(Provider provider, String repo, int prNumber, Duration sla) {

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrLifecyclePoller.java
@@ -138,9 +138,11 @@ public class PrLifecyclePoller {
     /**
      * The first time this poll sees a genuinely pending code-owner review request ({@code
      * pr.codeOwnerReviewers()} non-empty), permanently marks {@code codeownerReviewRequested} true on
-     * the record so it's remembered on every later poll — see {@link #codeownerApproved} for why this
-     * needs to be remembered rather than re-derived each time. A no-op (no write, same record
-     * returned) once already marked, for a non-codeowner repo, or when nothing is currently pending.
+     * the record so it's remembered on every later poll. {@link #codeownerApproved} no longer reads this
+     * flag for gating (it now fails closed on any unsatisfied aggregate, pending list aside — see its
+     * Javadoc), but it is still set for observability: a durable record of whether code-owner review was
+     * ever genuinely requested for this PR. A no-op (no write, same record returned) once already
+     * marked, for a non-codeowner repo, or when nothing is currently pending.
      */
     private PrTrackingRecord withCodeownerReviewRequestedIfNewlySeen(
             PrTrackingRecord record, PrTrackingProps.@Nullable Repository repoConfig, PrMetadata pr) {
@@ -203,38 +205,34 @@ public class PrLifecyclePoller {
     }
 
     /**
-     * Resolves whether the code-owner gate is satisfied, disambiguating a case the provider's
-     * aggregate decision alone can't: {@code pr.codeOwnersApproved()} (GitHub {@code reviewDecision})
-     * conflates "require code-owner review" with any separately configured minimum-approval-count
-     * rule, so a repo with both reports the *unsatisfied* aggregate for a PR whose paths need no
-     * code-owner review at all, purely because the generic approval count isn't met yet.
+     * Resolves whether the code-owner gate is satisfied. Always {@code false} when {@code
+     * requiresCodeowners} is false; otherwise:
      *
      * <ol>
-     *   <li>A currently pending code-owner request ({@code pr.codeOwnerReviewers()} non-empty) is
-     *       always outstanding — {@code false}, no ambiguity.
      *   <li>A {@code null} aggregate means the provider read failed or the gate is unknowable (GitHub
      *       GraphQL error, GitLab CE/transport error — both source clients document null as
-     *       must-fail-closed), and on those paths the pending list is empty too. Absence of signal is
-     *       not evidence that code-owner review never applied, so hold the gate shut and let the next
-     *       poll retry. The ambiguity this method disambiguates always presents as a definite {@code
-     *       false} ({@code REVIEW_REQUIRED}), never {@code null}, so this costs nothing.
-     *   <li>No pending request, and none has ever been observed for this record ({@code
-     *       record.codeownerReviewRequested()} still false after {@link
-     *       #withCodeownerReviewRequestedIfNewlySeen}) — code-owner review has never applied to this
-     *       PR's paths, so the gate doesn't apply: {@code true}, regardless of what the aggregate
-     *       decision says.
-     *   <li>No pending request, but one was observed on an earlier poll — a genuine code-owner
-     *       approval once satisfied the gate and may since have been dismissed or invalidated by a
-     *       later push (GitHub does NOT restore a dismissed reviewer to {@code reviewRequests} —
-     *       confirmed by hand against a real PR, not merely assumed). Trust the raw provider
-     *       aggregate here: {@code true} only on an actual {@code APPROVED}/inapplicable read.
+     *       must-fail-closed). Absence of signal is not evidence that code-owner review never applied,
+     *       so hold the gate shut and let the next poll retry.
+     *   <li>An unambiguous {@code true} aggregate ({@code APPROVED}, or no review required at all) is
+     *       satisfied on its own — {@code true}, even if {@code pr.codeOwnerReviewers()} still lists
+     *       other pending reviewers. GitHub's {@code reviewDecision} is satisfied once any required
+     *       code owner approves; it does not auto-clear the rest of an auto-requested team from
+     *       {@code reviewRequests}, so a non-empty pending list here does not mean the gate is still
+     *       shut (see {@code project_codeowner_gate_mismatch_stuck_pr} — PR left permanently stuck with
+     *       no message otherwise).
+     *   <li>Anything else — aggregate is definitely {@code false} ({@code REVIEW_REQUIRED} /
+     *       {@code CHANGES_REQUESTED}) — holds the gate shut: {@code false}, whether or not a
+     *       code-owner request is currently pending.
      * </ol>
+     *
+     * <p>Deliberately fails closed on a {@code false} aggregate rather than guessing whether an empty
+     * pending list means "review never applied" or "GitHub just isn't surfacing it" — those are
+     * indistinguishable and a wrong guess previously reported PRs approved with zero real approvals
+     * (see {@code project_codeowner_approved_fail_open_bug}). Worst case here: a PR with no owned paths
+     * waits until its own ordinary approval lands before advancing, same as a non-codeowner PR would.
      */
     private boolean codeownerApproved(PrTrackingRecord record, PrMetadata pr, boolean requiresCodeowners) {
         if (!requiresCodeowners) {
-            return false;
-        }
-        if (!pr.codeOwnerReviewers().isEmpty()) {
             return false;
         }
         if (pr.codeOwnersApproved() == null) {
@@ -244,9 +242,6 @@ public class PrLifecyclePoller {
                     .log(
                             "Code-owner approval signal unreadable for {}#{} (provider read failed or unavailable), holding gate shut");
             return false;
-        }
-        if (!record.codeownerReviewRequested()) {
-            return true;
         }
         return Boolean.TRUE.equals(pr.codeOwnersApproved());
     }

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrTrackingRecord.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrTrackingRecord.java
@@ -24,6 +24,8 @@ public record PrTrackingRecord(
         @Nullable Duration slaRemaining,
         @Nullable Instant lastReviewAt,
         @Nullable Instant lastAuthorActivityAt,
+        // Sticky, write-once; observability only — no gating decision reads this (see
+        // PrLifecyclePoller#codeownerApproved).
         boolean codeownerReviewRequested,
         boolean mergePhaseEntered) {
     public PrTrackingRecord {

--- a/api/service/src/main/java/com/coreeng/supportbot/security/SecurityConfig.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/security/SecurityConfig.java
@@ -50,6 +50,11 @@ public class SecurityConfig {
                         // Slack webhook endpoint - uses Slack's own signing secret verification
                         .requestMatchers("/slack/events")
                         .permitAll()
+                        // Feature-enabled checks are open to any authenticated user (not just leadership/
+                        // support engineers) so the UI sidebar can safely query them for everyone to decide
+                        // whether to show the nav item, without a 403 for users lacking that role.
+                        .requestMatchers("/elevate/enabled")
+                        .authenticated()
                         // Dashboard restricted to leadership or support engineers
                         .requestMatchers("/dashboard/**", "/summary-data/results", "/elevate/**")
                         .hasAnyRole("LEADERSHIP", "SUPPORT_ENGINEER")

--- a/api/service/src/test/java/com/coreeng/supportbot/elevate/ElevateEnabledControllerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/elevate/ElevateEnabledControllerTest.java
@@ -1,0 +1,32 @@
+package com.coreeng.supportbot.elevate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElevateEnabledControllerTest {
+
+    @Mock
+    private ElevateQueryService elevateQueryService;
+
+    @Test
+    void returnsEnabled_whenElevateConfigured() {
+        when(elevateQueryService.configured()).thenReturn(true);
+        var controller = new ElevateEnabledController(elevateQueryService);
+
+        assertThat(controller.enabled().enabled()).isTrue();
+    }
+
+    @Test
+    void returnsDisabled_whenElevateNotConfigured() {
+        when(elevateQueryService.configured()).thenReturn(false);
+        var controller = new ElevateEnabledController(elevateQueryService);
+
+        assertThat(controller.enabled().enabled()).isFalse();
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/elevate/ElevateSecurityRouteTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/elevate/ElevateSecurityRouteTest.java
@@ -1,0 +1,101 @@
+package com.coreeng.supportbot.elevate;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.coreeng.supportbot.security.AllowListService;
+import com.coreeng.supportbot.security.AuthCodeStore;
+import com.coreeng.supportbot.security.JwtGroupTeamMerger;
+import com.coreeng.supportbot.security.JwtService;
+import com.coreeng.supportbot.security.OAuth2AvailabilityChecker;
+import com.coreeng.supportbot.security.SecurityConfig;
+import com.coreeng.supportbot.teams.SupportTeamService;
+import com.coreeng.supportbot.teams.TeamService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * Proves the {@code /elevate/enabled} carve-out in {@link SecurityConfig} actually works at the
+ * request-matching level, not just that {@link ElevateEnabledController} itself has no {@code
+ * @PreAuthorize}. Unlike a plain controller unit test, this boots the real {@code SecurityFilterChain}
+ * bean, so a future reorder of the {@code requestMatchers} rules (which would silently 403 the sidebar's
+ * feature-flag check, or silently over-widen access) fails this test.
+ */
+@WebMvcTest(controllers = {ElevateEnabledController.class, ElevateStatusController.class})
+@Import(SecurityConfig.class)
+@TestPropertySource(
+        properties = {
+            "security.jwt.secret=test-jwt-secret-for-unit-tests-minimum-256-bits",
+            "security.oauth2.redirect-uri=http://localhost:3000/login",
+            "security.test-bypass.enabled=false"
+        })
+class ElevateSecurityRouteTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ElevateQueryService elevateQueryService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private AuthCodeStore authCodeStore;
+
+    @MockitoBean
+    private TeamService teamService;
+
+    @MockitoBean
+    private SupportTeamService supportTeamService;
+
+    @MockitoBean
+    private OAuth2AvailabilityChecker oauth2AvailabilityChecker;
+
+    @MockitoBean
+    private AllowListService allowListService;
+
+    @MockitoBean
+    private JwtGroupTeamMerger jwtGroupTeamMerger;
+
+    @TestConfiguration
+    static class CorsTestConfig {
+        @Bean
+        CorsConfigurationSource corsConfigurationSource() {
+            return new UrlBasedCorsConfigurationSource();
+        }
+    }
+
+    @Test
+    void elevateEnabledIsReachableByAnyAuthenticatedUserRegardlessOfRole() throws Exception {
+        mockMvc.perform(get("/elevate/enabled").with(user("plain-user").roles("USER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void elevateStatusStillRequiresLeadershipOrSupportEngineerRole() throws Exception {
+        mockMvc.perform(get("/elevate/status").with(user("plain-user").roles("USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void elevateStatusIsReachableByLeadership() throws Exception {
+        mockMvc.perform(get("/elevate/status").with(user("leader").roles("LEADERSHIP")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void elevateEnabledIsUnauthorizedWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/elevate/enabled")).andExpect(status().isUnauthorized());
+    }
+}

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -394,6 +394,163 @@ class PrDetectionServiceTest {
         }
 
         @Test
+        void postsNoSlaDefaultMessageWhenMaintainingTeamPendingAndNoOverrideConfigured() {
+            // given — same maintaining-team overlap as above, but no `sla` block configured and no
+            // `messages.detected` override either. Chasing the maintaining team still makes no sense, so
+            // this must read exactly like a normal no-SLA repo — never the code-owner chase copy.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of("**"),
+                            null,
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE)).thenReturn(null);
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/docs-team", null))));
+            when(prSourceClient.listChangedFiles(COORD, PR_NUMBER)).thenReturn(List.of("src/app.js"));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — no deadline, and the standard no-SLA-tracked wording, never the chase copy.
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).doesNotContain("code-owner").doesNotContain("chase");
+            assertThat(text).contains("have no automated SLAs");
+        }
+
+        @Test
+        void postsConfiguredOverrideWhenMaintainingTeamPendingAndNoSla() {
+            // given — same shape as above, but this repo has a `messages.detected` override configured
+            // (mirrors a real config: NBCUDTC/kaas-platform). The override must win over the default
+            // no-SLA text, same as it would for a normal (non-codeowner) no-SLA repo.
+            String customMessage = "DPE engineers monitor this repository regularly for pull requests.";
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of("**"),
+                            null,
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(escalationTeamsRegistry.findEscalationTeamByCode(TEAM_CODE)).thenReturn(null);
+            when(messageRenderer.render(eq(REPO), eq(MessageEvent.DETECTED), any()))
+                    .thenReturn(customMessage);
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/docs-team", null))));
+            when(prSourceClient.listChangedFiles(COORD, PR_NUMBER)).thenReturn(List.of("src/app.js"));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the configured override replaces the default no-SLA text.
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            assertThat(postMessageCaptor.getValue().message().getText()).isEqualTo(customMessage);
+        }
+
+        @Test
+        void keepsChaseMessageOverConfiguredOverrideWhenExternalCodeOwnerPendingWithNoSla() {
+            // given — pending code owner is a genuinely different team (not the maintaining team), no SLA
+            // configured, but this repo DOES have a `messages.detected` override. The override is meant
+            // for the normal/no-codeowner flow; a real chase target must still be named regardless.
+            String customMessage = "DPE engineers monitor this repository regularly for pull requests.";
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of("**"),
+                            null,
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/other-team", null))));
+            when(prSourceClient.listChangedFiles(COORD, PR_NUMBER)).thenReturn(List.of("src/app.js"));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the chase copy wins; the configured override isn't even consulted for this path.
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).isNotEqualTo(customMessage);
+            assertThat(text).contains("code-owner").contains("chase");
+            verifyNoInteractions(messageRenderer);
+        }
+
+        @Test
         void keepsChaseMessageWhenGithubTeamSlugNotConfiguredEvenIfNamesMatch() {
             // given — same pending team as the overlap case above, but the repo never declared its
             // maintaining team via github-team-slug, so the overlap can't be positively confirmed: the

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
@@ -1815,15 +1815,13 @@ class PrLifecyclePollerTest {
             // resurface the paused merge time as a live review deadline that could later review-escalate.
             PrLifecyclePoller poller = createPoller();
             // Poll 1 — already in AWAITING_MERGE with a live merge deadline; code owner requests changes.
-            // codeownerReviewRequested=true models a genuine prior request, so poll 2's codeownersApproved
-            // reads as "revoked" rather than "gate never applied" — see PrLifecyclePoller#codeownerApproved.
-            PrTrackingRecord record = register(withCodeownerReviewRequested(record(
+            PrTrackingRecord record = register(record(
                     1L,
                     100L,
                     "my-org/repo-a",
                     11,
                     PrTrackingStatus.AWAITING_MERGE,
-                    Instant.now().plus(Duration.ofHours(6)))));
+                    Instant.now().plus(Duration.ofHours(6))));
             PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofDays(2));
             when(prTrackingRepository.findAllActive()).thenReturn(List.of(record));
             when(prTrackingProps.repositories()).thenReturn(List.of(repoConfig));
@@ -1891,16 +1889,17 @@ class PrLifecyclePollerTest {
         }
 
         @Test
-        void prWithNoOwnedPathsAdvancesToAwaitingMergeDespiteUnsatisfiedAggregateDecision() {
-            // given — regression test: a repo combining "require code-owner review" with a separate
-            // minimum-approval-count rule reports the aggregate decision as unsatisfied (codeownersApproved
-            // =false, mirroring GitHub reviewDecision=REVIEW_REQUIRED) for ANY PR that hasn't met the generic
-            // approval count yet — including one whose changed paths match no CODEOWNERS rule at all, so no
-            // code-owner review request was ever created (empty pendingCodeOwners) and none has ever been
-            // observed for this record. The gate must not read that as "code-owner review outstanding": it
-            // never applied to this PR's paths, so the record advances to AWAITING_MERGE regardless of what
-            // the aggregate says. (Verified against a real repo — see coreeng-dev/code-owner PR #5 — before
-            // this test was written.)
+        void prWithNoOwnedPathsHoldsGateShutUntilAggregateActuallyApproves() {
+            // given — a repo combining "require code-owner review" with a separate minimum-approval-count
+            // rule reports the aggregate decision as unsatisfied (codeownersApproved=false, mirroring
+            // GitHub reviewDecision=REVIEW_REQUIRED) for ANY PR that hasn't met the generic approval count
+            // yet — including one whose changed paths match no CODEOWNERS rule at all, so no code-owner
+            // review request was ever created (empty pendingCodeOwners). codeownerApproved() deliberately
+            // does not try to disambiguate this from a genuinely-still-pending code-owner requirement
+            // GitHub's API just fails to surface in reviewRequests (see codeownerApproved's Javadoc, and
+            // project_codeowner_approved_fail_open_bug) — it fails closed either way. This case simply
+            // holds in OPEN one poll longer than it used to, until its own ordinary approval lands and
+            // flips the aggregate to APPROVED.
             PrLifecyclePoller poller = createPoller();
             PrTrackingRecord record = record(1L, 100L, "my-org/repo-a", 11, PrTrackingStatus.OPEN, null);
             PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofHours(6));
@@ -1908,16 +1907,15 @@ class PrLifecyclePollerTest {
             when(prSourceClient.fetchPullRequest(RepoCoord.github(record.repo()), record.prNumber()))
                     .thenReturn(codeownerPrWithPendingReview(record, true, false, false, List.of(), List.of()));
             when(prTrackingProps.repositories()).thenReturn(List.of(repoConfig));
-            when(slaLookup.getSla(eq(repoConfig), any(RepoCoord.class), eq(record.prNumber())))
-                    .thenReturn(Duration.ofHours(6));
 
             // when
             poller.poll();
 
-            // then — advances to AWAITING_MERGE, not held in OPEN.
-            verify(prTrackingRepository)
-                    .enterMergePhase(eq(record.id()), eq(PrTrackingStatus.AWAITING_MERGE), any(Instant.class));
-            verify(prTrackingRepository, never()).updateStatus(anyLong(), eq(PrTrackingStatus.ESCALATED), any(), any());
+            // then — held in OPEN, not advanced and not escalated (no review-phase SLA is ever set for a
+            // PR with no owned paths, so there is nothing to escalate on).
+            verify(prTrackingRepository, never()).enterMergePhase(anyLong(), any(), any());
+            verify(prTrackingRepository, never()).updateStatus(anyLong(), any(), any(), any());
+            verifyNoInteractions(slackClient);
         }
 
         @Test
@@ -1948,22 +1946,19 @@ class PrLifecyclePollerTest {
         @Test
         void failedProviderReadPausesRecordWithPriorApprovalInsteadOfTrustingAggregate() {
             // given — same failed-read shape as the test above (codeOwnersApproved=null, empty pending
-            // list), but this time on a record whose flag IS already marked (a genuine code-owner request
-            // was seen on an earlier poll) and which has already advanced to AWAITING_MERGE. This exercises
-            // the other half of codeownerApproved()'s branch ordering: the null-check must take priority
-            // over "trust the aggregate" even when the flag is marked, not just when it isn't (covered
-            // above). A record in this shape must pause back to OPEN exactly like a definite revoked
-            // approval (see revokedApprovalInAwaitingMergePausesMergeClockAndReturnsToOpen) — it must NOT
-            // keep the merge clock running just because the aggregate is unreadable rather than a definite
-            // false.
+            // list), but this time on a record that has already advanced to AWAITING_MERGE. The null-check
+            // must take priority regardless of prior state — a record in this shape must pause back to OPEN
+            // exactly like a definite revoked approval (see
+            // revokedApprovalInAwaitingMergePausesMergeClockAndReturnsToOpen) — it must NOT keep the merge
+            // clock running just because the aggregate is unreadable rather than a definite false.
             PrLifecyclePoller poller = createPoller();
-            PrTrackingRecord record = register(withCodeownerReviewRequested(record(
+            PrTrackingRecord record = register(record(
                     1L,
                     100L,
                     "my-org/repo-a",
                     11,
                     PrTrackingStatus.AWAITING_MERGE,
-                    Instant.now().plus(Duration.ofHours(6)))));
+                    Instant.now().plus(Duration.ofHours(6))));
             PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofHours(6));
             when(prTrackingRepository.findAllActive()).thenReturn(List.of(record));
             when(prSourceClient.fetchPullRequest(RepoCoord.github(record.repo()), record.prNumber()))
@@ -2017,9 +2012,9 @@ class PrLifecyclePollerTest {
             // given — same repo shape, but the code owners have NOT approved yet (gate closed) and none has
             // requested changes (codeownerChangesRequested=false). A drive-by raw CHANGES_REQUESTED review
             // must not surface as a tenant notification or a status change: the record simply holds in OPEN
-            // with the clock held, waiting on the code owners. A real, still-pending code-owner request is
-            // modeled explicitly (a non-empty pendingCodeOwners list) — otherwise this is indistinguishable
-            // from "code-owner review never applied here" and would wrongly advance to AWAITING_MERGE.
+            // with the clock held, waiting on the code owners. Models a real, still-pending code-owner
+            // request (non-empty pendingCodeOwners) to distinguish this from the "pending list empty"
+            // shape covered by prWithNoOwnedPathsHoldsGateShutUntilAggregateActuallyApproves.
             PrLifecyclePoller poller = createPoller();
             PrTrackingRecord record = record(1L, 100L, "my-org/repo-a", 11, PrTrackingStatus.OPEN, null);
             PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofHours(6));
@@ -2042,6 +2037,44 @@ class PrLifecyclePollerTest {
             verify(prTrackingRepository, never()).pauseSla(anyLong(), any(), any());
             verify(prTrackingRepository, never()).enterMergePhase(anyLong(), any(), any());
             verify(messageRenderer, never()).render(any(), eq(MessageEvent.CHANGES_REQUESTED), any());
+        }
+
+        @Test
+        void advancesToAwaitingMergeWhenApprovedDespiteOtherCodeOwnersStillPending() {
+            // Regression (PR #4659 on a real repo): aggregate reviewDecision is already APPROVED — code
+            // owner review is satisfied — but one other auto-requested member of the same CODEOWNERS team
+            // hasn't responded yet, so pr.codeOwnerReviewers() (the pending list) is still non-empty.
+            // GitHub does not clear the rest of an auto-requested team from reviewRequests just because
+            // the requirement is already met by one approval. Before this fix, codeownerApproved() treated
+            // ANY non-empty pending list as outstanding regardless of the aggregate decision, so the
+            // record never left OPEN and the tenant got no message at all — permanently stuck, since the
+            // remaining reviewer might never respond. The aggregate decision must win here.
+            PrLifecyclePoller poller = createPoller();
+            PrTrackingRecord record = register(withCodeownerReviewRequested(record(
+                    1L, 100L, "my-org/repo-a", 11, PrTrackingStatus.OPEN, null)));
+            PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofHours(6));
+            when(prTrackingRepository.findAllActive()).thenReturn(List.of(record));
+            when(prSourceClient.fetchPullRequest(RepoCoord.github(record.repo()), record.prNumber()))
+                    .thenReturn(codeownerPrWithPendingReview(
+                            record,
+                            true,
+                            true,
+                            false,
+                            List.of(),
+                            List.of(new CodeOwnerRef(CodeOwnerRef.Kind.USER, "owner-b", null))));
+            when(prTrackingProps.repositories()).thenReturn(List.of(repoConfig));
+            when(slaLookup.getSla(eq(repoConfig), any(RepoCoord.class), eq(record.prNumber())))
+                    .thenReturn(Duration.ofHours(6));
+            when(ticketRepository.findTicketById(new TicketId(record.ticketId())))
+                    .thenReturn(ticket(100L));
+
+            // when
+            poller.poll();
+
+            // then — advances to AWAITING_MERGE and notifies, not left stuck in OPEN.
+            verify(prTrackingRepository)
+                    .enterMergePhase(eq(record.id()), eq(PrTrackingStatus.AWAITING_MERGE), any(Instant.class));
+            verify(slackClient).postMessage(any());
         }
 
         @Test
@@ -2075,20 +2108,16 @@ class PrLifecyclePollerTest {
             // given — a record chasing the merge (AWAITING_MERGE, live merge deadline). The code owners'
             // approval is then revoked (a push dismissed it → codeOwnersApproved=false, no changes-requested)
             // while the PR stays mergeable. It must leave AWAITING_MERGE for OPEN with the merge clock paused,
-            // NOT keep running and merge-escalate a PR that now needs code-owner re-review.
-            //
-            // codeownerReviewRequested=true models that a genuine code-owner request was seen on an earlier
-            // poll (confirmed empirically: GitHub does NOT restore a dismissed reviewer to reviewRequests).
-            // Without it, this is indistinguishable from "code-owner review never applied to this PR's
-            // paths" and the record would wrongly stay in AWAITING_MERGE instead of returning to OPEN.
+            // NOT keep running and merge-escalate a PR that now needs code-owner re-review — codeownerApproved()
+            // fails closed on any false aggregate unconditionally, so this holds regardless of prior state.
             PrLifecyclePoller poller = createPoller();
-            PrTrackingRecord record = register(withCodeownerReviewRequested(record(
+            PrTrackingRecord record = register(record(
                     1L,
                     100L,
                     "my-org/repo-a",
                     11,
                     PrTrackingStatus.AWAITING_MERGE,
-                    Instant.now().plus(Duration.ofHours(6)))));
+                    Instant.now().plus(Duration.ofHours(6))));
             PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofHours(6));
             when(prTrackingRepository.findAllActive()).thenReturn(List.of(record));
             when(prSourceClient.fetchPullRequest(RepoCoord.github(record.repo()), record.prNumber()))
@@ -2182,10 +2211,11 @@ class PrLifecyclePollerTest {
 
         /**
          * Like {@link #codeownerPrWithReviews}, but with an explicit pending-code-owner-request list —
-         * needed to model "a real code-owner review is genuinely still outstanding" once the poller
-         * disambiguates on it (see {@code PrLifecyclePoller#codeownerApproved}): an empty list plus
-         * {@code codeownersApproved=false} is otherwise indistinguishable from "code-owner review never
-         * applied to this PR's paths" and would be read as the gate being satisfied instead.
+         * needed to model "a real code-owner review is genuinely still outstanding" for tests that pass a
+         * non-empty {@code pendingCodeOwners}. A non-empty aggregate-{@code false} test doesn't strictly
+         * need this over {@link #codeownerPrWithReviews} anymore ({@code codeownerApproved()} now fails
+         * closed on any false aggregate regardless of the pending list), but it keeps the PR metadata
+         * shape realistic for cases where a pending reviewer genuinely exists.
          */
         private PrMetadata codeownerPrWithPendingReview(
                 PrTrackingRecord record,

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrLifecyclePollerTest.java
@@ -2050,8 +2050,8 @@ class PrLifecyclePollerTest {
             // record never left OPEN and the tenant got no message at all — permanently stuck, since the
             // remaining reviewer might never respond. The aggregate decision must win here.
             PrLifecyclePoller poller = createPoller();
-            PrTrackingRecord record = register(withCodeownerReviewRequested(record(
-                    1L, 100L, "my-org/repo-a", 11, PrTrackingStatus.OPEN, null)));
+            PrTrackingRecord record = register(
+                    withCodeownerReviewRequested(record(1L, 100L, "my-org/repo-a", 11, PrTrackingStatus.OPEN, null)));
             PrTrackingProps.Repository repoConfig = codeownerRepoConfig(Duration.ofHours(6));
             when(prTrackingRepository.findAllActive()).thenReturn(List.of(record));
             when(prSourceClient.fetchPullRequest(RepoCoord.github(record.repo()), record.prNumber()))

--- a/ui/src/app/__tests__/page.test.tsx
+++ b/ui/src/app/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import { useTeamFilter } from "@/contexts/TeamFilterContext";
 import { useAuth } from "@/hooks/useAuth";
-import { useKnowledgeGapsEnabled, useTenantInsightsEnabled } from "@/lib/hooks";
+import { useElevateEnabled, useKnowledgeGapsEnabled, useTenantInsightsEnabled } from "@/lib/hooks";
 import { render, screen, waitFor } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import DashboardLayoutComponent from "../(dashboard)/layout";
@@ -23,6 +23,7 @@ jest.mock("../../contexts/TeamFilterContext", () => ({
 jest.mock("../../lib/hooks", () => ({
   useKnowledgeGapsEnabled: jest.fn(),
   useTenantInsightsEnabled: jest.fn(),
+  useElevateEnabled: jest.fn(),
 }));
 
 // Mock all the page components
@@ -77,6 +78,7 @@ const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockUseTeamFilter = useTeamFilter as jest.MockedFunction<typeof useTeamFilter>;
 const mockUseKnowledgeGapsEnabled = useKnowledgeGapsEnabled as jest.MockedFunction<typeof useKnowledgeGapsEnabled>;
 const mockUseTenantInsightsEnabled = useTenantInsightsEnabled as jest.MockedFunction<typeof useTenantInsightsEnabled>;
+const mockUseElevateEnabled = useElevateEnabled as jest.MockedFunction<typeof useElevateEnabled>;
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 
 // Helper to render Dashboard with Layout (simulating the route group structure)
@@ -93,6 +95,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
     jest.clearAllMocks();
     mockUseRouter.mockReturnValue(mockRouter as any);
     mockUseTenantInsightsEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
+    mockUseElevateEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
     mockUseTeamFilter.mockReturnValue({
       hasUnrestrictedDataScope: true,
       selectedTeam: null,
@@ -446,6 +449,7 @@ describe("Dashboard - Support Area Summary visibility", () => {
         error: null,
       } as any);
       mockUseTenantInsightsEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
+      mockUseElevateEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
 
       mockUseTeamFilter.mockReturnValue({
         hasUnrestrictedDataScope: false,
@@ -567,5 +571,68 @@ describe("Dashboard - Support Area Summary visibility", () => {
         expect(screen.getByText("Escalations")).toBeInTheDocument();
       });
     });
+  });
+});
+
+describe("Dashboard - Elevate nav item visibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue(mockRouter as any);
+    mockUseKnowledgeGapsEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
+    mockUseTenantInsightsEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
+    mockUseTeamFilter.mockReturnValue({
+      hasUnrestrictedDataScope: true,
+      selectedTeam: null,
+      setSelectedTeam: jest.fn(),
+      effectiveTeams: [],
+      allTeams: [],
+      initialized: true,
+      teamScope: { mode: "uninitialized" as const },
+      hasNoTeamScope: false,
+      isViewingAllTeams: false,
+      isViewingAsEscalationTeam: false,
+    });
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "user@example.com",
+        name: "User",
+        email: "user@example.com",
+        roles: ["SUPPORT_ENGINEER"],
+        teams: [],
+      },
+      isLoading: false,
+      isAuthenticated: true,
+      logout: jest.fn(),
+      isLeadership: false,
+      isEscalationTeam: false,
+      isSupportEngineer: true,
+      actualEscalationTeams: [],
+    });
+  });
+
+  it("hides Elevate when the integration is not configured, even with the required role", async () => {
+    // Regression: the Elevate nav item previously had no requiresFeatureFlag, so it was visible to
+    // any user with the restricted-dashboards role regardless of whether Elevate was ever configured
+    // (base-url/client-id/client-secret all blank) — see /elevate/enabled.
+    mockUseElevateEnabled.mockReturnValue({ data: false, isLoading: false, error: null } as any);
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Elevate")).not.toBeInTheDocument();
+    expect(screen.queryByText("Integrations")).not.toBeInTheDocument();
+  });
+
+  it("shows Elevate once the integration is configured and the role capability is present", async () => {
+    mockUseElevateEnabled.mockReturnValue({ data: true, isLoading: false, error: null } as any);
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Elevate")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Integrations")).toBeInTheDocument();
   });
 });

--- a/ui/src/components/dashboard-layout/app-sidebar.tsx
+++ b/ui/src/components/dashboard-layout/app-sidebar.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/components/ui/sidebar";
 import { useAuth } from "@/hooks/useAuth";
 import { type UiCapability, hasUiCapability, UI_CAPABILITIES } from "@/lib/auth/capabilities";
-import { useKnowledgeGapsEnabled, useTenantInsightsEnabled } from "@/lib/hooks";
+import { useElevateEnabled, useKnowledgeGapsEnabled, useTenantInsightsEnabled } from "@/lib/hooks";
 
 type NavItem = {
   title: string;
@@ -33,7 +33,7 @@ type NavItem = {
 
 type TabVisibility = {
   requiredCapability?: UiCapability;
-  requiresFeatureFlag?: "knowledgeGaps" | "tenantInsights";
+  requiresFeatureFlag?: "knowledgeGaps" | "tenantInsights" | "elevate";
 };
 
 type SupportTab = {
@@ -78,7 +78,7 @@ const INTEGRATION_TABS: SupportTab[] = [
     path: "/elevate",
     title: "Elevate",
     icon: Cable,
-    visibility: { requiredCapability: UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS },
+    visibility: { requiredCapability: UI_CAPABILITIES.VIEW_RESTRICTED_DASHBOARDS, requiresFeatureFlag: "elevate" },
   },
 ];
 
@@ -88,10 +88,12 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const { user, isLoading } = useAuth();
   const { data: isKnowledgeGapsEnabled } = useKnowledgeGapsEnabled();
   const { data: isTenantInsightsEnabled } = useTenantInsightsEnabled();
+  const { data: isElevateEnabled } = useElevateEnabled();
 
   const flags: Record<NonNullable<TabVisibility["requiresFeatureFlag"]>, boolean | undefined> = {
     knowledgeGaps: isKnowledgeGapsEnabled,
     tenantInsights: isTenantInsightsEnabled,
+    elevate: isElevateEnabled,
   };
 
   const isVisible = (tab: SupportTab) => {

--- a/ui/src/lib/hooks/index.ts
+++ b/ui/src/lib/hooks/index.ts
@@ -510,6 +510,17 @@ export function useAnalysis() {
   });
 }
 
+export function useElevateEnabled() {
+  return useQuery<boolean>({
+    queryKey: ["elevate", "enabled"],
+    queryFn: async () => {
+      const response = await apiGet<{ enabled: boolean }>("/elevate/enabled");
+      return response.enabled;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
 export function useTenantInsightsEnabled() {
   return useQuery<boolean>({
     queryKey: ["tenant-insights", "enabled"],


### PR DESCRIPTION
- Fix three bugs in codeowner-gated PR tracking (PrLifecyclePoller, PrDetectionService):
  - Stuck PRs: a PR could get permanently stuck with zero Slack messages if one auto-requested reviewer from a codeowner team never responded, even though the review requirement was already satisfied by someone else's approval.
  - "Chase yourself" message: no-SLA repos where the codeowner is the owning team told that team to go chase themselves instead of posting a normal message.
  - False "approved, ready to merge": any PR that didn't touch a codeowner-owned path could get declared approved before a single human reviewed it — not a rare edge case, but the default state for such PRs on any repo requiring at least one approval (nearly all of them). The gate now fails closed instead of guessing.
- Hide the Elevate integration's sidebar nav item until it's actually configured — previously visible to any user with dashboard access regardless of whether elevate.base-url/client-id/client-secret were set. Adds GET /elevate/enabled, wired into the sidebar's existing feature-flag mechanism.