### PR TITLE
fix: pin hadolint and fix two findings new in 2.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,16 +99,20 @@ p2p-prod:          publish-prod        publish-chart                            
 
 ##@ Lint targets
 
+# Pinned: an untagged image resolves to :latest, so a new hadolint release
+# breaks main with no commit to this repo (2.15.0 did exactly that).
+HADOLINT_IMAGE ?= docker.io/hadolint/hadolint:v2.15.0
+
 .PHONY: lint-api
 lint-api: ## Lint API Dockerfiles
-	docker run --rm -i docker.io/hadolint/hadolint < api/Dockerfile
-	docker run --rm -i docker.io/hadolint/hadolint < api/functional/Dockerfile
-	docker run --rm -i docker.io/hadolint/hadolint < api/integration-tests/Dockerfile
-	docker run --rm -i docker.io/hadolint/hadolint < api/nft/Dockerfile
+	docker run --rm -i $(HADOLINT_IMAGE) < api/Dockerfile
+	docker run --rm -i $(HADOLINT_IMAGE) < api/functional/Dockerfile
+	docker run --rm -i $(HADOLINT_IMAGE) < api/integration-tests/Dockerfile
+	docker run --rm -i $(HADOLINT_IMAGE) < api/nft/Dockerfile
 
 .PHONY: lint-ui
 lint-ui: ## Lint UI Dockerfiles
-	docker run --rm -i docker.io/hadolint/hadolint < ui/Dockerfile
+	docker run --rm -i $(HADOLINT_IMAGE) < ui/Dockerfile
 
 .PHONY: lint-app
 lint-app: lint-api lint-ui ## Lint all Dockerfiles

--- a/api/integration-tests/Dockerfile
+++ b/api/integration-tests/Dockerfile
@@ -1,10 +1,13 @@
 FROM gradle:9.3.1-jdk25 AS builder
 WORKDIR /home/gradle/project
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install Helm and kubectl with pinned versions and checksum verification
 ARG HELM_VERSION=3.19.0
 ARG KUBECTL_VERSION=v1.33.5
+
+# Must sit below the ARGs: hadolint 2.15.0 resets its tracked shell to POSIX sh
+# on ARG/ENV, which makes it flag `set -o pipefail` below as SC3040.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN set -euxo pipefail; \
   curl -fsSLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" && \

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=build /app/public ./public
 COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-USER nextjs
+USER 1001
 
 EXPOSE 3000
 


### PR DESCRIPTION
The lint targets ran `docker.io/hadolint/hadolint` untagged, which resolves to :latest. hadolint 2.15.0 was published 2026-07-30 and broke main with no commit to this repo — the flagged Dockerfile lines date from 2025.

Pin the image behind HADOLINT_IMAGE so a third-party release can't break the build again, and fix the two findings 2.15.0 introduced:

- api/integration-tests/Dockerfile SC3040: 2.15.0's "propagating shell options across build stages" change resets the tracked shell to POSIX sh on ARG/ENV, so the SHELL at the top no longer applied to the RUN below the ARGs. Moving SHELL below them restores it. Verified: only ARG and ENV reset it; WORKDIR/COPY/LABEL/EXPOSE/USER do not.

- ui/Dockerfile DL3066 (new rule): USER nextjs -> USER 1001. The user is created as --uid 1001 at line 34, and helm-chart/values.yaml already pins runAsUser/runAsGroup/fsGroup to 1001 for the UI, so this matches what Kubernetes enforces instead of relying on an /etc/passwd lookup.

All five Dockerfiles verified clean under both 2.15.0 and 2.14.0.