### PR TITLE
fix(security): remediate weekly Support Bot findings

### DIFF
--- a/.p2p-security-ignore.yaml
+++ b/.p2p-security-ignore.yaml
@@ -42,6 +42,11 @@ images:
 
 source:
   secrets:
+    - id: 38fa3e746d6e664a65484a44df7d4bbb2f913784ca977835df9801d6cc8f6b69
+      path: .agents/skills/support-bot-review/SKILL.md
+      reason: >-
+        False positive: the Atlassian detector matched the review template placeholder
+        "Diff Range: <base>...HEAD", not a credential.
     - id: 6926d3ba9e59e8bfa458b82d3109c3ac1da0723b32eee6a4f391794f58ac5d3d
       reason: "False positive: historical FlatIO detector match in removed support-bot-ui/yarn.lock dependency metadata."
     - id: 1b8e8972627e7ef0db02f63678f41989887dec6064d7cb0e1a4d505207f619c4

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -43,10 +43,10 @@ val safeDependencyVersions =
         "org.eclipse.jetty:jetty-util" to "12.0.36",
         "org.postgresql:postgresql" to "42.7.12",
         "org.springframework.security:spring-security-web" to "6.5.11",
-        "org.springframework:spring-context" to "6.2.18",
-        "org.springframework:spring-core" to "6.2.18",
-        "org.springframework:spring-web" to "6.2.18",
-        "org.springframework:spring-webmvc" to "6.2.18",
+        "org.springframework:spring-context" to "6.2.19",
+        "org.springframework:spring-core" to "6.2.19",
+        "org.springframework:spring-web" to "6.2.19",
+        "org.springframework:spring-webmvc" to "6.2.19",
     )
 val managedDependencyVersions =
     mapOf(

--- a/ui/p2p/tests/functional/package.json
+++ b/ui/p2p/tests/functional/package.json
@@ -23,7 +23,7 @@
   },
   "resolutions": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "minimatch": "^10.2.5",
     "uuid": "11.1.1"
   }

--- a/ui/p2p/tests/functional/yarn.lock
+++ b/ui/p2p/tests/functional/yarn.lock
@@ -326,10 +326,10 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.3.tgz#6337a2f23e0604a30481423432f99eac603599f9"
   integrity sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==
 
-brace-expansion@5.0.8, brace-expansion@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+brace-expansion@5.0.9, brace-expansion@^5.0.5:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -75,7 +75,7 @@
     "test-exclude/glob/minimatch/brace-expansion": "1.1.13",
     "@babel/core": "7.29.6",
     "js-yaml": "4.2.0",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "sharp": "0.35.0"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5279,10 +5279,10 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.12:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 napi-postinstall@^0.3.0:
   version "0.3.4"
@@ -5583,12 +5583,12 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
-postcss@8.4.31, postcss@8.5.18, postcss@^8.5.6:
-  version "8.5.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.18.tgz#8717e5a33a3b15fe8a538d2431a1e1bbbfb07614"
-  integrity sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==
+postcss@8.4.31, postcss@8.5.23, postcss@^8.5.6:
+  version "8.5.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Summary

- resolve the repository-wide source findings for `postcss` and `brace-expansion`
- pin Spring Framework 6.2.19 to address all 11 active `support-bot` runtime-image findings
- record a path-scoped accepted false positive for the historical Atlassian detector match in the review-skill template

## Evidence

- Scheduled scan: https://github.com/coreeng/support-bot/actions/runs/30879474759
- Workflow: `support-bot-security-scan.yaml`
- Scan head: `7dfd0df5bcd2f22dbe455dd4e6395738462670c6`
- Completed: 2026-08-04 05:06 UTC (fresh at remediation time)
- All three image-stage artifacts had the same normalized finding fingerprint.
- Production `support-bot` image: 11 findings (3 high, 6 medium, 2 low), all against Spring Framework 6.2.18 and all fixed in 6.2.19.
- Source scan: `brace-expansion` 5.0.8 (fixed 5.0.9), `postcss` 8.5.18 (fixed 8.5.23), and one unverified Atlassian detector false positive for the literal review-template placeholder `Diff Range: <base>...HEAD`.

## Local verification

- UI `yarn install`: passed in both affected workspaces; lockfiles resolve `postcss` 8.5.23 and `brace-expansion` 5.0.9.
- UI `yarn format` and `yarn format:check`: passed.
- UI `yarn lint`: passed with 0 errors and 4 pre-existing warnings.
- UI `yarn test`: 58 suites / 789 tests passed.
- UI `yarn build`: application compilation passed; the local process was killed with exit 137 during TypeScript checking. A direct `tsc --noEmit` exposed existing test typing errors outside this patch, so the full build remains CI-verified only.
- API Spotless: passed.
- API dependency insight: `org.springframework:spring-webmvc` resolves to 6.2.19.
- API compile / Checkstyle: not completed locally because the repository task graph requires Docker-backed Flyway and JOOQ generation, which is prohibited for this unattended remediation.
- `.p2p-security-ignore.yaml`: valid YAML with schema version 1; exact normalized finding ID and path used.

## CI verification

- Fast-feedback run: https://github.com/coreeng/support-bot/actions/runs/30895748506
- Build, functional, NFT, source scan/policies, and image scan/policies all passed on head `bbb1faf6ca8aef53e74fb0c086690e149963472b`.
- Normalized source artifact: 0 active vulnerabilities and 0 active secrets. This clears the two current-tree source CVEs. PR secret scanning covers the change range, so the historical full-history ignore remains scheduled-scan verification only.
- Normalized image artifact: 0 active findings for `support-bot`; all 11 Spring Framework findings are absent from the rebuilt image. No active image secrets were reported.

## Remaining

- `support-bot-dex` remains unresolved: 145 active production findings (3 critical, 79 high, 51 medium, 8 low). Dex v2.45.1 is still the latest official release; fixing its embedded Dex and gomplate binaries would require an intrusive upstream-binary replacement or source build, so it is intentionally excluded from this focused PR.
- The path-scoped historical Atlassian false-positive ignore must be confirmed by the next scheduled full-history scan.
- This PR must remain draft and must not be merged or auto-merged by automation.
