### PR TITLE
fix(api): update vulnerable runtime dependencies

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -2,26 +2,27 @@ plugins {
     id("com.diffplug.spotless") version "8.0.0" apply false
 }
 
-val jacksonVersion = "2.22.0"
+val jacksonVersion = "2.22.1"
 val jacksonBom = "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
 val safeDependencyVersions =
     mapOf(
-        "ch.qos.logback:logback-core" to "1.5.25",
+        "ch.qos.logback:logback-core" to "1.5.34",
         "com.github.jknack:handlebars" to "4.5.2",
         "com.microsoft.kiota:microsoft-kiota-abstractions" to "1.9.1",
         "com.nimbusds:nimbus-jose-jwt" to "10.0.2",
         "com.squareup.okhttp3:okhttp" to "4.12.0",
         "com.squareup.okio:okio" to "3.16.4",
-        "io.netty:netty-codec" to "4.1.135.Final",
-        "io.netty:netty-codec-dns" to "4.1.135.Final",
-        "io.netty:netty-codec-http" to "4.1.135.Final",
-        "io.netty:netty-codec-http2" to "4.1.135.Final",
-        "io.netty:netty-common" to "4.1.135.Final",
-        "io.netty:netty-handler" to "4.1.135.Final",
-        "io.netty:netty-handler-proxy" to "4.1.135.Final",
-        "io.netty:netty-resolver-dns" to "4.1.135.Final",
-        "io.netty:netty-transport-native-epoll" to "4.1.135.Final",
-        "io.netty:netty-transport-native-kqueue" to "4.1.135.Final",
+        "io.grpc:grpc-netty-shaded" to "1.75.0",
+        "io.netty:netty-codec" to "4.1.136.Final",
+        "io.netty:netty-codec-dns" to "4.1.136.Final",
+        "io.netty:netty-codec-http" to "4.1.136.Final",
+        "io.netty:netty-codec-http2" to "4.1.136.Final",
+        "io.netty:netty-common" to "4.1.136.Final",
+        "io.netty:netty-handler" to "4.1.136.Final",
+        "io.netty:netty-handler-proxy" to "4.1.136.Final",
+        "io.netty:netty-resolver-dns" to "4.1.136.Final",
+        "io.netty:netty-transport-native-epoll" to "4.1.136.Final",
+        "io.netty:netty-transport-native-kqueue" to "4.1.136.Final",
         "io.opentelemetry:opentelemetry-api" to "1.62.0",
         "io.vertx:vertx-core" to "4.5.27",
         "io.vertx:vertx-web" to "4.5.22",
@@ -36,9 +37,12 @@ val safeDependencyVersions =
         "org.bouncycastle:bcpkix-jdk18on" to "1.84",
         "org.bouncycastle:bcprov-jdk18on" to "1.84",
         "org.codehaus.plexus:plexus-utils" to "4.0.3",
-        "org.eclipse.jetty:jetty-http" to "12.0.35",
-        "org.eclipse.jetty:jetty-server" to "12.0.35",
-        "org.postgresql:postgresql" to "42.7.11",
+        "org.eclipse.jetty:jetty-http" to "12.0.36",
+        "org.eclipse.jetty:jetty-security" to "12.0.36",
+        "org.eclipse.jetty:jetty-server" to "12.0.36",
+        "org.eclipse.jetty:jetty-util" to "12.0.36",
+        "org.postgresql:postgresql" to "42.7.12",
+        "org.springframework.security:spring-security-web" to "6.5.11",
         "org.springframework:spring-context" to "6.2.18",
         "org.springframework:spring-core" to "6.2.18",
         "org.springframework:spring-web" to "6.2.18",
@@ -49,10 +53,14 @@ val managedDependencyVersions =
         "asm.version" to "9.9.1",
         "byte-buddy.version" to "1.18.4",
         "commons-lang3.version" to safeDependencyVersions.getValue("org.apache.commons:commons-lang3"),
+        "jetty.version" to safeDependencyVersions.getValue("org.eclipse.jetty:jetty-server"),
+        "logback.version" to safeDependencyVersions.getValue("ch.qos.logback:logback-core"),
         "mockito.version" to "5.21.0",
         "netty.version" to safeDependencyVersions.getValue("io.netty:netty-common"),
         "opentelemetry.version" to safeDependencyVersions.getValue("io.opentelemetry:opentelemetry-api"),
         "postgresql.version" to safeDependencyVersions.getValue("org.postgresql:postgresql"),
+        "spring-security.version" to
+            safeDependencyVersions.getValue("org.springframework.security:spring-security-web"),
         "spring-framework.version" to safeDependencyVersions.getValue("org.springframework:spring-core"),
     )
 

--- a/api/service/build.gradle.kts
+++ b/api/service/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     implementation("com.microsoft.kiota:microsoft-kiota-http-okHttp:1.9.1")
 
-    jooqCodegen("org.postgresql:postgresql:42.7.11")
+    jooqCodegen("org.postgresql:postgresql:42.7.12")
     jooqCodegen("org.testcontainers:testcontainers-postgresql:2.0.5")
     jooqCodegen("org.jooq:jooq-codegen:3.19.18")
 
@@ -220,7 +220,7 @@ buildscript {
     }
     dependencies {
         classpath("org.flywaydb:flyway-database-postgresql:12.0.0")
-        classpath("org.postgresql:postgresql:42.7.11")
+        classpath("org.postgresql:postgresql:42.7.12")
         classpath("org.testcontainers:testcontainers-postgresql:2.0.5")
         classpath("org.jooq:jooq-codegen:3.19.18")
     }


### PR DESCRIPTION
## Evidence

- Scheduled production scan: https://github.com/coreeng/support-bot/actions/runs/30423987768
- Scanned `origin/main` SHA: `a7d9fa7523af51669a29af97b093d0ef09296894`
- Authoritative artifact: `security-image-scan-reports-prod-gcp-prod/image-security-findings.json`
- `support-bot` image scope: 32 active findings (22 Java and 10 Red Hat 9.8); no active image secrets

## Java findings addressed

The existing central strict-constraint and Spring managed-version mechanisms now resolve the affected runtime families at the scanner's fixed versions:

- Jackson core/databind: `2.22.1`
- gRPC Netty shaded: `1.75.0`
- Netty: `4.1.136.Final`
- Jetty security/server/util (and the aligned Jetty family): `12.0.36`
- PostgreSQL JDBC: `42.7.12`
- Spring Security Web (and the aligned Spring Security family): `6.5.11`
- Logback core (and the aligned Logback family): `1.5.34`

This covers all 22 active Java findings in the scheduled artifact. The duplicated PostgreSQL versions used by jOOQ/Flyway build metadata are kept aligned at `42.7.12`.

## OS findings evaluated

The 10 active Red Hat 9.8 findings affect `glib2`, `glibc`, `libacl`, `libsolv`, `libxml2`, and `python3`/`python3-libs`.

Red Hat's current catalog identifies `ubi9/openjdk-25-runtime:1.24-2.1782292627` as the latest same-family release (manifest list `sha256:a0c3ecb2af6e1100394721417ba412a9c9088dfadce53b8d98bb95a7bb4d23ea`):

- https://catalog.redhat.com/en/software/containers/ubi9/openjdk-25-runtime/69204990c46419100ce30a5b
- https://catalog.redhat.com/api/containers/v1/images/id/6a3ba4a343daea307c579a8b/rpm-manifest

Its published RPM manifest still contains the vulnerable package versions reported by the scheduled scan, including `glib2-2.68.4-19.el9_8.1`, `glibc-2.34-270.el9_8`, `libacl-2.3.1-4.el9`, `libsolv-0.7.24-5.el9_8`, `libxml2-2.9.13-14.el9_8.1`, and `python3-libs-3.9.25-7.el9_8`. No newer safe normal tag in this image family could be established, so `api/Dockerfile` is intentionally unchanged and these OS findings remain pending a rebuilt Red Hat base image.

## Local verification

- `./gradlew spotlessCheck --no-daemon`: passed
- `./gradlew :service:checkstyleMain -x :service:compileJava -x :service:jooqCodegen -x :service:flywayMigrate --no-daemon`: passed
- Runtime `dependencyInsight`: confirmed the exact versions listed above for Jackson core/databind, gRPC Netty shaded, Netty codec, Jetty security/server/util, PostgreSQL, Spring Security Web, and Logback core
- The unmodified `checkstyleMain`/`compileJava` task path is wired through `jooqCodegen` and `flywayMigrate`; it stopped before analysis/compilation because no Docker environment was available for the Testcontainers PostgreSQL service. Per the local-verification boundary, Docker or a service database was not started.
- Docker image build and local image scans were not run

The PR CI image build and production-equivalent vulnerability scans are authoritative and pending. In particular, Java clearance requires the newly built CI artifact, while the 10 OS findings remain dependent on a future fixed Red Hat base release.
