### PR TITLE
Further fixes to PR Lifecycle logic

### DIFF
--- a/api/service/src/main/java/com/coreeng/supportbot/github/GitHubPullRequest.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/github/GitHubPullRequest.java
@@ -24,7 +24,8 @@ public record GitHubPullRequest(
         List<GitHubPullRequestReview> reviews,
         @Nullable String authorLogin,
         @Nullable ReviewDecision reviewDecision,
-        List<CodeOwnerReviewer> codeOwnerReviewers) {
+        List<CodeOwnerReviewer> codeOwnerReviewers,
+        boolean isDraft) {
     public GitHubPullRequest {
         requireNonNull(repositoryName, "repositoryName must not be null");
         requireNonNull(createdAt, "createdAt must not be null");
@@ -36,6 +37,38 @@ public record GitHubPullRequest(
         if (pullRequestNumber <= 0) {
             throw new IllegalArgumentException("pullRequestNumber must be positive, was " + pullRequestNumber);
         }
+    }
+
+    /**
+     * Preserves every existing caller's shape from before {@code isDraft} existed, defaulting it to
+     * {@code false} — draft-awareness is opt-in via the constructors below, not a behavior change for
+     * anyone not yet passing it explicitly.
+     */
+    public GitHubPullRequest(
+            String repositoryName,
+            int pullRequestNumber,
+            Instant createdAt,
+            PrState state,
+            @Nullable Boolean mergeable,
+            @Nullable String mergeableState,
+            @Nullable List<String> requestedTeamReviewerLogins,
+            List<GitHubPullRequestReview> reviews,
+            @Nullable String authorLogin,
+            @Nullable ReviewDecision reviewDecision,
+            List<CodeOwnerReviewer> codeOwnerReviewers) {
+        this(
+                repositoryName,
+                pullRequestNumber,
+                createdAt,
+                state,
+                mergeable,
+                mergeableState,
+                requestedTeamReviewerLogins,
+                reviews,
+                authorLogin,
+                reviewDecision,
+                codeOwnerReviewers,
+                false);
     }
 
     /** Convenience constructor for callers (and tests) that don't supply an author. */
@@ -91,6 +124,36 @@ public record GitHubPullRequest(
                 List.of());
     }
 
+    /**
+     * Convenience constructor for the hub4j REST path with draft status known but no code-owner signals
+     * yet (those are populated only by the GraphQL client, for {@code requires-codeowners} repos).
+     */
+    public GitHubPullRequest(
+            String repositoryName,
+            int pullRequestNumber,
+            Instant createdAt,
+            PrState state,
+            @Nullable Boolean mergeable,
+            @Nullable String mergeableState,
+            @Nullable List<String> requestedTeamReviewerLogins,
+            List<GitHubPullRequestReview> reviews,
+            @Nullable String authorLogin,
+            boolean isDraft) {
+        this(
+                repositoryName,
+                pullRequestNumber,
+                createdAt,
+                state,
+                mergeable,
+                mergeableState,
+                requestedTeamReviewerLogins,
+                reviews,
+                authorLogin,
+                null,
+                List.of(),
+                isDraft);
+    }
+
     /** Returns a copy with the code-owner review signals (from the GraphQL client) populated. */
     public GitHubPullRequest withCodeownerReview(
             @Nullable ReviewDecision reviewDecision, List<CodeOwnerReviewer> codeOwnerReviewers) {
@@ -105,7 +168,8 @@ public record GitHubPullRequest(
                 reviews,
                 authorLogin,
                 reviewDecision,
-                codeOwnerReviewers);
+                codeOwnerReviewers,
+                isDraft);
     }
 
     public boolean isOpen() {

--- a/api/service/src/main/java/com/coreeng/supportbot/github/Hub4jGitHubClient.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/github/Hub4jGitHubClient.java
@@ -219,6 +219,7 @@ public final class Hub4jGitHubClient implements GitHubClient {
             }
             Boolean mergeable = pr.getMergeable();
             String mergeableState = pr.getMergeableState();
+            boolean isDraft = pr.isDraft();
             GHUser author = pr.getUser();
             String authorLogin = author != null ? author.getLogin() : null;
             @Nullable List<String> requestedTeamReviewerLogins;
@@ -248,7 +249,8 @@ public final class Hub4jGitHubClient implements GitHubClient {
                     mergeableState,
                     requestedTeamReviewerLogins,
                     reviews,
-                    authorLogin);
+                    authorLogin,
+                    isDraft);
         } catch (IllegalArgumentException e) {
             throw new GitHubApiException(
                     0, "Invalid repository name '%s': %s".formatted(repositoryName, e.getMessage()), e);

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/PrDetectionService.java
@@ -702,6 +702,9 @@ public class PrDetectionService {
     /**
      * Detection for requires-codeowners repos. By default: no review deadline, "chase the code owner"
      * message, never review-escalates — unchanged from before this class had any code-owner awareness.
+     * On GitHub, {@link #excludingOwningTeam} drops the repo's own maintaining team from the chase list,
+     * so a pending list mixing the maintaining team with a genuinely external reviewer names only the
+     * external one.
      *
      * <p>One carve-out (an exception to that default): if the pending code owners ARE the repo's own
      * maintaining team ({@link #pendingCodeOwnersAreMaintainingTeam}), chasing them makes no sense — the
@@ -712,6 +715,10 @@ public class PrDetectionService {
      * no-SLA-tracked message. Everything else (a genuinely external pending code owner) keeps the
      * default chase message even if an override is configured — the override applies to the
      * normal/no-codeowner flow, not to a real chase.
+     *
+     * <p>A copy-only variation (no effect on the deadline or escalation): a draft PR with an empty pending
+     * list and a confirmed-unsatisfied gate that isn't changes-requested gets {@link
+     * #formatCodeownerDraftPendingText} instead of the default chase copy.
      *
      * <p>Path filtering still applies with no {@code sla} block: like any no-SLA repo, only PRs touching
      * the configured {@code paths} are tracked.
@@ -831,12 +838,23 @@ public class PrDetectionService {
                                 detectedPr.repositoryName(),
                                 resolveTeamLabel(repoConfig.owningTeam()));
                     }
+                } else if (prMetadata.isDraft()
+                        && prMetadata.codeOwnerReviewers().isEmpty()
+                        && Boolean.FALSE.equals(prMetadata.codeOwnersApproved())
+                        && !prMetadata.codeownerChangesRequested()) {
+                    // An empty pending list on a draft means the generic "needs code-owner approval" copy
+                    // would imply someone was asked when nobody may have been. codeOwnersApproved==FALSE
+                    // (rather than just an empty list) keeps this off the unknown case, where the gate
+                    // couldn't be read at all and the value is null.
+                    text = formatCodeownerDraftPendingText(
+                            detectedPr.provider(), detectedPr.repositoryName(), detectedPr.pullNumber());
                 } else {
                     text = formatCodeownerDetectedText(
                             detectedPr.provider(),
                             detectedPr.repositoryName(),
                             detectedPr.pullNumber(),
-                            prMetadata.codeOwnerReviewers());
+                            excludingOwningTeam(
+                                    detectedPr, repoConfig, prMetadata.codeOwnerReviewers(), teamReviewerCache));
                 }
                 postText(
                         text,
@@ -1340,12 +1358,32 @@ public class PrDetectionService {
     }
 
     /**
+     * Draft counterpart to {@link #formatCodeownerDetectedText}'s empty-list branch, which would imply
+     * someone had already been asked. States only that the PR is a draft — an empty pending list has
+     * several indistinguishable causes (never auto-requested, a review already submitted, an approval
+     * dismissed by a push), so the copy deliberately attributes none of them.
+     */
+    private String formatCodeownerDraftPendingText(Provider provider, String repo, int prNumber) {
+        String prRef = "<%s|%s %s%d>"
+                .formatted(
+                        prUrl(repo, prNumber),
+                        PrTerminology.noun(provider),
+                        PrTerminology.separator(provider),
+                        prNumber);
+        return "%s in `%s` is still a draft, so it's not ready for code-owner review yet. I'll let you know once the code owners have approved."
+                .formatted(prRef, repo);
+    }
+
+    /**
      * True when every pending code owner on this PR is a member of the repo's configured maintaining team
      * ({@code github-team-slug} / {@code gitlab-group-path}). A one-shot check at detection time — never
      * re-evaluated later.
      *
-     * <p>Defaults to {@code false} (keep the chase copy) whenever it can't be confirmed for sure: nothing
-     * pending, no team configured, or membership can't be resolved.
+     * <p>Defaults to {@code false} whenever it can't be confirmed for sure: nothing pending, no team
+     * configured, or membership can't be resolved. That default doesn't always mean the chase copy is
+     * used verbatim — an empty pending list on a draft PR can instead get {@link
+     * #formatCodeownerDraftPendingText}, and even the default chase copy has the maintaining team
+     * excluded from it by {@link #excludingOwningTeam}.
      */
     private boolean pendingCodeOwnersAreMaintainingTeam(
             DetectedPr detectedPr,
@@ -1361,18 +1399,12 @@ public class PrDetectionService {
             if (teamSlug == null) {
                 return false;
             }
-            String repoName = detectedPr.repositoryName();
-            int slash = repoName.indexOf('/');
-            if (slash <= 0) {
-                // Repo name came from parsing whatever URL the user pasted, so "org/repo" isn't guaranteed.
-                log.atWarn()
-                        .addArgument(() -> repoName)
-                        .addArgument(detectedPr::pullNumber)
-                        .log(
-                                "Repo name {} for PR #{} has no org/repo separator — can't confirm the maintaining-team carve-out, keeping the code-owner chase copy");
+            String expectedTeamDisplay = expectedGithubTeamDisplay(detectedPr, teamSlug);
+            if (expectedTeamDisplay == null) {
+                logUnparseableRepoName(
+                        detectedPr, "can't confirm the maintaining-team carve-out, keeping the code-owner chase copy");
                 return false;
             }
-            String expectedTeamDisplay = repoName.substring(0, slash) + "/" + teamSlug;
             for (CodeOwnerRef ref : pending) {
                 if (ref.isTeam()) {
                     if (!ref.display().equalsIgnoreCase(expectedTeamDisplay)) {
@@ -1412,6 +1444,96 @@ public class PrDetectionService {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Drops the repo's own maintaining team ({@code github-team-slug}) — as a team ref, or as an
+     * individual member of it — out of a pending code-owner list before it's rendered in the chase
+     * message. {@link #pendingCodeOwnersAreMaintainingTeam} only suppresses the chase copy when the
+     * maintaining team is the ENTIRE pending list; when the list is mixed (the maintaining team plus a
+     * genuinely external reviewer), that carve-out doesn't engage and the chase message would otherwise
+     * tell the owning team to chase itself. This never changes which repos get the carve-out or their SLA
+     * deadline — it only trims what gets named in the chase text. Mirrors
+     * {@link #pendingCodeOwnersAreMaintainingTeam}'s own per-entry matching (team-ref display, or
+     * individual membership via {@link #teamReviewFilter}), so anything that method would count as "the
+     * maintaining team" is excluded here too.
+     */
+    private List<CodeOwnerRef> excludingOwningTeam(
+            DetectedPr detectedPr,
+            PrTrackingProps.Repository repoConfig,
+            List<CodeOwnerRef> pending,
+            Map<String, Optional<Set<String>>> teamReviewerCache) {
+        if (pending.isEmpty() || detectedPr.provider() != Provider.GITHUB) {
+            return pending;
+        }
+        String teamSlug = repoConfig.githubTeamSlug();
+        if (teamSlug == null) {
+            return pending;
+        }
+        String expectedTeamDisplay = expectedGithubTeamDisplay(detectedPr, teamSlug);
+        if (expectedTeamDisplay == null) {
+            logUnparseableRepoName(
+                    detectedPr, "leaving the chase list unfiltered, so it may name the repo's own maintaining team");
+            return pending;
+        }
+        // Resolving members needs org Members:Read, which repos listing only teams in CODEOWNERS never
+        // otherwise pay for, so only look it up when an individual ref actually has to be matched.
+        Set<String> members = null;
+        if (pending.stream().anyMatch(ref -> !ref.isTeam())) {
+            RepoCoord coord = new RepoCoord(detectedPr.provider(), detectedPr.repositoryName());
+            members = teamReviewFilter.resolveTeamMembers(coord, teamSlug, teamReviewerCache);
+            if (members == null) {
+                logTeamResolutionFailed(detectedPr, teamSlug);
+            }
+        }
+        Set<String> resolvedMembers = members;
+        List<CodeOwnerRef> filtered = pending.stream()
+                .filter(ref -> {
+                    if (ref.isTeam()) {
+                        return !ref.display().equalsIgnoreCase(expectedTeamDisplay);
+                    }
+                    // resolvedMembers == null means resolution failed, same as the sibling carve-out
+                    // check — fail safe by keeping the entry in the chase list rather than risking
+                    // dropping a genuinely external reviewer we couldn't confirm is a team member.
+                    return resolvedMembers == null
+                            || resolvedMembers.stream().noneMatch(member -> member.equalsIgnoreCase(ref.display()));
+                })
+                .toList();
+        if (filtered.isEmpty()) {
+            // The carve-out runs first on this same list and would have suppressed the chase copy
+            // entirely if every entry were the maintaining team, so this should be unreachable. Falling
+            // back to the unfiltered list keeps a real chase list rather than silently naming nobody.
+            log.atWarn()
+                    .addArgument(detectedPr::repositoryName)
+                    .addArgument(detectedPr::pullNumber)
+                    .log("Owning-team filter emptied the chase list for {}#{}, falling back to the unfiltered list");
+            return pending;
+        }
+        return filtered;
+    }
+
+    /**
+     * The org-qualified display string ({@code org/team}) GitHub uses for a team ref, derived from the
+     * repo's own {@code org/repo} name and the configured {@code teamSlug}. {@code null} when the repo
+     * name has no parseable org prefix (it came from parsing whatever URL the user pasted, so "org/repo"
+     * isn't guaranteed); callers log that themselves, since the consequence differs per caller.
+     */
+    private @Nullable String expectedGithubTeamDisplay(DetectedPr detectedPr, String teamSlug) {
+        String repoName = detectedPr.repositoryName();
+        int slash = repoName.indexOf('/');
+        if (slash <= 0) {
+            return null;
+        }
+        return repoName.substring(0, slash) + "/" + teamSlug;
+    }
+
+    /** Marks that an unparseable {@code org/repo} name, not a genuine mismatch, is why a check bailed. */
+    private void logUnparseableRepoName(DetectedPr detectedPr, String consequence) {
+        log.atWarn()
+                .addArgument(detectedPr::repositoryName)
+                .addArgument(detectedPr::pullNumber)
+                .addArgument(() -> consequence)
+                .log("Repo name {} for PR #{} has no org/repo separator — {}");
     }
 
     /** Marks that a lookup failure, not a genuine mismatch, is why the carve-out didn't engage. */

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/GitHubPrSourceClient.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/GitHubPrSourceClient.java
@@ -93,7 +93,8 @@ public class GitHubPrSourceClient implements PrSourceClient {
                     codeownerChangesRequested,
                     pr.codeOwnerReviewers().stream()
                             .map(GitHubPrSourceClient::mapCodeOwner)
-                            .toList());
+                            .toList(),
+                    pr.isDraft());
         } catch (GitHubApiException e) {
             throw new PrSourceException(e.getMessage(), e);
         }

--- a/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/PrMetadata.java
+++ b/api/service/src/main/java/com/coreeng/supportbot/prtracking/source/PrMetadata.java
@@ -33,7 +33,8 @@ public record PrMetadata(
         @Nullable String authorLogin,
         @Nullable Boolean codeOwnersApproved,
         boolean codeownerChangesRequested,
-        List<CodeOwnerRef> codeOwnerReviewers) {
+        List<CodeOwnerRef> codeOwnerReviewers,
+        boolean isDraft) {
     public PrMetadata {
         requireNonNull(coord, "coord must not be null");
         requireNonNull(createdAt, "createdAt must not be null");
@@ -48,6 +49,38 @@ public record PrMetadata(
         if (Boolean.TRUE.equals(codeOwnersApproved) && codeownerChangesRequested) {
             throw new IllegalArgumentException("codeOwnersApproved and codeownerChangesRequested can't both be true");
         }
+    }
+
+    /**
+     * Preserves every existing caller's shape from before {@code isDraft} existed, defaulting it to
+     * {@code false} — draft-awareness is opt-in via the constructors below, not a behavior change for
+     * anyone not yet passing it explicitly.
+     */
+    public PrMetadata(
+            RepoCoord coord,
+            int number,
+            Instant createdAt,
+            PrState state,
+            @Nullable Boolean mergeable,
+            @Nullable List<String> requestedTeamReviewerLogins,
+            List<Review> reviews,
+            @Nullable String authorLogin,
+            @Nullable Boolean codeOwnersApproved,
+            boolean codeownerChangesRequested,
+            List<CodeOwnerRef> codeOwnerReviewers) {
+        this(
+                coord,
+                number,
+                createdAt,
+                state,
+                mergeable,
+                requestedTeamReviewerLogins,
+                reviews,
+                authorLogin,
+                codeOwnersApproved,
+                codeownerChangesRequested,
+                codeOwnerReviewers,
+                false);
     }
 
     /**

--- a/api/service/src/test/java/com/coreeng/supportbot/github/GitHubPullRequestTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/github/GitHubPullRequestTest.java
@@ -101,4 +101,28 @@ class GitHubPullRequestTest {
         assertThat(closed.isOpen()).isFalse();
         assertThat(merged.isOpen()).isFalse();
     }
+
+    @Test
+    void isDraftDefaultsFalseWhenNotSuppliedByLegacyConstructors() {
+        var pr = new GitHubPullRequest(
+                "org/repo", 1, CREATED_AT, GitHubPullRequest.PrState.OPEN, true, "clean", List.of(), List.of());
+        assertThat(pr.isDraft()).isFalse();
+    }
+
+    @Test
+    void withCodeownerReviewPreservesIsDraft() {
+        var pr = new GitHubPullRequest(
+                "org/repo",
+                1,
+                CREATED_AT,
+                GitHubPullRequest.PrState.OPEN,
+                true,
+                "clean",
+                List.of(),
+                List.of(),
+                "author",
+                true);
+        var updated = pr.withCodeownerReview(GitHubPullRequest.ReviewDecision.REVIEW_REQUIRED, List.of());
+        assertThat(updated.isDraft()).isTrue();
+    }
 }

--- a/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/github/Hub4jGitHubClientTest.java
@@ -347,6 +347,33 @@ class Hub4jGitHubClientTest {
     }
 
     @Test
+    void getPullRequestMapsIsDraftTrue() throws IOException {
+        // given
+        TestPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        pr.testDraft = true;
+        stubReviews(pr, List.of());
+
+        // when
+        GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
+
+        // then
+        assertThat(result.isDraft()).isTrue();
+    }
+
+    @Test
+    void getPullRequestMapsIsDraftFalse() throws IOException {
+        // given
+        TestPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
+        stubReviews(pr, List.of());
+
+        // when
+        GitHubPullRequest result = client.getPullRequest("my-org/my-repo", 42);
+
+        // then
+        assertThat(result.isDraft()).isFalse();
+    }
+
+    @Test
     void getPullRequestMapsApprovedReviewCorrectly() throws IOException {
         // given
         TestPullRequest pr = stubOpenPullRequest("my-org/my-repo", 42);
@@ -648,6 +675,8 @@ class Hub4jGitHubClientTest {
 
         @Nullable String testMergeableState;
 
+        boolean testDraft;
+
         @Nullable String testAuthorLogin;
 
         List<GHTeam> testRequestedTeams = List.of();
@@ -684,6 +713,11 @@ class Hub4jGitHubClientTest {
         @Override
         public String getMergeableState() throws IOException {
             return testMergeableState;
+        }
+
+        @Override
+        public boolean isDraft() throws IOException {
+            return testDraft;
         }
 
         @Override
@@ -749,6 +783,7 @@ class Hub4jGitHubClientTest {
         pr.returnNullIssueState = false;
         pr.testMergeable = null;
         pr.testMergeableState = null;
+        pr.testDraft = false;
         pr.testRequestedTeams = List.of();
         pr.testRequestedTeamsException = null;
         pr.testReviewsException = null;

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/PrDetectionServiceTest.java
@@ -592,11 +592,13 @@ class PrDetectionServiceTest {
             // when
             service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
 
-            // then — no deadline (the overlap couldn't be confirmed), and the original chase copy.
+            // then — no deadline (the overlap couldn't be confirmed), and the original chase copy naming
+            // the pending team (proving the chase list wasn't silently filtered to empty).
             verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
             assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
             verify(slackClient).postMessage(postMessageCaptor.capture());
-            assertThat(postMessageCaptor.getValue().message().getText()).contains("code-owner");
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("code-owner").contains("chase").contains("my-org/docs-team");
         }
 
         @Test
@@ -645,6 +647,437 @@ class PrDetectionServiceTest {
             assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
             verify(slackClient).postMessage(postMessageCaptor.capture());
             assertThat(postMessageCaptor.getValue().message().getText()).contains("code-owner");
+        }
+
+        @Test
+        void chaseMessageExcludesOwningTeamButKeepsExternalCodeOwnerWhenPendingListIsMixed() {
+            // given — github-team-slug IS configured, and the pending list is a MIX: the maintaining team
+            // itself plus a genuinely external team. The maintaining-team carve-out doesn't engage here
+            // (not every pending owner is the maintaining team), so the chase copy is used — but it must
+            // never tell the owning team to chase itself; the external team still needs to be named.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/security-team", null),
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/docs-team", null))));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — no deadline (the carve-out didn't engage for a mixed list), the chase copy is used,
+            // it names the external team, and it never names the owning team as something to chase.
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("code-owner").contains("chase");
+            assertThat(text).contains("my-org/security-team");
+            assertThat(text).doesNotContain("docs-team");
+        }
+
+        @Test
+        void chaseMessageExcludesIndividualOwningTeamMemberButKeepsExternalCodeOwnerWhenPendingListIsMixed() {
+            // given — same mixed-list shape as the test above, but CODEOWNERS names the maintaining
+            // team's member as an INDIVIDUAL rather than the team handle. Filtering must catch this case
+            // too, the same way pendingCodeOwnersAreMaintainingTeam's own per-entry check already does —
+            // otherwise the "chase yourself" bug reproduces verbatim whenever a repo lists individuals
+            // instead of the team.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.resolveTeamMembers(COORD, "docs-team")).thenReturn(List.of("owner-a"));
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/security-team", null),
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.USER, "owner-a", null))));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — no deadline (the carve-out didn't engage for a mixed list), the chase copy is used,
+            // it names the external team, and it never names the owning team's individual member.
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("code-owner").contains("chase");
+            assertThat(text).contains("my-org/security-team");
+            assertThat(text).doesNotContain("owner-a");
+        }
+
+        @Test
+        void postsDraftPendingTextWhenDraftPrHasNeverHadCodeownersRequested() {
+            // given — a requires-codeowners repo, and a PR that's still a draft with an EMPTY pending
+            // code-owner list: GitHub hasn't run CODEOWNERS auto-request yet (this PR was opened directly
+            // as a draft and never marked ready-for-review), not "requested and already actioned."
+            // Claiming "needs code-owner approval" here would be misleading.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            null,
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(),
+                            true));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — no deadline, and honest "still a draft" wording instead of the code-owner chase copy.
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("draft");
+            assertThat(text).doesNotContain("needs code-owner approval").doesNotContain("chase");
+        }
+
+        @Test
+        void keepsGenericChaseMessageWhenDraftPrHasEmptyListButCodeownerGateWasNeverConfirmed() {
+            // given — same draft, same empty pending list as the test above, but codeOwnersApproved is
+            // null rather than false: the GraphQL codeowner query failed or was never attempted, so the
+            // empty list can't actually be attributed to "GitHub hasn't asked yet" — that's simply
+            // unknown. The draft-pending copy must NOT engage here; the original, cause-agnostic generic
+            // copy is used instead, same as a non-draft PR with the gate unresolved.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            null,
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            null,
+                            false,
+                            List.of(),
+                            true));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — no deadline, and the original generic "needs code-owner approval" copy, NOT the
+            // draft-pending wording (which would wrongly assert a cause we haven't actually confirmed).
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("needs code-owner approval");
+            assertThat(text).doesNotContain("still a draft");
+        }
+
+        @Test
+        void keepsNormalChaseMessageWhenDraftPrAlreadyHasPendingCodeOwners() {
+            // given — the PR is a draft, but it already has a real, non-empty pending code-owner list
+            // (e.g. it was opened ready-for-review and converted to draft afterward, so GitHub already ran
+            // CODEOWNERS auto-request against it). The draft-pending copy must NOT engage here — the
+            // pending code owners genuinely need chasing, same as a non-draft PR.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            null,
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/security-team", null)),
+                            true));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the normal chase copy, naming the pending team, exactly as a non-draft PR would get.
+            verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
+            assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("code-owner").contains("chase").contains("my-org/security-team");
+        }
+
+        @Test
+        void keepsGenericChaseMessageWhenDraftPrHasEmptyListBecauseCodeOwnerRequestedChanges() {
+            // given — a draft PR with an empty pending list, but the gate is unsatisfied because a code
+            // owner reviewed and REQUESTED CHANGES. GitHub drops a reviewer from reviewRequests once they
+            // submit, so the list is empty for a reason that has nothing to do with draft status, and
+            // codeOwnersApproved is false for CHANGES_REQUESTED exactly as it is for REVIEW_REQUIRED. The
+            // draft copy must not engage — a code owner demonstrably was asked and did answer.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            null,
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            true,
+                            List.of(),
+                            true));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the generic copy, never the draft wording.
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("needs code-owner approval");
+            assertThat(text).doesNotContain("still a draft");
+        }
+
+        @Test
+        void doesNotResolveTeamMembersWhenPendingCodeOwnersAreAllTeams() {
+            // given — a mixed pending list of TEAM refs only. Team refs match on display name alone, so
+            // filtering must not spend an org Members:Read lookup that repos listing only teams in
+            // CODEOWNERS would otherwise never need.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/security-team", null),
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/docs-team", null))));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the owning team is still filtered out, with no membership lookup at all.
+            verify(prSourceClient, never()).resolveTeamMembers(any(), any());
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("my-org/security-team");
+            assertThat(text).doesNotContain("docs-team");
+        }
+
+        @Test
+        void keepsExternalCodeOwnerInChaseListWhenTeamMemberResolutionFails() {
+            // given — a mixed list with an individual ref, and membership resolution failing. The filter
+            // must fail safe: an individual it couldn't confirm is a team member stays in the chase list,
+            // rather than being silently dropped and leaving nobody to chase.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            "docs-team",
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.resolveTeamMembers(COORD, "docs-team")).thenThrow(new PrSourceException("boom"));
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            false,
+                            false,
+                            List.of(
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.TEAM, "my-org/docs-team", null),
+                                    new CodeOwnerRef(CodeOwnerRef.Kind.USER, "external-user", null))));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the unconfirmable individual survives; the team ref (matched on display alone, which
+            // needs no lookup) is still dropped.
+            verify(slackClient).postMessage(postMessageCaptor.capture());
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("chase").contains("external-user");
+            assertThat(text).doesNotContain("docs-team");
         }
 
         @Test
@@ -698,6 +1131,55 @@ class PrDetectionServiceTest {
         }
 
         @Test
+        void skipsChaseMessageWhenCodeOwnersAlreadyApprovedAtDetectionEvenForADraftPr() {
+            // given — same already-approved case as above, but the PR is ALSO a draft with an empty
+            // pending list. The isDraft-pending branch must never even be considered here: the outer
+            // "already approved" skip has to win first, exactly as it does for a non-draft PR.
+            Instant prCreatedAt = Instant.now().minus(Duration.ofHours(1));
+            when(prTrackingProps.prEmoji()).thenReturn(PR_EMOJI);
+            when(prTrackingProps.repositories())
+                    .thenReturn(List.of(new PrTrackingProps.Repository(
+                            REPO,
+                            TEAM_CODE,
+                            Provider.GITHUB,
+                            null,
+                            null,
+                            List.of(),
+                            sla(SLA_24H),
+                            null,
+                            null,
+                            List.of(),
+                            true,
+                            false)));
+            when(prUrlParser.parse(any())).thenReturn(List.of(new DetectedPr(Provider.GITHUB, REPO, PR_NUMBER)));
+            when(prTrackingRepository.existsByTicketIdAndRepoAndPrNumber(anyLong(), any(), any(), anyInt()))
+                    .thenReturn(false);
+            when(prSourceClient.fetchPullRequest(COORD, PR_NUMBER))
+                    .thenReturn(new PrMetadata(
+                            RepoCoord.github(REPO),
+                            PR_NUMBER,
+                            prCreatedAt,
+                            PrMetadata.PrState.OPEN,
+                            true,
+                            List.of(),
+                            List.of(),
+                            "author",
+                            true,
+                            false,
+                            List.of(),
+                            true));
+            when(prTrackingRepository.insertIfAbsent(any())).thenReturn(stubTrackingRecord(prCreatedAt, null));
+
+            // when
+            service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
+
+            // then — the record is created but no message is posted at all, draft-pending or otherwise.
+            verify(prTrackingRepository).insertIfAbsent(any());
+            verify(slackClient, never()).postMessage(any());
+            verify(prTrackingRepository, never()).markCodeownerReviewRequested(anyLong());
+        }
+
+        @Test
         void tracksNoSlaCodeownerPrTouchingConfiguredPaths() {
             // given — a requires-codeowners repo with no SLA block (so config mandates paths) and a PR
             // that touches the configured paths.
@@ -739,11 +1221,14 @@ class PrDetectionServiceTest {
             // when
             service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
 
-            // then — tracked with no deadline, and the code-owner chase message is posted.
+            // then — tracked with no deadline, and the code-owner chase message is posted. This PR is not a
+            // draft, so it must never get the draft copy — that pins the isDraft half of the draft guard.
             verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
             assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
             verify(slackClient).postMessage(postMessageCaptor.capture());
-            assertThat(postMessageCaptor.getValue().message().getText()).contains("code-owner");
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("needs code-owner approval");
+            assertThat(text).doesNotContain("still a draft");
         }
 
         @Test
@@ -893,11 +1378,13 @@ class PrDetectionServiceTest {
             // when
             service.handleMessagePosted(messagePostedWith("msg"), ticketWithId(1L));
 
-            // then — no deadline, and the original chase copy.
+            // then — no deadline, and the original chase copy naming the pending owner (proving the
+            // chase list wasn't silently filtered to empty).
             verify(prTrackingRepository).insertIfAbsent(newTrackingCaptor.capture());
             assertThat(newTrackingCaptor.getValue().slaDeadline()).isNull();
             verify(slackClient).postMessage(postMessageCaptor.capture());
-            assertThat(postMessageCaptor.getValue().message().getText()).contains("code-owner");
+            String text = postMessageCaptor.getValue().message().getText();
+            assertThat(text).contains("code-owner").contains("chase").contains("owner-a");
         }
 
         @Test

--- a/api/service/src/test/java/com/coreeng/supportbot/prtracking/source/GitHubPrSourceClientTest.java
+++ b/api/service/src/test/java/com/coreeng/supportbot/prtracking/source/GitHubPrSourceClientTest.java
@@ -74,6 +74,26 @@ class GitHubPrSourceClientTest {
     }
 
     @Test
+    void mapsIsDraftFromTheUnderlyingPullRequest() {
+        GitHubPrSourceClient client = codeownerClient();
+        when(gitHubClient.getPullRequest(eq(REPO), eq(PR), anyBoolean()))
+                .thenReturn(new GitHubPullRequest(
+                        REPO,
+                        PR,
+                        Instant.now(),
+                        GitHubPullRequest.PrState.OPEN,
+                        true,
+                        "clean",
+                        List.of(),
+                        List.of(),
+                        "author",
+                        true));
+        stubReview(GitHubPullRequest.ReviewDecision.REVIEW_REQUIRED);
+
+        assertThat(client.fetchPullRequest(COORD, PR).isDraft()).isTrue();
+    }
+
+    @Test
     void doesNotQueryGraphQlForNonCodeownerRepo() {
         GitHubPrSourceClient client = new GitHubPrSourceClient(gitHubClient, graphQlClient, props(false));
         stubOpenPr();


### PR DESCRIPTION
## What

Three fixes to the code-owner detection messages posted when a PR is first linked in a support thread. All three are cases where the bot stated something that wasn't true.

## Why

### 1. The chase message told the owning team to chase itself

`pendingCodeOwnersAreMaintainingTeam` only suppresses the chase copy when the pending code-owner list is *entirely* the repo's own maintaining team. When the list is **mixed** — the maintaining team plus a genuinely external reviewer — the carve-out doesn't engage, and the message named the owning team as somebody to go chase.

`excludingOwningTeam` now drops the maintaining team from the rendered chase list, as a team ref or as an individual member of it, so a mixed list names only the external reviewer. This only trims what the message names; it doesn't change which repos get the carve-out, their SLA deadline, or escalation behaviour.

### 2. Draft PRs were told they "need code-owner approval"

GitHub doesn't run CODEOWNERS auto-request against a PR that has never been marked ready-for-review, so a draft typically has an empty pending list. The generic copy — *"needs code-owner approval… I'll let you know once the code owners have approved"* — implied somebody had already been asked when nobody had.

Draft PRs with an empty pending list and a confirmed-unsatisfied gate now get:

> `<link>` in `org/repo` is still a draft, so it's not ready for code-owner review yet. I'll let you know once the code owners have approved.

The copy deliberately doesn't claim *why* the list is empty. An empty list has several causes that are indistinguishable through the API — never auto-requested, a review already submitted, an approval dismissed by a push — so asserting any one of them would just trade an old false statement for a new one. It states only what we actually know: the PR is a draft.

This is **copy-only**. The PR is still tracked, still gets the reaction, still polled, and the SLA deadline is unchanged (null on this path either way).

### 3. `isDraft` was not available at all

Threaded from the hub4j REST fetch through `GitHubPullRequest` → `GitHubPrSourceClient` → `PrMetadata`. `withCodeownerReview` preserves it, since draft status comes from REST while the code-owner signals come from the later GraphQL enrichment.

## Notable details

- The draft branch requires `codeOwnersApproved == FALSE` rather than just an empty list. The list is *also* empty when the GraphQL code-owner query failed or was never attempted, in which case the value is `null` — an unknown state the copy shouldn't assert anything about.
- It also requires `!codeownerChangesRequested()`. `codeOwnersApproved` is `false` for **both** `REVIEW_REQUIRED` and `CHANGES_REQUESTED`, and GitHub clears a reviewer from `reviewRequests` once they submit — so a draft whose code owner reviewed and requested changes would otherwise have hit the draft copy.
- Team-member resolution is now only performed when an individual ref actually needs matching. Resolving members needs org `Members: Read`, and repos that list only teams in CODEOWNERS never otherwise pay for that scope — resolving unconditionally would have made the filter silently no-op in deployments without it.
- `expectedGithubTeamDisplay` is a pure mapper; each caller logs its own consequence, since an unparseable `org/repo` name means something different for the carve-out than for the chase-list filter.

## Testing

`./gradlew spotlessCheck compileJava compileTestJava` clean (ErrorProne + NullAway).

164 tests green across `PrDetectionServiceTest`, `GitHubPullRequestTest`, `Hub4jGitHubClientTest`, `GitHubPrSourceClientTest`.

New behavioural coverage:
- mixed pending list excludes the owning team as a team ref, and as an individual member
- draft with an empty list gets the draft copy
- draft with an unresolved gate (`null`) keeps the generic copy
- draft whose code owner requested changes keeps the generic copy
- draft that already has a real pending list keeps the normal chase copy
- already-approved skip still wins over the draft branch
- team-only pending lists perform no membership lookup
- membership-resolution failure keeps the unconfirmed individual in the chase list

Existing assertions were tightened from a bare `contains("code-owner")` to also name the expected pending owner, so over-filtering the chase list to empty now fails the suite.