### PR TITLE
Pilot Support Bot fast feedback on Blacksmith

### DIFF
--- a/.github/actions/p2p-runner-setup/action.yml
+++ b/.github/actions/p2p-runner-setup/action.yml
@@ -1,0 +1,20 @@
+name: Configure Support Bot P2P runner
+description: Configure the Docker builder used by P2P command execution jobs
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Blacksmith Docker builder
+      uses: useblacksmith/setup-docker-builder@5733de2ef2a4b92db67ba8d396b1e99db29a2631 # v1
+      with:
+        nofallback: "true"
+
+    - name: Select Blacksmith build arguments
+      shell: bash
+      run: echo "P2P_DOCKER_BUILD_ARGS=--load" >> "$GITHUB_ENV"
+
+    - name: Verify Docker builder
+      shell: bash
+      run: |
+        docker buildx version
+        docker buildx inspect --bootstrap

--- a/.github/workflows/support-bot-fast-feedback.yaml
+++ b/.github/workflows/support-bot-fast-feedback.yaml
@@ -38,7 +38,7 @@ jobs:
 
   fastfeedback:
     needs: [version]
-    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@8f22fd6371bce32e4a353541d02ebff51d512dfc
     secrets:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: |
@@ -53,6 +53,9 @@ jobs:
         LDAP_BOOTSTRAP_USER_PASSWORD=${{ secrets.LDAP_BOOTSTRAP_USER_PASSWORD }}
     with:
       app-name: support-bot
+      repository-runner-setup: true
+      run-fastfeedback-integration-on-prs: true
+      runner-label: blacksmith-2vcpu-ubuntu-2404
       tenant-name: support-bot
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/.github/workflows/support-bot-fast-feedback.yaml
+++ b/.github/workflows/support-bot-fast-feedback.yaml
@@ -38,7 +38,7 @@ jobs:
 
   fastfeedback:
     needs: [version]
-    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@8f22fd6371bce32e4a353541d02ebff51d512dfc
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@0b21e9b80d7da5bba79b56cce118f14c103baf22
     secrets:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: |
@@ -54,8 +54,8 @@ jobs:
     with:
       app-name: support-bot
       repository-runner-setup: true
-      run-fastfeedback-integration-on-prs: true
       runner-label: blacksmith-2vcpu-ubuntu-2404
+      skip-fastfeedback-integration-on-prs: true
       tenant-name: support-bot
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/.github/workflows/support-bot-fast-feedback.yaml
+++ b/.github/workflows/support-bot-fast-feedback.yaml
@@ -38,7 +38,7 @@ jobs:
 
   fastfeedback:
     needs: [version]
-    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@0b21e9b80d7da5bba79b56cce118f14c103baf22
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@8f22fd6371bce32e4a353541d02ebff51d512dfc
     secrets:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
       env_vars: |
@@ -55,7 +55,6 @@ jobs:
       app-name: support-bot
       repository-runner-setup: true
       runner-label: blacksmith-2vcpu-ubuntu-2404
-      skip-fastfeedback-integration-on-prs: true
       tenant-name: support-bot
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ HELM_CHART_PATH ?= helm-chart
 
 P2P_IMAGE_NAMES := $(P2P_APP_NAME) $(P2P_APP_NAME)-ui $(P2P_APP_NAME)-dex
 
+# Keep P2P's external GHA cache arguments unless a pilot runner supplies an override.
+P2P_DOCKER_BUILD_ARGS ?=
+p2p_docker_build_args = $(if $(P2P_DOCKER_BUILD_ARGS),$(P2P_DOCKER_BUILD_ARGS),$(p2p_image_cache))
+p2p_docker_build_args_for = $(if $(P2P_DOCKER_BUILD_ARGS),$(P2P_DOCKER_BUILD_ARGS),$(call p2p_image_cache,$(1)))
+p2p_integration_docker_build_args = $(if $(P2P_DOCKER_BUILD_ARGS),$(P2P_DOCKER_BUILD_ARGS),$(p2p_image_cache) --load)
+
 # Download and include p2p makefile
 $(shell curl -fsSL "https://raw.githubusercontent.com/coreeng/p2p/v1/p2p.mk" -o ".p2p.mk")
 include .p2p.mk
@@ -178,44 +184,44 @@ check-chart: lint-chart test-chart validate-chart-values ## Run all Helm chart c
 
 .PHONY: build-api-app
 build-api-app: lint-api ## Build API
-	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" --build-arg P2P_VERSION="$(p2p_version)" api
+	docker buildx build $(p2p_docker_build_args) --tag "$(p2p_image_tag)" --build-arg P2P_VERSION="$(p2p_version)" api
 
 .PHONY: build-ui-app
 build-ui-app: lint-ui ## Build UI
-	docker buildx build $(call p2p_image_cache,$(p2p_app_name)-ui) --tag "$(call p2p_image_tag,$(p2p_app_name)-ui)" --build-arg P2P_VERSION="$(p2p_version)" ui
+	docker buildx build $(call p2p_docker_build_args_for,$(p2p_app_name)-ui) --tag "$(call p2p_image_tag,$(p2p_app_name)-ui)" --build-arg P2P_VERSION="$(p2p_version)" ui
 
 .PHONY: build-dex-app
 build-dex-app: ## Build Dex (upstream dexidp/dex + Support Bot login theme)
-	docker buildx build $(call p2p_image_cache,$(p2p_app_name)-dex) --tag "$(call p2p_image_tag,$(p2p_app_name)-dex)" dex
+	docker buildx build $(call p2p_docker_build_args_for,$(p2p_app_name)-dex) --tag "$(call p2p_image_tag,$(p2p_app_name)-dex)" dex
 
 .PHONY: build-app
 build-app: check-chart build-api-app build-ui-app build-dex-app ## Build all apps
 
 .PHONY: build-api-functional
 build-api-functional: ## Build API functional test docker image
-	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" --file api/functional/Dockerfile api
+	docker buildx build $(p2p_docker_build_args) --tag "$(p2p_image_tag)" --file api/functional/Dockerfile api
 
 .PHONY: build-ui-functional
 build-ui-functional: ## Build UI functional test docker image
-	docker buildx build $(call p2p_image_cache,$(p2p_app_name)-ui) --tag "$(call p2p_image_tag,$(p2p_app_name)-ui)" ui/p2p/tests/functional/
+	docker buildx build $(call p2p_docker_build_args_for,$(p2p_app_name)-ui) --tag "$(call p2p_image_tag,$(p2p_app_name)-ui)" ui/p2p/tests/functional/
 
 .PHONY: build-functional
 build-functional: build-api-functional build-ui-functional ## Build functional test docker images
 
 .PHONY: build-api-nft
 build-api-nft: ## Build API nft test docker image
-	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" --file api/nft/Dockerfile api
+	docker buildx build $(p2p_docker_build_args) --tag "$(p2p_image_tag)" --file api/nft/Dockerfile api
 
 .PHONY: build-ui-nft
 build-ui-nft: ## Build UI nft test docker image
-	docker buildx build $(call p2p_image_cache,$(p2p_app_name)-ui) --tag "$(call p2p_image_tag,$(p2p_app_name)-ui)" ui/p2p/tests/nft/
+	docker buildx build $(call p2p_docker_build_args_for,$(p2p_app_name)-ui) --tag "$(call p2p_image_tag,$(p2p_app_name)-ui)" ui/p2p/tests/nft/
 
 .PHONY: build-nft
 build-nft: build-api-nft build-ui-nft ## Build nft test docker images
 
 .PHONY: build-integration
 build-integration:
-	docker buildx build --platform linux/amd64 $(p2p_image_cache) --tag "$(p2p_image_tag)" --file api/integration-tests/Dockerfile . --load
+	docker buildx build --platform linux/amd64 $(p2p_integration_docker_build_args) --tag "$(p2p_image_tag)" --file api/integration-tests/Dockerfile .
 
 .PHONY: build-extended-test
 build-extended-test:

--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -6,7 +6,7 @@ ARG DEX_BASE_TAG=v2.45.1
 FROM ghcr.io/dexidp/dex:${DEX_BASE_TAG}
 
 USER root
-RUN apk add --no-cache \
+RUN apk add --no-cache --upgrade \
     alpine-baselayout=3.7.2-r0 \
     alpine-baselayout-data=3.7.2-r0 \
     alpine-release=3.23.5-r0 \

--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -10,9 +10,9 @@ RUN apk add --no-cache --upgrade \
     alpine-baselayout=3.7.2-r0 \
     alpine-baselayout-data=3.7.2-r0 \
     alpine-release=3.23.5-r0 \
-    apk-tools=3.0.6-r0 \
+    apk-tools=3.0.7-r0 \
     ca-certificates-bundle=20260611-r0 \
-    libapk=3.0.6-r0 \
+    libapk=3.0.7-r0 \
     libcrypto3=3.5.7-r0 \
     libssl3=3.5.7-r0 \
     musl=1.2.5-r23 \


### PR DESCRIPTION
## What changed

- run only Support Bot fast-feedback command jobs on `blacksmith-2vcpu-ubuntu-2404`
- configure Blacksmith's persistent Docker builder through a caller-owned composite action pinned to `useblacksmith/setup-docker-builder@5733de2ef2a4b92db67ba8d396b1e99db29a2631`
- set `nofallback: true`
- select `--load` with no external GHA cache arguments only for the pilot; non-pilot Make invocations retain their existing scoped GHA cache arguments
- pin the provider-neutral P2P reusable-workflow contract to `8f22fd6371bce32e4a353541d02ebff51d512dfc`
- retain exact Dex package pins while allowing the base image's installed apk packages to upgrade to the current Alpine v3.23 repository versions

Integration-on-PR is not enabled. Security scans, promotion, notifications, extended tests, production workflows, and unrelated workflows keep their existing runners.

## Why

This is a narrow, reversible draft pilot to measure whether Blacksmith improves Support Bot fast-feedback execution without changing P2P's default behavior or adding provider-specific concepts to P2P.

## Vanilla baseline

Median of three recent representative successful main runs:

| Job | Run 30536670565 | Run 30437899079 | Run 30354790079 | Vanilla median |
| --- | ---: | ---: | ---: | ---: |
| `p2p-build` | 7m 20s | 7m 20s | 6m 40s | 7m 20s |
| `p2p-functional` | 12m 59s | 12m 06s | 15m 00s | 12m 59s |
| `p2p-nft` | 10m 51s | 11m 12s | 11m 43s | 11m 12s |
| `p2p-integration` | 5m 50s | 7m 05s | 5m 23s | 5m 50s |
| Whole workflow | 27m 37s | 28m 05s | 28m 45s | 28m 05s |

- https://github.com/coreeng/support-bot/actions/runs/30536670565
- https://github.com/coreeng/support-bot/actions/runs/30437899079
- https://github.com/coreeng/support-bot/actions/runs/30354790079

The latest exact-base vanilla run also passed the API functional suite with all 109 tests successful:

- https://github.com/coreeng/support-bot/actions/runs/30551576673

The live P2P `v1` tag resolves to `b20b0e20bfc81459a0e8fcf34668a1652d120773`, the direct parent of the pilot's runner-contract commit. The vanilla/P2P comparison therefore does not contain an unrelated P2P implementation drift.

## Cold-build compatibility fix

The first uncached Dex build exposed two existing package-resolution problems that vanilla cache hits had hidden:

1. the Dex base image contained `apk-tools`/`libapk` `3.0.3-r1`, so exact newer pins required `apk add --upgrade`
2. Alpine v3.23 had advanced the coupled `apk-tools`/`libapk` packages from the repository's old `3.0.6-r0` pins to `3.0.7-r0`

The fix keeps all 11 exact package pins, adds `--upgrade`, and changes only those two coupled pins to `3.0.7-r0`.

## Pilot timings and outcome

Run: https://github.com/coreeng/support-bot/actions/runs/30569961126

| Attempt | Cache state | Build | Functional | NFT | Whole attempt | Outcome |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| 1 | cold | 6m 45s | 9m 32s | 15m 46s | 23m 21s | build and NFT passed; UI functional test failed transiently |
| 2 | warm | 1m 34s | 12m 47s | 12m 44s | 15m 15s | UI passed; API functional test repeatedly returned 401 and hit its 180s deadline |
| 3 | warm | 1m 37s | 13m 29s | 14m 25s | 17m 01s | UI passed; the same API 401/deadline failure reproduced |

Compared with the vanilla median:

- cold build: 35s faster (`6m45s` vs `7m20s`)
- warm build: 5m43s-5m46s faster (`1m34s`/`1m37s` vs `7m20s`)
- NFT was slower in the observed pilot attempts (`12m44s`-`15m46s` vs `11m12s`)
- there is no successful functional, integration, or whole-workflow pilot timing to compare

## Repeatable blocker

Attempts 2 and 3 both deployed a Ready service, passed the UI functional suite, then received repeated `401 Unauthorized` responses in the API functional suite until Kubernetes deleted the test pod at its 180-second deadline. Integration was skipped downstream.

No smallest code/config fix is evidenced:

- the exact-base vanilla API functional job passed all 109 tests
- this PR does not change API service or functional-test source
- the effective Helm render sets `SPRING_PROFILES_ACTIVE=functionaltests`
- the vanilla and pilot service JARs are both 201.3 MB and every extracted entry is byte-identical except `META-INF/MANIFEST.MF`
- the only manifest difference is the expected `Implementation-Version` value
- `application-functionaltests.yaml` is byte-identical in both images

Existing job logs do not capture the service pod's startup logs. The failed API test pod is deleted at its deadline before the script can save it, leaving the repeated 401 responses and Grafana link but no retained pod log. Changing authentication/profile/configuration without that evidence would be speculative.

## Runtime evidence

- command jobs ran on Blacksmith `-2vcpu` runners in Blacksmith runner groups
- the reusable workflow received `runner-label: blacksmith-2vcpu-ubuntu-2404` and `repository-runner-setup: true`
- the pinned Blacksmith builder action ran with `nofallback: true`
- Buildx used Blacksmith's remote driver
- P2P's standard `Setup Docker Buildx` step was skipped
- app, functional, and NFT build commands used `--load`
- no observed pilot build command contained `--cache-from` or `--cache-to`
- the cold successful build had zero `CACHED` build steps; warm build attempts each reported 37 cached steps
- all app images pushed successfully after the Dex fix
- source and image security scans/policies passed on their existing runners

## Validation

- `actionlint`
- `yq` parsing and exact-value assertions for the workflow and composite action
- `git diff --check`
- non-executing Make dry-runs proving vanilla invocations preserve scoped `cache-from`/`cache-to` arguments while pilot invocations use `--load` with neither external cache argument
- Helm render confirms the functional service profile is `functionaltests`
- read-only Artifact Registry image/JAR comparison
- no local Docker builds or service-starting tests were run

## Security boundary

The selected command jobs execute the repository checkout, temporary GitHub/OIDC credentials, and configured reusable-workflow secrets on Blacksmith third-party infrastructure. This exposure was explicitly approved for the pilot.

This PR remains draft because the complete pilot path is blocked before integration and no evidence-backed fix is available in the approved narrow scope.
