### PR TITLE
fix(security): ignore public Jira tenant identifier

### DIFF
--- a/.p2p-security-ignore.yaml
+++ b/.p2p-security-ignore.yaml
@@ -64,3 +64,6 @@ source:
       reason: "False positive: GitLab detector matched functional-test repository fixture names, not a credential."
     - id: 47cc33af5d9b098bb6d6f2effbf1b51150b5e11eec627d9fd41a8ad8ce4a343f
       reason: "False positive: URI detector matched a redirect URI validation test case for userinfo injection, not a secret."
+    - id: 38fa3e746d6e664a65484a44df7d4bbb2f913784ca977835df9801d6cc8f6b69
+      path: .agents/skills/support-bot-review/SKILL.md
+      reason: "False positive: Atlassian detector matched the public Jira cloud tenant identifier used by the Jira tool, not a credential."


### PR DESCRIPTION
## Summary

- classify the scheduled full-history Atlassian match as a false positive
- scope the accepted finding to `.agents/skills/support-bot-review/SKILL.md`
- preserve the exact redacted P2P finding ID without recording any secret value

## Evidence

- Scheduled run: https://github.com/coreeng/support-bot/actions/runs/30423987768
- Scanned default-branch SHA: `a7d9fa7523af51669a29af97b093d0ef09296894`
- Artifact: `security-source-scan-findings/source-security-findings.json`
- Before this change: 1 active source secret and 22 ignored source-secret records
- Classification: the Atlassian detector matched the public Jira cloud tenant identifier used by the repository's review skill, not a credential

## Verification

- parsed `.p2p-security-ignore.yaml` successfully with Ruby YAML
- confirmed the new entry uses the exact finding ID and repository-relative path
- confirmed the branch changes only `.p2p-security-ignore.yaml`

CI source-scan artifact verification is pending. This PR is intentionally draft.
